### PR TITLE
OpenSCAD-Konstruktion mit kleineren Toleranzen und korrigierter Ausrichtung

### DIFF
--- a/Konstruktionsdateien/Clip.scad
+++ b/Konstruktionsdateien/Clip.scad
@@ -1,0 +1,10 @@
+union(){
+    difference(){
+        cylinder(d=22,h=5,$fn=100);
+        translate([0,0,-1])cylinder(d=12,h=7,$fn=100);
+        translate([0,0,-1])cube([15,15,7]);
+        translate([0,0,-1])rotate([0,0,60])cube([15,15,7]);
+    }
+    translate([8.5,0,0])cylinder(d=5,h=5,$fn=50);
+    rotate([0,0,150])translate([8.5,0,0])cylinder(d=5,h=5,$fn=50);
+}

--- a/Konstruktionsdateien/Clip.stl
+++ b/Konstruktionsdateien/Clip.stl
@@ -1,0 +1,4734 @@
+solid OpenSCAD_Model
+  facet normal 0.750108 -0.661315 0
+    outer loop
+      vertex 8.01865 -7.53002 5
+      vertex 8.47565 -7.01166 0
+      vertex 8.47565 -7.01166 5
+    endloop
+  endfacet
+  facet normal 0.750108 -0.661315 0
+    outer loop
+      vertex 8.47565 -7.01166 0
+      vertex 8.01865 -7.53002 5
+      vertex 8.01865 -7.53002 0
+    endloop
+  endfacet
+  facet normal 0.987689 -0.156431 0
+    outer loop
+      vertex 10.8052 -2.06119 5
+      vertex 10.9133 -1.37866 0
+      vertex 10.9133 -1.37866 5
+    endloop
+  endfacet
+  facet normal 0.987689 -0.156431 0
+    outer loop
+      vertex 10.9133 -1.37866 0
+      vertex 10.8052 -2.06119 5
+      vertex 10.8052 -2.06119 0
+    endloop
+  endfacet
+  facet normal 0.562078 -0.827084 0
+    outer loop
+      vertex 5.89409 -9.28761 0
+      vertex 6.46564 -8.89919 5
+      vertex 5.89409 -9.28761 5
+    endloop
+  endfacet
+  facet normal 0.562078 -0.827084 0
+    outer loop
+      vertex 6.46564 -8.89919 5
+      vertex 5.89409 -9.28761 0
+      vertex 6.46564 -8.89919 0
+    endloop
+  endfacet
+  facet normal 0.661315 -0.750108 0
+    outer loop
+      vertex 7.01166 -8.47565 0
+      vertex 7.53002 -8.01865 5
+      vertex 7.01166 -8.47565 5
+    endloop
+  endfacet
+  facet normal 0.661315 -0.750108 0
+    outer loop
+      vertex 7.53002 -8.01865 5
+      vertex 7.01166 -8.47565 0
+      vertex 7.53002 -8.01865 0
+    endloop
+  endfacet
+  facet normal -0.891004 0.453996 0
+    outer loop
+      vertex -9.9531 4.68357 0
+      vertex -9.63937 5.29929 5
+      vertex -9.63937 5.29929 0
+    endloop
+  endfacet
+  facet normal -0.891004 0.453996 0
+    outer loop
+      vertex -9.63937 5.29929 5
+      vertex -9.9531 4.68357 0
+      vertex -9.9531 4.68357 5
+    endloop
+  endfacet
+  facet normal -0.860745 0.509036 0
+    outer loop
+      vertex -9.63937 5.29929 0
+      vertex -9.55557 5.44099 5
+      vertex -9.55557 5.44099 0
+    endloop
+  endfacet
+  facet normal -0.860745 0.509036 0
+    outer loop
+      vertex -9.55557 5.44099 5
+      vertex -9.63937 5.29929 0
+      vertex -9.63937 5.29929 5
+    endloop
+  endfacet
+  facet normal -0.999507 -0.0314021 0
+    outer loop
+      vertex -10.9783 -0.690695 0
+      vertex -11 0 5
+      vertex -11 0 0
+    endloop
+  endfacet
+  facet normal -0.999507 -0.0314021 0
+    outer loop
+      vertex -11 0 5
+      vertex -10.9783 -0.690695 0
+      vertex -10.9783 -0.690695 5
+    endloop
+  endfacet
+  facet normal 0.999507 -0.0314021 0
+    outer loop
+      vertex 10.9783 -0.690695 5
+      vertex 11 0 0
+      vertex 11 0 5
+    endloop
+  endfacet
+  facet normal 0.999507 -0.0314021 0
+    outer loop
+      vertex 11 0 0
+      vertex 10.9783 -0.690695 5
+      vertex 10.9783 -0.690695 0
+    endloop
+  endfacet
+  facet normal 0.917777 -0.397096 0
+    outer loop
+      vertex 9.9531 -4.68357 5
+      vertex 10.2275 -4.04937 0
+      vertex 10.2275 -4.04937 5
+    endloop
+  endfacet
+  facet normal 0.917777 -0.397096 0
+    outer loop
+      vertex 10.2275 -4.04937 0
+      vertex 9.9531 -4.68357 5
+      vertex 9.9531 -4.68357 0
+    endloop
+  endfacet
+  facet normal 0.960291 -0.279 0
+    outer loop
+      vertex 10.4616 -3.39919 5
+      vertex 10.6544 -2.73559 0
+      vertex 10.6544 -2.73559 5
+    endloop
+  endfacet
+  facet normal 0.960291 -0.279 0
+    outer loop
+      vertex 10.6544 -2.73559 0
+      vertex 10.4616 -3.39919 5
+      vertex 10.4616 -3.39919 0
+    endloop
+  endfacet
+  facet normal -0.509037 -0.860744 0
+    outer loop
+      vertex -5.89409 -9.28761 0
+      vertex -5.29929 -9.63937 5
+      vertex -5.89409 -9.28761 5
+    endloop
+  endfacet
+  facet normal -0.509037 -0.860744 -0
+    outer loop
+      vertex -5.29929 -9.63937 5
+      vertex -5.89409 -9.28761 0
+      vertex -5.29929 -9.63937 0
+    endloop
+  endfacet
+  facet normal 0.453996 -0.891004 0
+    outer loop
+      vertex 4.68357 -9.9531 0
+      vertex 5.29929 -9.63937 5
+      vertex 4.68357 -9.9531 5
+    endloop
+  endfacet
+  facet normal 0.453996 -0.891004 0
+    outer loop
+      vertex 5.29929 -9.63937 5
+      vertex 4.68357 -9.9531 0
+      vertex 5.29929 -9.63937 0
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex -7.53002 -8.01865 0
+      vertex -8.01865 -7.53002 5
+      vertex -8.01865 -7.53002 0
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex -8.01865 -7.53002 5
+      vertex -7.53002 -8.01865 0
+      vertex -7.53002 -8.01865 5
+    endloop
+  endfacet
+  facet normal -0.9759 -0.218217 0
+    outer loop
+      vertex -10.6544 -2.73559 0
+      vertex -10.8052 -2.06119 5
+      vertex -10.8052 -2.06119 0
+    endloop
+  endfacet
+  facet normal -0.9759 -0.218217 0
+    outer loop
+      vertex -10.8052 -2.06119 5
+      vertex -10.6544 -2.73559 0
+      vertex -10.6544 -2.73559 5
+    endloop
+  endfacet
+  facet normal -0.827084 -0.562078 0
+    outer loop
+      vertex -8.89919 -6.46564 0
+      vertex -9.28761 -5.89409 5
+      vertex -9.28761 -5.89409 0
+    endloop
+  endfacet
+  facet normal -0.827084 -0.562078 0
+    outer loop
+      vertex -9.28761 -5.89409 5
+      vertex -8.89919 -6.46564 0
+      vertex -8.89919 -6.46564 5
+    endloop
+  endfacet
+  facet normal -0.562078 -0.827084 0
+    outer loop
+      vertex -6.46564 -8.89919 0
+      vertex -5.89409 -9.28761 5
+      vertex -6.46564 -8.89919 5
+    endloop
+  endfacet
+  facet normal -0.562078 -0.827084 -0
+    outer loop
+      vertex -5.89409 -9.28761 5
+      vertex -6.46564 -8.89919 0
+      vertex -5.89409 -9.28761 0
+    endloop
+  endfacet
+  facet normal -0.987689 -0.156431 0
+    outer loop
+      vertex -10.8052 -2.06119 0
+      vertex -10.9133 -1.37866 5
+      vertex -10.9133 -1.37866 0
+    endloop
+  endfacet
+  facet normal -0.987689 -0.156431 0
+    outer loop
+      vertex -10.9133 -1.37866 5
+      vertex -10.8052 -2.06119 0
+      vertex -10.8052 -2.06119 5
+    endloop
+  endfacet
+  facet normal 0.940871 -0.338765 0
+    outer loop
+      vertex 10.2275 -4.04937 5
+      vertex 10.4616 -3.39919 0
+      vertex 10.4616 -3.39919 5
+    endloop
+  endfacet
+  facet normal 0.940871 -0.338765 0
+    outer loop
+      vertex 10.4616 -3.39919 0
+      vertex 10.2275 -4.04937 5
+      vertex 10.2275 -4.04937 0
+    endloop
+  endfacet
+  facet normal -0.940871 -0.338765 0
+    outer loop
+      vertex -10.2275 -4.04937 0
+      vertex -10.4616 -3.39919 5
+      vertex -10.4616 -3.39919 0
+    endloop
+  endfacet
+  facet normal -0.940871 -0.338765 0
+    outer loop
+      vertex -10.4616 -3.39919 5
+      vertex -10.2275 -4.04937 0
+      vertex -10.2275 -4.04937 5
+    endloop
+  endfacet
+  facet normal 0.156431 -0.987689 0
+    outer loop
+      vertex 1.37866 -10.9133 0
+      vertex 2.06119 -10.8052 5
+      vertex 1.37866 -10.9133 5
+    endloop
+  endfacet
+  facet normal 0.156431 -0.987689 0
+    outer loop
+      vertex 2.06119 -10.8052 5
+      vertex 1.37866 -10.9133 0
+      vertex 2.06119 -10.8052 0
+    endloop
+  endfacet
+  facet normal -0.917777 0.397096 0
+    outer loop
+      vertex -10.2275 4.04937 0
+      vertex -9.9531 4.68357 5
+      vertex -9.9531 4.68357 0
+    endloop
+  endfacet
+  facet normal -0.917777 0.397096 0
+    outer loop
+      vertex -9.9531 4.68357 5
+      vertex -10.2275 4.04937 0
+      vertex -10.2275 4.04937 5
+    endloop
+  endfacet
+  facet normal 0.860744 -0.509037 0
+    outer loop
+      vertex 9.28761 -5.89409 5
+      vertex 9.63937 -5.29929 0
+      vertex 9.63937 -5.29929 5
+    endloop
+  endfacet
+  facet normal 0.860744 -0.509037 0
+    outer loop
+      vertex 9.63937 -5.29929 0
+      vertex 9.28761 -5.89409 5
+      vertex 9.28761 -5.89409 0
+    endloop
+  endfacet
+  facet normal -0.218217 -0.9759 0
+    outer loop
+      vertex -2.73559 -10.6544 0
+      vertex -2.06119 -10.8052 5
+      vertex -2.73559 -10.6544 5
+    endloop
+  endfacet
+  facet normal -0.218217 -0.9759 -0
+    outer loop
+      vertex -2.06119 -10.8052 5
+      vertex -2.73559 -10.6544 0
+      vertex -2.06119 -10.8052 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.25784 2.89052 0
+      vertex -5.19615 3 0
+      vertex -5.19387 2.99868 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.88803 3.88479 0
+      vertex -4.87491 4.51132 0
+      vertex -4.86176 4.19764 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.88803 3.88479 0
+      vertex -4.92727 4.82088 0
+      vertex -4.87491 4.51132 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.95331 3.5777 0
+      vertex -4.92727 4.82088 0
+      vertex -4.88803 3.88479 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.95331 3.5777 0
+      vertex -5.01801 5.12143 0
+      vertex -4.92727 4.82088 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.05656 3.28121 0
+      vertex -5.01801 5.12143 0
+      vertex -4.95331 3.5777 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.05656 3.28121 0
+      vertex -5.14571 5.40824 0
+      vertex -5.01801 5.12143 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.19615 3 0
+      vertex -5.14571 5.40824 0
+      vertex -5.05656 3.28121 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.55557 5.44099 0
+      vertex -5.19615 3 0
+      vertex -5.25784 2.89052 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.19615 3 0
+      vertex -5.30834 5.67678 0
+      vertex -5.14571 5.40824 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.63937 5.29929 0
+      vertex -5.25784 2.89052 0
+      vertex -5.42896 2.55468 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.19615 3 0
+      vertex -9.55557 5.44099 0
+      vertex -5.30834 5.67678 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.9531 4.68357 0
+      vertex -5.42896 2.55468 0
+      vertex -5.57866 2.20875 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.2275 4.04937 0
+      vertex -5.57866 2.20875 0
+      vertex -5.70634 1.8541 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.25784 2.89052 0
+      vertex -9.63937 5.29929 0
+      vertex -9.55557 5.44099 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.4616 3.39919 0
+      vertex -5.70634 1.8541 0
+      vertex -5.8115 1.49214 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.6544 2.73559 0
+      vertex -5.8115 1.49214 0
+      vertex -5.89372 1.12429 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.8052 2.06119 0
+      vertex -5.89372 1.12429 0
+      vertex -5.95269 0.751999 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.42896 2.55468 0
+      vertex -9.9531 4.68357 0
+      vertex -9.63937 5.29929 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9133 1.37866 0
+      vertex -5.95269 0.751999 0
+      vertex -5.98816 0.376742 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9783 0.690695 0
+      vertex -5.98816 0.376742 0
+      vertex -6 0 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -5.30834 5.67678 0
+      vertex -9.55557 5.44099 0
+      vertex -5.50335 5.92283 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6 0 0
+      vertex 11 0 0
+      vertex 10.9783 -0.690695 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11 0 0
+      vertex 6 0 0
+      vertex 10.9803 0.313333 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.98816 -0.376742 0
+      vertex 10.9783 -0.690695 0
+      vertex 10.9133 -1.37866 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 6 0 0
+      vertex 10.9783 -0.690695 0
+      vertex 5.98816 -0.376742 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.95269 -0.751999 0
+      vertex 10.9133 -1.37866 0
+      vertex 10.8052 -2.06119 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 10.9803 0.313333 0
+      vertex 6 0 0
+      vertex 10.9215 0.621724 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.89372 -1.12429 0
+      vertex 10.8052 -2.06119 0
+      vertex 10.6544 -2.73559 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 10.9215 0.621724 0
+      vertex 6 0 0
+      vertex 10.8244 0.920311 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.8115 -1.49214 0
+      vertex 10.6544 -2.73559 0
+      vertex 10.4616 -3.39919 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.9133 -1.37866 0
+      vertex 5.95269 -0.751999 0
+      vertex 5.98816 -0.376742 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.70634 -1.8541 0
+      vertex 10.4616 -3.39919 0
+      vertex 10.2275 -4.04937 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 10.8244 0.920311 0
+      vertex 6 0 0
+      vertex 10.6908 1.20438 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.57866 -2.20875 0
+      vertex 10.2275 -4.04937 0
+      vertex 9.9531 -4.68357 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 10.6908 1.20438 0
+      vertex 6 0 0
+      vertex 10.5225 1.46946 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.42896 -2.55468 0
+      vertex 9.9531 -4.68357 0
+      vertex 9.63937 -5.29929 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.8052 -2.06119 0
+      vertex 5.89372 -1.12429 0
+      vertex 5.95269 -0.751999 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.25784 -2.89052 0
+      vertex 9.63937 -5.29929 0
+      vertex 9.28761 -5.89409 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 10.5225 1.46946 0
+      vertex 6 0 0
+      vertex 10.3224 1.71137 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 10.3224 1.71137 0
+      vertex 6 0 0
+      vertex 10.0936 1.92628 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.06597 -3.21496 0
+      vertex 9.28761 -5.89409 0
+      vertex 8.89919 -6.46564 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 10.0936 1.92628 0
+      vertex 6 0 0
+      vertex 9.83957 2.11082 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.8541 -3.52671 0
+      vertex 8.89919 -6.46564 0
+      vertex 8.47565 -7.01166 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 9.83957 2.11082 0
+      vertex 6 0 0
+      vertex 9.56445 2.26207 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 9.56445 2.26207 0
+      vertex 6 0 0
+      vertex 9.27254 2.37764 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.62308 -3.82454 0
+      vertex 8.47565 -7.01166 0
+      vertex 8.01865 -7.53002 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 9.27254 2.37764 0
+      vertex 6 0 0
+      vertex 8.96845 2.45572 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.37381 -4.10728 0
+      vertex 8.01865 -7.53002 0
+      vertex 7.53002 -8.01865 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 8.96845 2.45572 0
+      vertex 6 0 0
+      vertex 8.65698 2.49507 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 8.65698 2.49507 0
+      vertex 6 0 0
+      vertex 8.34302 2.49507 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.10728 -4.37381 0
+      vertex 7.53002 -8.01865 0
+      vertex 7.01166 -8.47565 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.34302 2.49507 0
+      vertex 6 0 0
+      vertex 8.03155 2.45572 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.03155 2.45572 0
+      vertex 6 0 0
+      vertex 7.72746 2.37764 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.72746 2.37764 0
+      vertex 6 0 0
+      vertex 7.43555 2.26207 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.82454 -4.62308 0
+      vertex 7.01166 -8.47565 0
+      vertex 6.46564 -8.89919 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.16043 2.11082 0
+      vertex 6 0 0
+      vertex 6.90644 1.92628 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.90644 1.92628 0
+      vertex 6 0 0
+      vertex 6.67758 1.71137 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.67758 1.71137 0
+      vertex 6 0 0
+      vertex 6.47746 1.46946 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.30923 1.20438 0
+      vertex 6 0 0
+      vertex 6.17556 0.920311 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.17556 0.920311 0
+      vertex 6 0 0
+      vertex 6.07854 0.621724 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.07854 0.621724 0
+      vertex 6 0 0
+      vertex 6.01971 0.313333 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.47746 1.46946 0
+      vertex 6 0 0
+      vertex 6.30923 1.20438 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.52671 -4.8541 0
+      vertex 6.46564 -8.89919 0
+      vertex 5.89409 -9.28761 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.43555 2.26207 0
+      vertex 6 0 0
+      vertex 7.16043 2.11082 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.6544 -2.73559 0
+      vertex 5.8115 -1.49214 0
+      vertex 5.89372 -1.12429 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.4616 -3.39919 0
+      vertex 5.70634 -1.8541 0
+      vertex 5.8115 -1.49214 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.2275 -4.04937 0
+      vertex 5.57866 -2.20875 0
+      vertex 5.70634 -1.8541 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.9531 -4.68357 0
+      vertex 5.42896 -2.55468 0
+      vertex 5.57866 -2.20875 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.21496 -5.06597 0
+      vertex 5.89409 -9.28761 0
+      vertex 5.29929 -9.63937 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.63937 -5.29929 0
+      vertex 5.25784 -2.89052 0
+      vertex 5.42896 -2.55468 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.28761 -5.89409 0
+      vertex 5.06597 -3.21496 0
+      vertex 5.25784 -2.89052 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.89919 -6.46564 0
+      vertex 4.8541 -3.52671 0
+      vertex 5.06597 -3.21496 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.89052 -5.25784 0
+      vertex 5.29929 -9.63937 0
+      vertex 4.68357 -9.9531 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.47565 -7.01166 0
+      vertex 4.62308 -3.82454 0
+      vertex 4.8541 -3.52671 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.01865 -7.53002 0
+      vertex 4.37381 -4.10728 0
+      vertex 4.62308 -3.82454 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.53002 -8.01865 0
+      vertex 4.10728 -4.37381 0
+      vertex 4.37381 -4.10728 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.55468 -5.42896 0
+      vertex 4.68357 -9.9531 0
+      vertex 4.04937 -10.2275 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.01166 -8.47565 0
+      vertex 3.82454 -4.62308 0
+      vertex 4.10728 -4.37381 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.46564 -8.89919 0
+      vertex 3.52671 -4.8541 0
+      vertex 3.82454 -4.62308 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.20875 -5.57866 0
+      vertex 4.04937 -10.2275 0
+      vertex 3.39919 -10.4616 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.89409 -9.28761 0
+      vertex 3.21496 -5.06597 0
+      vertex 3.52671 -4.8541 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.29929 -9.63937 0
+      vertex 2.89052 -5.25784 0
+      vertex 3.21496 -5.06597 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.8541 -5.70634 0
+      vertex 3.39919 -10.4616 0
+      vertex 2.73559 -10.6544 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.68357 -9.9531 0
+      vertex 2.55468 -5.42896 0
+      vertex 2.89052 -5.25784 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.04937 -10.2275 0
+      vertex 2.20875 -5.57866 0
+      vertex 2.55468 -5.42896 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49214 -5.8115 0
+      vertex 2.73559 -10.6544 0
+      vertex 2.06119 -10.8052 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.39919 -10.4616 0
+      vertex 1.8541 -5.70634 0
+      vertex 2.20875 -5.57866 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.73559 -10.6544 0
+      vertex 1.49214 -5.8115 0
+      vertex 1.8541 -5.70634 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.12429 -5.89372 0
+      vertex 2.06119 -10.8052 0
+      vertex 1.37866 -10.9133 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.06119 -10.8052 0
+      vertex 1.12429 -5.89372 0
+      vertex 1.49214 -5.8115 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.37866 -10.9133 0
+      vertex 0.751999 -5.95269 0
+      vertex 1.12429 -5.89372 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.690695 -10.9783 0
+      vertex 0.751999 -5.95269 0
+      vertex 1.37866 -10.9133 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.690695 -10.9783 0
+      vertex 0.376742 -5.98816 0
+      vertex 0.751999 -5.95269 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -11 0
+      vertex 0.376742 -5.98816 0
+      vertex 0.690695 -10.9783 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -11 0
+      vertex 0 -6 0
+      vertex 0.376742 -5.98816 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -11 0
+      vertex -0.376742 -5.98816 0
+      vertex 0 -6 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.690695 -10.9783 0
+      vertex -0.376742 -5.98816 0
+      vertex 0 -11 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.690695 -10.9783 0
+      vertex -0.751999 -5.95269 0
+      vertex -0.376742 -5.98816 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.37866 -10.9133 0
+      vertex -0.751999 -5.95269 0
+      vertex -0.690695 -10.9783 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.751999 -5.95269 0
+      vertex -1.37866 -10.9133 0
+      vertex -1.12429 -5.89372 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.06119 -10.8052 0
+      vertex -1.12429 -5.89372 0
+      vertex -1.37866 -10.9133 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.12429 -5.89372 0
+      vertex -2.06119 -10.8052 0
+      vertex -1.49214 -5.8115 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.73559 -10.6544 0
+      vertex -1.49214 -5.8115 0
+      vertex -2.06119 -10.8052 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.49214 -5.8115 0
+      vertex -2.73559 -10.6544 0
+      vertex -1.8541 -5.70634 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.39919 -10.4616 0
+      vertex -1.8541 -5.70634 0
+      vertex -2.73559 -10.6544 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.8541 -5.70634 0
+      vertex -3.39919 -10.4616 0
+      vertex -2.20875 -5.57866 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.04937 -10.2275 0
+      vertex -2.20875 -5.57866 0
+      vertex -3.39919 -10.4616 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -2.20875 -5.57866 0
+      vertex -4.04937 -10.2275 0
+      vertex -2.55468 -5.42896 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.68357 -9.9531 0
+      vertex -2.55468 -5.42896 0
+      vertex -4.04937 -10.2275 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -2.55468 -5.42896 0
+      vertex -4.68357 -9.9531 0
+      vertex -2.89052 -5.25784 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.29929 -9.63937 0
+      vertex -2.89052 -5.25784 0
+      vertex -4.68357 -9.9531 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -2.89052 -5.25784 0
+      vertex -5.29929 -9.63937 0
+      vertex -3.21496 -5.06597 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.89409 -9.28761 0
+      vertex -3.21496 -5.06597 0
+      vertex -5.29929 -9.63937 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -3.21496 -5.06597 0
+      vertex -5.89409 -9.28761 0
+      vertex -3.52671 -4.8541 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.46564 -8.89919 0
+      vertex -3.52671 -4.8541 0
+      vertex -5.89409 -9.28761 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -3.52671 -4.8541 0
+      vertex -6.46564 -8.89919 0
+      vertex -3.82454 -4.62308 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.01166 -8.47565 0
+      vertex -3.82454 -4.62308 0
+      vertex -6.46564 -8.89919 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -3.82454 -4.62308 0
+      vertex -7.01166 -8.47565 0
+      vertex -4.10728 -4.37381 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.53002 -8.01865 0
+      vertex -4.10728 -4.37381 0
+      vertex -7.01166 -8.47565 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -4.10728 -4.37381 0
+      vertex -7.53002 -8.01865 0
+      vertex -4.37381 -4.10728 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.01865 -7.53002 0
+      vertex -4.37381 -4.10728 0
+      vertex -7.53002 -8.01865 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -4.37381 -4.10728 0
+      vertex -8.01865 -7.53002 0
+      vertex -4.62308 -3.82454 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.47565 -7.01166 0
+      vertex -4.62308 -3.82454 0
+      vertex -8.01865 -7.53002 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -4.62308 -3.82454 0
+      vertex -8.47565 -7.01166 0
+      vertex -4.8541 -3.52671 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.89919 -6.46564 0
+      vertex -4.8541 -3.52671 0
+      vertex -8.47565 -7.01166 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -4.8541 -3.52671 0
+      vertex -8.89919 -6.46564 0
+      vertex -5.06597 -3.21496 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.28761 -5.89409 0
+      vertex -5.06597 -3.21496 0
+      vertex -8.89919 -6.46564 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -5.06597 -3.21496 0
+      vertex -9.28761 -5.89409 0
+      vertex -5.25784 -2.89052 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.63937 -5.29929 0
+      vertex -5.25784 -2.89052 0
+      vertex -9.28761 -5.89409 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -5.25784 -2.89052 0
+      vertex -9.63937 -5.29929 0
+      vertex -5.42896 -2.55468 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.9531 -4.68357 0
+      vertex -5.42896 -2.55468 0
+      vertex -9.63937 -5.29929 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -5.42896 -2.55468 0
+      vertex -9.9531 -4.68357 0
+      vertex -5.57866 -2.20875 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.2275 -4.04937 0
+      vertex -5.57866 -2.20875 0
+      vertex -9.9531 -4.68357 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -5.57866 -2.20875 0
+      vertex -10.2275 -4.04937 0
+      vertex -5.70634 -1.8541 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.4616 -3.39919 0
+      vertex -5.70634 -1.8541 0
+      vertex -10.2275 -4.04937 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -5.70634 -1.8541 0
+      vertex -10.4616 -3.39919 0
+      vertex -5.8115 -1.49214 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.6544 -2.73559 0
+      vertex -5.8115 -1.49214 0
+      vertex -10.4616 -3.39919 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -5.8115 -1.49214 0
+      vertex -10.6544 -2.73559 0
+      vertex -5.89372 -1.12429 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.8052 -2.06119 0
+      vertex -5.89372 -1.12429 0
+      vertex -10.6544 -2.73559 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -5.89372 -1.12429 0
+      vertex -10.8052 -2.06119 0
+      vertex -5.95269 -0.751999 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9133 -1.37866 0
+      vertex -5.95269 -0.751999 0
+      vertex -10.8052 -2.06119 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -5.95269 -0.751999 0
+      vertex -10.9133 -1.37866 0
+      vertex -5.98816 -0.376742 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9783 -0.690695 0
+      vertex -5.98816 -0.376742 0
+      vertex -10.9133 -1.37866 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -5.98816 -0.376742 0
+      vertex -10.9783 -0.690695 0
+      vertex -6 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11 0 0
+      vertex -6 0 0
+      vertex -10.9783 -0.690695 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -10.9783 0.690695 0
+      vertex -6 0 0
+      vertex -11 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.98816 0.376742 0
+      vertex -10.9783 0.690695 0
+      vertex -10.9133 1.37866 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.95269 0.751999 0
+      vertex -10.9133 1.37866 0
+      vertex -10.8052 2.06119 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.89372 1.12429 0
+      vertex -10.8052 2.06119 0
+      vertex -10.6544 2.73559 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.35254 5.7615 0
+      vertex -9.55557 5.44099 0
+      vertex -9.52628 5.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.8115 1.49214 0
+      vertex -10.6544 2.73559 0
+      vertex -10.4616 3.39919 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.70634 1.8541 0
+      vertex -10.4616 3.39919 0
+      vertex -10.2275 4.04937 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.1474 5.99916 0
+      vertex -9.55557 5.44099 0
+      vertex -9.35254 5.7615 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.91408 6.20923 0
+      vertex -9.55557 5.44099 0
+      vertex -9.1474 5.99916 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.37806 6.53386 0
+      vertex -9.55557 5.44099 0
+      vertex -8.65628 6.38841 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.65628 6.38841 0
+      vertex -9.55557 5.44099 0
+      vertex -8.91408 6.20923 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.57866 2.20875 0
+      vertex -10.2275 4.04937 0
+      vertex -9.9531 4.68357 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.08379 6.6433 0
+      vertex -9.55557 5.44099 0
+      vertex -8.37806 6.53386 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -5.50335 5.92283 0
+      vertex -9.55557 5.44099 0
+      vertex -5.72766 6.14249 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.77814 6.71499 0
+      vertex -9.55557 5.44099 0
+      vertex -8.08379 6.6433 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.4659 6.74781 0
+      vertex -9.55557 5.44099 0
+      vertex -7.77814 6.71499 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -7.15202 6.74123 0
+      vertex -9.55557 5.44099 0
+      vertex -7.4659 6.74781 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -6.53905 6.61094 0
+      vertex -9.55557 5.44099 0
+      vertex -6.84144 6.69537 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -6.84144 6.69537 0
+      vertex -9.55557 5.44099 0
+      vertex -7.15202 6.74123 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -5.97774 6.3323 0
+      vertex -9.55557 5.44099 0
+      vertex -6.24963 6.48928 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -6.24963 6.48928 0
+      vertex -9.55557 5.44099 0
+      vertex -6.53905 6.61094 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -5.72766 6.14249 0
+      vertex -9.55557 5.44099 0
+      vertex -5.97774 6.3323 0
+    endloop
+  endfacet
+  facet normal 0.509037 -0.860744 0
+    outer loop
+      vertex 5.29929 -9.63937 0
+      vertex 5.89409 -9.28761 5
+      vertex 5.29929 -9.63937 5
+    endloop
+  endfacet
+  facet normal 0.509037 -0.860744 0
+    outer loop
+      vertex 5.89409 -9.28761 5
+      vertex 5.29929 -9.63937 0
+      vertex 5.89409 -9.28761 0
+    endloop
+  endfacet
+  facet normal 0.0314021 -0.999507 0
+    outer loop
+      vertex 0 -11 0
+      vertex 0.690695 -10.9783 5
+      vertex 0 -11 5
+    endloop
+  endfacet
+  facet normal 0.0314021 -0.999507 0
+    outer loop
+      vertex 0.690695 -10.9783 5
+      vertex 0 -11 0
+      vertex 0.690695 -10.9783 0
+    endloop
+  endfacet
+  facet normal 0.0940626 -0.995566 0
+    outer loop
+      vertex 0.690695 -10.9783 0
+      vertex 1.37866 -10.9133 5
+      vertex 0.690695 -10.9783 5
+    endloop
+  endfacet
+  facet normal 0.0940626 -0.995566 0
+    outer loop
+      vertex 1.37866 -10.9133 5
+      vertex 0.690695 -10.9783 0
+      vertex 1.37866 -10.9133 0
+    endloop
+  endfacet
+  facet normal -0.917777 -0.397096 0
+    outer loop
+      vertex -9.9531 -4.68357 0
+      vertex -10.2275 -4.04937 5
+      vertex -10.2275 -4.04937 0
+    endloop
+  endfacet
+  facet normal -0.917777 -0.397096 0
+    outer loop
+      vertex -10.2275 -4.04937 5
+      vertex -9.9531 -4.68357 0
+      vertex -9.9531 -4.68357 5
+    endloop
+  endfacet
+  facet normal -0.156431 -0.987689 0
+    outer loop
+      vertex -2.06119 -10.8052 0
+      vertex -1.37866 -10.9133 5
+      vertex -2.06119 -10.8052 5
+    endloop
+  endfacet
+  facet normal -0.156431 -0.987689 -0
+    outer loop
+      vertex -1.37866 -10.9133 5
+      vertex -2.06119 -10.8052 0
+      vertex -1.37866 -10.9133 0
+    endloop
+  endfacet
+  facet normal 0.279 -0.960291 0
+    outer loop
+      vertex 2.73559 -10.6544 0
+      vertex 3.39919 -10.4616 5
+      vertex 2.73559 -10.6544 5
+    endloop
+  endfacet
+  facet normal 0.279 -0.960291 0
+    outer loop
+      vertex 3.39919 -10.4616 5
+      vertex 2.73559 -10.6544 0
+      vertex 3.39919 -10.4616 0
+    endloop
+  endfacet
+  facet normal -0.750108 -0.661315 0
+    outer loop
+      vertex -8.01865 -7.53002 0
+      vertex -8.47565 -7.01166 5
+      vertex -8.47565 -7.01166 0
+    endloop
+  endfacet
+  facet normal -0.750108 -0.661315 0
+    outer loop
+      vertex -8.47565 -7.01166 5
+      vertex -8.01865 -7.53002 0
+      vertex -8.01865 -7.53002 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.87491 4.51132 5
+      vertex -4.88803 3.88479 5
+      vertex -4.86176 4.19764 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.92727 4.82088 5
+      vertex -4.88803 3.88479 5
+      vertex -4.87491 4.51132 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.92727 4.82088 5
+      vertex -4.95331 3.5777 5
+      vertex -4.88803 3.88479 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.01801 5.12143 5
+      vertex -4.95331 3.5777 5
+      vertex -4.92727 4.82088 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.01801 5.12143 5
+      vertex -5.05656 3.28121 5
+      vertex -4.95331 3.5777 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.14571 5.40824 5
+      vertex -5.05656 3.28121 5
+      vertex -5.01801 5.12143 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.14571 5.40824 5
+      vertex -5.19615 3 5
+      vertex -5.05656 3.28121 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.30834 5.67678 5
+      vertex -5.19615 3 5
+      vertex -5.14571 5.40824 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -9.55557 5.44099 5
+      vertex -5.19615 3 5
+      vertex -5.30834 5.67678 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.19615 3 5
+      vertex -9.55557 5.44099 5
+      vertex -5.25784 2.89052 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.55557 5.44099 5
+      vertex -5.30834 5.67678 5
+      vertex -5.50335 5.92283 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -9.63937 5.29929 5
+      vertex -5.25784 2.89052 5
+      vertex -9.55557 5.44099 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.25784 2.89052 5
+      vertex -9.63937 5.29929 5
+      vertex -5.42896 2.55468 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.55557 5.44099 5
+      vertex -5.50335 5.92283 5
+      vertex -5.72766 6.14249 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.42896 2.55468 5
+      vertex -9.9531 4.68357 5
+      vertex -5.57866 2.20875 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.2275 4.04937 5
+      vertex -5.57866 2.20875 5
+      vertex -9.9531 4.68357 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.4616 3.39919 5
+      vertex -5.70634 1.8541 5
+      vertex -10.2275 4.04937 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.55557 5.44099 5
+      vertex -5.72766 6.14249 5
+      vertex -5.97774 6.3323 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.70634 1.8541 5
+      vertex -10.4616 3.39919 5
+      vertex -5.8115 1.49214 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.6544 2.73559 5
+      vertex -5.8115 1.49214 5
+      vertex -10.4616 3.39919 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.55557 5.44099 5
+      vertex -5.97774 6.3323 5
+      vertex -6.24963 6.48928 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.19387 2.99868 5
+      vertex -5.19615 3 5
+      vertex -5.25784 2.89052 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 0 5
+      vertex 11 0 5
+      vertex 10.9803 0.313333 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 0 5
+      vertex 10.9803 0.313333 5
+      vertex 10.9215 0.621724 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11 0 5
+      vertex 6 0 5
+      vertex 10.9783 -0.690695 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 0 5
+      vertex 10.9215 0.621724 5
+      vertex 10.8244 0.920311 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9783 -0.690695 5
+      vertex 5.98816 -0.376742 5
+      vertex 10.9133 -1.37866 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 0 5
+      vertex 10.8244 0.920311 5
+      vertex 10.6908 1.20438 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 5.95269 -0.751999 5
+      vertex 10.9133 -1.37866 5
+      vertex 5.98816 -0.376742 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 0 5
+      vertex 10.6908 1.20438 5
+      vertex 10.5225 1.46946 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9133 -1.37866 5
+      vertex 5.95269 -0.751999 5
+      vertex 10.8052 -2.06119 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 0 5
+      vertex 10.5225 1.46946 5
+      vertex 10.3224 1.71137 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.8052 -2.06119 5
+      vertex 5.89372 -1.12429 5
+      vertex 10.6544 -2.73559 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 0 5
+      vertex 10.3224 1.71137 5
+      vertex 10.0936 1.92628 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 5.8115 -1.49214 5
+      vertex 10.6544 -2.73559 5
+      vertex 5.89372 -1.12429 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 0 5
+      vertex 10.0936 1.92628 5
+      vertex 9.83957 2.11082 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.6544 -2.73559 5
+      vertex 5.8115 -1.49214 5
+      vertex 10.4616 -3.39919 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 0 5
+      vertex 9.83957 2.11082 5
+      vertex 9.56445 2.26207 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.4616 -3.39919 5
+      vertex 5.70634 -1.8541 5
+      vertex 10.2275 -4.04937 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 0 5
+      vertex 9.56445 2.26207 5
+      vertex 9.27254 2.37764 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 0 5
+      vertex 9.27254 2.37764 5
+      vertex 8.96845 2.45572 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 5.57866 -2.20875 5
+      vertex 10.2275 -4.04937 5
+      vertex 5.70634 -1.8541 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 0 5
+      vertex 8.96845 2.45572 5
+      vertex 8.65698 2.49507 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.2275 -4.04937 5
+      vertex 5.57866 -2.20875 5
+      vertex 9.9531 -4.68357 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 0 5
+      vertex 8.65698 2.49507 5
+      vertex 8.34302 2.49507 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 0 5
+      vertex 8.34302 2.49507 5
+      vertex 8.03155 2.45572 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 5.42896 -2.55468 5
+      vertex 9.9531 -4.68357 5
+      vertex 5.57866 -2.20875 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 0 5
+      vertex 8.03155 2.45572 5
+      vertex 7.72746 2.37764 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.9531 -4.68357 5
+      vertex 5.42896 -2.55468 5
+      vertex 9.63937 -5.29929 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 0 5
+      vertex 7.72746 2.37764 5
+      vertex 7.43555 2.26207 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 0 5
+      vertex 7.43555 2.26207 5
+      vertex 7.16043 2.11082 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 5.25784 -2.89052 5
+      vertex 9.63937 -5.29929 5
+      vertex 5.42896 -2.55468 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 0 5
+      vertex 7.16043 2.11082 5
+      vertex 6.90644 1.92628 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 0 5
+      vertex 6.90644 1.92628 5
+      vertex 6.67758 1.71137 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 0 5
+      vertex 6.67758 1.71137 5
+      vertex 6.47746 1.46946 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 5.70634 -1.8541 5
+      vertex 10.4616 -3.39919 5
+      vertex 5.8115 -1.49214 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 0 5
+      vertex 6.47746 1.46946 5
+      vertex 6.30923 1.20438 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 0 5
+      vertex 6.30923 1.20438 5
+      vertex 6.17556 0.920311 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 0 5
+      vertex 6.17556 0.920311 5
+      vertex 6.07854 0.621724 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 0 5
+      vertex 6.07854 0.621724 5
+      vertex 6.01971 0.313333 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9783 -0.690695 5
+      vertex 6 0 5
+      vertex 5.98816 -0.376742 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 5.89372 -1.12429 5
+      vertex 10.8052 -2.06119 5
+      vertex 5.95269 -0.751999 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.63937 -5.29929 5
+      vertex 5.25784 -2.89052 5
+      vertex 9.28761 -5.89409 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 5.06597 -3.21496 5
+      vertex 9.28761 -5.89409 5
+      vertex 5.25784 -2.89052 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.28761 -5.89409 5
+      vertex 5.06597 -3.21496 5
+      vertex 8.89919 -6.46564 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.8541 -3.52671 5
+      vertex 8.89919 -6.46564 5
+      vertex 5.06597 -3.21496 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.89919 -6.46564 5
+      vertex 4.8541 -3.52671 5
+      vertex 8.47565 -7.01166 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.62308 -3.82454 5
+      vertex 8.47565 -7.01166 5
+      vertex 4.8541 -3.52671 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.47565 -7.01166 5
+      vertex 4.62308 -3.82454 5
+      vertex 8.01865 -7.53002 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.37381 -4.10728 5
+      vertex 8.01865 -7.53002 5
+      vertex 4.62308 -3.82454 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.01865 -7.53002 5
+      vertex 4.37381 -4.10728 5
+      vertex 7.53002 -8.01865 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.10728 -4.37381 5
+      vertex 7.53002 -8.01865 5
+      vertex 4.37381 -4.10728 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.53002 -8.01865 5
+      vertex 4.10728 -4.37381 5
+      vertex 7.01166 -8.47565 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 3.82454 -4.62308 5
+      vertex 7.01166 -8.47565 5
+      vertex 4.10728 -4.37381 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.01166 -8.47565 5
+      vertex 3.82454 -4.62308 5
+      vertex 6.46564 -8.89919 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 3.52671 -4.8541 5
+      vertex 6.46564 -8.89919 5
+      vertex 3.82454 -4.62308 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.46564 -8.89919 5
+      vertex 3.52671 -4.8541 5
+      vertex 5.89409 -9.28761 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 3.21496 -5.06597 5
+      vertex 5.89409 -9.28761 5
+      vertex 3.52671 -4.8541 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.89409 -9.28761 5
+      vertex 3.21496 -5.06597 5
+      vertex 5.29929 -9.63937 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.89052 -5.25784 5
+      vertex 5.29929 -9.63937 5
+      vertex 3.21496 -5.06597 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.29929 -9.63937 5
+      vertex 2.89052 -5.25784 5
+      vertex 4.68357 -9.9531 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.55468 -5.42896 5
+      vertex 4.68357 -9.9531 5
+      vertex 2.89052 -5.25784 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.68357 -9.9531 5
+      vertex 2.55468 -5.42896 5
+      vertex 4.04937 -10.2275 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.20875 -5.57866 5
+      vertex 4.04937 -10.2275 5
+      vertex 2.55468 -5.42896 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.04937 -10.2275 5
+      vertex 2.20875 -5.57866 5
+      vertex 3.39919 -10.4616 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.8541 -5.70634 5
+      vertex 3.39919 -10.4616 5
+      vertex 2.20875 -5.57866 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.39919 -10.4616 5
+      vertex 1.8541 -5.70634 5
+      vertex 2.73559 -10.6544 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.49214 -5.8115 5
+      vertex 2.73559 -10.6544 5
+      vertex 1.8541 -5.70634 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.73559 -10.6544 5
+      vertex 1.49214 -5.8115 5
+      vertex 2.06119 -10.8052 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.12429 -5.89372 5
+      vertex 2.06119 -10.8052 5
+      vertex 1.49214 -5.8115 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.06119 -10.8052 5
+      vertex 1.12429 -5.89372 5
+      vertex 1.37866 -10.9133 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.751999 -5.95269 5
+      vertex 1.37866 -10.9133 5
+      vertex 1.12429 -5.89372 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.751999 -5.95269 5
+      vertex 0.690695 -10.9783 5
+      vertex 1.37866 -10.9133 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.376742 -5.98816 5
+      vertex 0.690695 -10.9783 5
+      vertex 0.751999 -5.95269 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0 -6 5
+      vertex 0.690695 -10.9783 5
+      vertex 0.376742 -5.98816 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 -6 5
+      vertex 0 -11 5
+      vertex 0.690695 -10.9783 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.376742 -5.98816 5
+      vertex 0 -11 5
+      vertex 0 -6 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.376742 -5.98816 5
+      vertex -0.690695 -10.9783 5
+      vertex 0 -11 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.751999 -5.95269 5
+      vertex -0.690695 -10.9783 5
+      vertex -0.376742 -5.98816 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.37866 -10.9133 5
+      vertex -0.751999 -5.95269 5
+      vertex -1.12429 -5.89372 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.751999 -5.95269 5
+      vertex -1.37866 -10.9133 5
+      vertex -0.690695 -10.9783 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.06119 -10.8052 5
+      vertex -1.12429 -5.89372 5
+      vertex -1.49214 -5.8115 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.73559 -10.6544 5
+      vertex -1.49214 -5.8115 5
+      vertex -1.8541 -5.70634 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.12429 -5.89372 5
+      vertex -2.06119 -10.8052 5
+      vertex -1.37866 -10.9133 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.39919 -10.4616 5
+      vertex -1.8541 -5.70634 5
+      vertex -2.20875 -5.57866 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.04937 -10.2275 5
+      vertex -2.20875 -5.57866 5
+      vertex -2.55468 -5.42896 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.49214 -5.8115 5
+      vertex -2.73559 -10.6544 5
+      vertex -2.06119 -10.8052 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.68357 -9.9531 5
+      vertex -2.55468 -5.42896 5
+      vertex -2.89052 -5.25784 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.29929 -9.63937 5
+      vertex -2.89052 -5.25784 5
+      vertex -3.21496 -5.06597 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.8541 -5.70634 5
+      vertex -3.39919 -10.4616 5
+      vertex -2.73559 -10.6544 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.89409 -9.28761 5
+      vertex -3.21496 -5.06597 5
+      vertex -3.52671 -4.8541 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.46564 -8.89919 5
+      vertex -3.52671 -4.8541 5
+      vertex -3.82454 -4.62308 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.20875 -5.57866 5
+      vertex -4.04937 -10.2275 5
+      vertex -3.39919 -10.4616 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.01166 -8.47565 5
+      vertex -3.82454 -4.62308 5
+      vertex -4.10728 -4.37381 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.53002 -8.01865 5
+      vertex -4.10728 -4.37381 5
+      vertex -4.37381 -4.10728 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.01865 -7.53002 5
+      vertex -4.37381 -4.10728 5
+      vertex -4.62308 -3.82454 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.55468 -5.42896 5
+      vertex -4.68357 -9.9531 5
+      vertex -4.04937 -10.2275 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.47565 -7.01166 5
+      vertex -4.62308 -3.82454 5
+      vertex -4.8541 -3.52671 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.89919 -6.46564 5
+      vertex -4.8541 -3.52671 5
+      vertex -5.06597 -3.21496 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.28761 -5.89409 5
+      vertex -5.06597 -3.21496 5
+      vertex -5.25784 -2.89052 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.89052 -5.25784 5
+      vertex -5.29929 -9.63937 5
+      vertex -4.68357 -9.9531 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.63937 -5.29929 5
+      vertex -5.25784 -2.89052 5
+      vertex -5.42896 -2.55468 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.9531 -4.68357 5
+      vertex -5.42896 -2.55468 5
+      vertex -5.57866 -2.20875 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.2275 -4.04937 5
+      vertex -5.57866 -2.20875 5
+      vertex -5.70634 -1.8541 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.4616 -3.39919 5
+      vertex -5.70634 -1.8541 5
+      vertex -5.8115 -1.49214 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.6544 -2.73559 5
+      vertex -5.8115 -1.49214 5
+      vertex -5.89372 -1.12429 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.21496 -5.06597 5
+      vertex -5.89409 -9.28761 5
+      vertex -5.29929 -9.63937 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.8052 -2.06119 5
+      vertex -5.89372 -1.12429 5
+      vertex -5.95269 -0.751999 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.9133 -1.37866 5
+      vertex -5.95269 -0.751999 5
+      vertex -5.98816 -0.376742 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.9783 -0.690695 5
+      vertex -5.98816 -0.376742 5
+      vertex -6 0 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.8115 1.49214 5
+      vertex -10.6544 2.73559 5
+      vertex -5.89372 1.12429 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.52671 -4.8541 5
+      vertex -6.46564 -8.89919 5
+      vertex -5.89409 -9.28761 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.55557 5.44099 5
+      vertex -6.24963 6.48928 5
+      vertex -6.53905 6.61094 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.55557 5.44099 5
+      vertex -6.53905 6.61094 5
+      vertex -6.84144 6.69537 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.82454 -4.62308 5
+      vertex -7.01166 -8.47565 5
+      vertex -6.46564 -8.89919 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.55557 5.44099 5
+      vertex -6.84144 6.69537 5
+      vertex -7.15202 6.74123 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.55557 5.44099 5
+      vertex -7.15202 6.74123 5
+      vertex -7.4659 6.74781 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.10728 -4.37381 5
+      vertex -7.53002 -8.01865 5
+      vertex -7.01166 -8.47565 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.55557 5.44099 5
+      vertex -7.4659 6.74781 5
+      vertex -7.77814 6.71499 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.37381 -4.10728 5
+      vertex -8.01865 -7.53002 5
+      vertex -7.53002 -8.01865 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.55557 5.44099 5
+      vertex -7.77814 6.71499 5
+      vertex -8.08379 6.6433 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.55557 5.44099 5
+      vertex -8.08379 6.6433 5
+      vertex -8.37806 6.53386 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.62308 -3.82454 5
+      vertex -8.47565 -7.01166 5
+      vertex -8.01865 -7.53002 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.55557 5.44099 5
+      vertex -8.37806 6.53386 5
+      vertex -8.65628 6.38841 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.8541 -3.52671 5
+      vertex -8.89919 -6.46564 5
+      vertex -8.47565 -7.01166 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.55557 5.44099 5
+      vertex -8.65628 6.38841 5
+      vertex -8.91408 6.20923 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.55557 5.44099 5
+      vertex -8.91408 6.20923 5
+      vertex -9.1474 5.99916 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.06597 -3.21496 5
+      vertex -9.28761 -5.89409 5
+      vertex -8.89919 -6.46564 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.55557 5.44099 5
+      vertex -9.1474 5.99916 5
+      vertex -9.35254 5.7615 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.55557 5.44099 5
+      vertex -9.35254 5.7615 5
+      vertex -9.52628 5.5 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -9.9531 4.68357 5
+      vertex -5.42896 2.55468 5
+      vertex -9.63937 5.29929 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.57866 2.20875 5
+      vertex -10.2275 4.04937 5
+      vertex -5.70634 1.8541 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.25784 -2.89052 5
+      vertex -9.63937 -5.29929 5
+      vertex -9.28761 -5.89409 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.8052 2.06119 5
+      vertex -5.89372 1.12429 5
+      vertex -10.6544 2.73559 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.42896 -2.55468 5
+      vertex -9.9531 -4.68357 5
+      vertex -9.63937 -5.29929 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.89372 1.12429 5
+      vertex -10.8052 2.06119 5
+      vertex -5.95269 0.751999 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.57866 -2.20875 5
+      vertex -10.2275 -4.04937 5
+      vertex -9.9531 -4.68357 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.9133 1.37866 5
+      vertex -5.95269 0.751999 5
+      vertex -10.8052 2.06119 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.70634 -1.8541 5
+      vertex -10.4616 -3.39919 5
+      vertex -10.2275 -4.04937 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.95269 0.751999 5
+      vertex -10.9133 1.37866 5
+      vertex -5.98816 0.376742 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.8115 -1.49214 5
+      vertex -10.6544 -2.73559 5
+      vertex -10.4616 -3.39919 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.9783 0.690695 5
+      vertex -5.98816 0.376742 5
+      vertex -10.9133 1.37866 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.89372 -1.12429 5
+      vertex -10.8052 -2.06119 5
+      vertex -10.6544 -2.73559 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.98816 0.376742 5
+      vertex -10.9783 0.690695 5
+      vertex -6 0 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.95269 -0.751999 5
+      vertex -10.9133 -1.37866 5
+      vertex -10.8052 -2.06119 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6 0 5
+      vertex -10.9783 0.690695 5
+      vertex -11 0 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.98816 -0.376742 5
+      vertex -10.9783 -0.690695 5
+      vertex -10.9133 -1.37866 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6 0 5
+      vertex -11 0 5
+      vertex -10.9783 -0.690695 5
+    endloop
+  endfacet
+  facet normal -0.279 -0.960291 0
+    outer loop
+      vertex -3.39919 -10.4616 0
+      vertex -2.73559 -10.6544 5
+      vertex -3.39919 -10.4616 5
+    endloop
+  endfacet
+  facet normal -0.279 -0.960291 -0
+    outer loop
+      vertex -2.73559 -10.6544 5
+      vertex -3.39919 -10.4616 0
+      vertex -2.73559 -10.6544 0
+    endloop
+  endfacet
+  facet normal 0.827084 -0.562078 0
+    outer loop
+      vertex 8.89919 -6.46564 5
+      vertex 9.28761 -5.89409 0
+      vertex 9.28761 -5.89409 5
+    endloop
+  endfacet
+  facet normal 0.827084 -0.562078 0
+    outer loop
+      vertex 9.28761 -5.89409 0
+      vertex 8.89919 -6.46564 5
+      vertex 8.89919 -6.46564 0
+    endloop
+  endfacet
+  facet normal -0.453996 -0.891004 0
+    outer loop
+      vertex -5.29929 -9.63937 0
+      vertex -4.68357 -9.9531 5
+      vertex -5.29929 -9.63937 5
+    endloop
+  endfacet
+  facet normal -0.453996 -0.891004 -0
+    outer loop
+      vertex -4.68357 -9.9531 5
+      vertex -5.29929 -9.63937 0
+      vertex -4.68357 -9.9531 0
+    endloop
+  endfacet
+  facet normal -0.995566 0.0940626 0
+    outer loop
+      vertex -10.9783 0.690695 0
+      vertex -10.9133 1.37866 5
+      vertex -10.9133 1.37866 0
+    endloop
+  endfacet
+  facet normal -0.995566 0.0940626 0
+    outer loop
+      vertex -10.9133 1.37866 5
+      vertex -10.9783 0.690695 0
+      vertex -10.9783 0.690695 5
+    endloop
+  endfacet
+  facet normal 0.995566 -0.0940626 0
+    outer loop
+      vertex 10.9133 -1.37866 5
+      vertex 10.9783 -0.690695 0
+      vertex 10.9783 -0.690695 5
+    endloop
+  endfacet
+  facet normal 0.995566 -0.0940626 0
+    outer loop
+      vertex 10.9783 -0.690695 0
+      vertex 10.9133 -1.37866 5
+      vertex 10.9133 -1.37866 0
+    endloop
+  endfacet
+  facet normal -0.9759 0.218217 0
+    outer loop
+      vertex -10.8052 2.06119 0
+      vertex -10.6544 2.73559 5
+      vertex -10.6544 2.73559 0
+    endloop
+  endfacet
+  facet normal -0.9759 0.218217 0
+    outer loop
+      vertex -10.6544 2.73559 5
+      vertex -10.8052 2.06119 0
+      vertex -10.8052 2.06119 5
+    endloop
+  endfacet
+  facet normal -0.987689 0.156431 0
+    outer loop
+      vertex -10.9133 1.37866 0
+      vertex -10.8052 2.06119 5
+      vertex -10.8052 2.06119 0
+    endloop
+  endfacet
+  facet normal -0.987689 0.156431 0
+    outer loop
+      vertex -10.8052 2.06119 5
+      vertex -10.9133 1.37866 0
+      vertex -10.9133 1.37866 5
+    endloop
+  endfacet
+  facet normal -0.960291 -0.279 0
+    outer loop
+      vertex -10.4616 -3.39919 0
+      vertex -10.6544 -2.73559 5
+      vertex -10.6544 -2.73559 0
+    endloop
+  endfacet
+  facet normal -0.960291 -0.279 0
+    outer loop
+      vertex -10.6544 -2.73559 5
+      vertex -10.4616 -3.39919 0
+      vertex -10.4616 -3.39919 5
+    endloop
+  endfacet
+  facet normal -0.0940626 -0.995566 0
+    outer loop
+      vertex -1.37866 -10.9133 0
+      vertex -0.690695 -10.9783 5
+      vertex -1.37866 -10.9133 5
+    endloop
+  endfacet
+  facet normal -0.0940626 -0.995566 -0
+    outer loop
+      vertex -0.690695 -10.9783 5
+      vertex -1.37866 -10.9133 0
+      vertex -0.690695 -10.9783 0
+    endloop
+  endfacet
+  facet normal -0.860744 -0.509037 0
+    outer loop
+      vertex -9.28761 -5.89409 0
+      vertex -9.63937 -5.29929 5
+      vertex -9.63937 -5.29929 0
+    endloop
+  endfacet
+  facet normal -0.860744 -0.509037 0
+    outer loop
+      vertex -9.63937 -5.29929 5
+      vertex -9.28761 -5.89409 0
+      vertex -9.28761 -5.89409 5
+    endloop
+  endfacet
+  facet normal 0.61291 -0.790153 0
+    outer loop
+      vertex 6.46564 -8.89919 0
+      vertex 7.01166 -8.47565 5
+      vertex 6.46564 -8.89919 5
+    endloop
+  endfacet
+  facet normal 0.61291 -0.790153 0
+    outer loop
+      vertex 7.01166 -8.47565 5
+      vertex 6.46564 -8.89919 0
+      vertex 7.01166 -8.47565 0
+    endloop
+  endfacet
+  facet normal 0.790153 -0.61291 0
+    outer loop
+      vertex 8.47565 -7.01166 5
+      vertex 8.89919 -6.46564 0
+      vertex 8.89919 -6.46564 5
+    endloop
+  endfacet
+  facet normal 0.790153 -0.61291 0
+    outer loop
+      vertex 8.89919 -6.46564 0
+      vertex 8.47565 -7.01166 5
+      vertex 8.47565 -7.01166 0
+    endloop
+  endfacet
+  facet normal 0.891004 -0.453996 0
+    outer loop
+      vertex 9.63937 -5.29929 5
+      vertex 9.9531 -4.68357 0
+      vertex 9.9531 -4.68357 5
+    endloop
+  endfacet
+  facet normal 0.891004 -0.453996 0
+    outer loop
+      vertex 9.9531 -4.68357 0
+      vertex 9.63937 -5.29929 5
+      vertex 9.63937 -5.29929 0
+    endloop
+  endfacet
+  facet normal 0.9759 -0.218217 0
+    outer loop
+      vertex 10.6544 -2.73559 5
+      vertex 10.8052 -2.06119 0
+      vertex 10.8052 -2.06119 5
+    endloop
+  endfacet
+  facet normal 0.9759 -0.218217 0
+    outer loop
+      vertex 10.8052 -2.06119 0
+      vertex 10.6544 -2.73559 5
+      vertex 10.6544 -2.73559 0
+    endloop
+  endfacet
+  facet normal 0.218217 -0.9759 0
+    outer loop
+      vertex 2.06119 -10.8052 0
+      vertex 2.73559 -10.6544 5
+      vertex 2.06119 -10.8052 5
+    endloop
+  endfacet
+  facet normal 0.218217 -0.9759 0
+    outer loop
+      vertex 2.73559 -10.6544 5
+      vertex 2.06119 -10.8052 0
+      vertex 2.73559 -10.6544 0
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 0
+    outer loop
+      vertex 7.53002 -8.01865 5
+      vertex 8.01865 -7.53002 0
+      vertex 8.01865 -7.53002 5
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 0
+    outer loop
+      vertex 8.01865 -7.53002 0
+      vertex 7.53002 -8.01865 5
+      vertex 7.53002 -8.01865 0
+    endloop
+  endfacet
+  facet normal -0.790153 -0.61291 0
+    outer loop
+      vertex -8.47565 -7.01166 0
+      vertex -8.89919 -6.46564 5
+      vertex -8.89919 -6.46564 0
+    endloop
+  endfacet
+  facet normal -0.790153 -0.61291 0
+    outer loop
+      vertex -8.89919 -6.46564 5
+      vertex -8.47565 -7.01166 0
+      vertex -8.47565 -7.01166 5
+    endloop
+  endfacet
+  facet normal -0.995566 -0.0940626 0
+    outer loop
+      vertex -10.9133 -1.37866 0
+      vertex -10.9783 -0.690695 5
+      vertex -10.9783 -0.690695 0
+    endloop
+  endfacet
+  facet normal -0.995566 -0.0940626 0
+    outer loop
+      vertex -10.9783 -0.690695 5
+      vertex -10.9133 -1.37866 0
+      vertex -10.9133 -1.37866 5
+    endloop
+  endfacet
+  facet normal -0.940871 0.338765 0
+    outer loop
+      vertex -10.4616 3.39919 0
+      vertex -10.2275 4.04937 5
+      vertex -10.2275 4.04937 0
+    endloop
+  endfacet
+  facet normal -0.940871 0.338765 0
+    outer loop
+      vertex -10.2275 4.04937 5
+      vertex -10.4616 3.39919 0
+      vertex -10.4616 3.39919 5
+    endloop
+  endfacet
+  facet normal -0.0314021 -0.999507 0
+    outer loop
+      vertex -0.690695 -10.9783 0
+      vertex 0 -11 5
+      vertex -0.690695 -10.9783 5
+    endloop
+  endfacet
+  facet normal -0.0314021 -0.999507 -0
+    outer loop
+      vertex 0 -11 5
+      vertex -0.690695 -10.9783 0
+      vertex 0 -11 0
+    endloop
+  endfacet
+  facet normal -0.61291 -0.790153 0
+    outer loop
+      vertex -7.01166 -8.47565 0
+      vertex -6.46564 -8.89919 5
+      vertex -7.01166 -8.47565 5
+    endloop
+  endfacet
+  facet normal -0.61291 -0.790153 -0
+    outer loop
+      vertex -6.46564 -8.89919 5
+      vertex -7.01166 -8.47565 0
+      vertex -6.46564 -8.89919 0
+    endloop
+  endfacet
+  facet normal 0.338765 -0.940871 0
+    outer loop
+      vertex 3.39919 -10.4616 0
+      vertex 4.04937 -10.2275 5
+      vertex 3.39919 -10.4616 5
+    endloop
+  endfacet
+  facet normal 0.338765 -0.940871 0
+    outer loop
+      vertex 4.04937 -10.2275 5
+      vertex 3.39919 -10.4616 0
+      vertex 4.04937 -10.2275 0
+    endloop
+  endfacet
+  facet normal -0.960291 0.279 0
+    outer loop
+      vertex -10.6544 2.73559 0
+      vertex -10.4616 3.39919 5
+      vertex -10.4616 3.39919 0
+    endloop
+  endfacet
+  facet normal -0.960291 0.279 0
+    outer loop
+      vertex -10.4616 3.39919 5
+      vertex -10.6544 2.73559 0
+      vertex -10.6544 2.73559 5
+    endloop
+  endfacet
+  facet normal -0.661315 -0.750108 0
+    outer loop
+      vertex -7.53002 -8.01865 0
+      vertex -7.01166 -8.47565 5
+      vertex -7.53002 -8.01865 5
+    endloop
+  endfacet
+  facet normal -0.661315 -0.750108 -0
+    outer loop
+      vertex -7.01166 -8.47565 5
+      vertex -7.53002 -8.01865 0
+      vertex -7.01166 -8.47565 0
+    endloop
+  endfacet
+  facet normal 0.397096 -0.917777 0
+    outer loop
+      vertex 4.04937 -10.2275 0
+      vertex 4.68357 -9.9531 5
+      vertex 4.04937 -10.2275 5
+    endloop
+  endfacet
+  facet normal 0.397096 -0.917777 0
+    outer loop
+      vertex 4.68357 -9.9531 5
+      vertex 4.04937 -10.2275 0
+      vertex 4.68357 -9.9531 0
+    endloop
+  endfacet
+  facet normal -0.999507 0.0314021 0
+    outer loop
+      vertex -11 0 0
+      vertex -10.9783 0.690695 5
+      vertex -10.9783 0.690695 0
+    endloop
+  endfacet
+  facet normal -0.999507 0.0314021 0
+    outer loop
+      vertex -10.9783 0.690695 5
+      vertex -11 0 0
+      vertex -11 0 5
+    endloop
+  endfacet
+  facet normal -0.397096 -0.917777 0
+    outer loop
+      vertex -4.68357 -9.9531 0
+      vertex -4.04937 -10.2275 5
+      vertex -4.68357 -9.9531 5
+    endloop
+  endfacet
+  facet normal -0.397096 -0.917777 -0
+    outer loop
+      vertex -4.04937 -10.2275 5
+      vertex -4.68357 -9.9531 0
+      vertex -4.04937 -10.2275 0
+    endloop
+  endfacet
+  facet normal -0.338765 -0.940871 0
+    outer loop
+      vertex -4.04937 -10.2275 0
+      vertex -3.39919 -10.4616 5
+      vertex -4.04937 -10.2275 5
+    endloop
+  endfacet
+  facet normal -0.338765 -0.940871 -0
+    outer loop
+      vertex -3.39919 -10.4616 5
+      vertex -4.04937 -10.2275 0
+      vertex -3.39919 -10.4616 0
+    endloop
+  endfacet
+  facet normal -0.891004 -0.453996 0
+    outer loop
+      vertex -9.63937 -5.29929 0
+      vertex -9.9531 -4.68357 5
+      vertex -9.9531 -4.68357 0
+    endloop
+  endfacet
+  facet normal -0.891004 -0.453996 0
+    outer loop
+      vertex -9.9531 -4.68357 5
+      vertex -9.63937 -5.29929 0
+      vertex -9.63937 -5.29929 5
+    endloop
+  endfacet
+  facet normal 0.0941024 0.995563 -0
+    outer loop
+      vertex -0.376742 -5.98816 0
+      vertex -0.751999 -5.95269 5
+      vertex -0.376742 -5.98816 5
+    endloop
+  endfacet
+  facet normal 0.0941024 0.995563 0
+    outer loop
+      vertex -0.751999 -5.95269 5
+      vertex -0.376742 -5.98816 0
+      vertex -0.751999 -5.95269 0
+    endloop
+  endfacet
+  facet normal -0.0314118 0.999507 0
+    outer loop
+      vertex 0.376742 -5.98816 0
+      vertex 0 -6 5
+      vertex 0.376742 -5.98816 5
+    endloop
+  endfacet
+  facet normal -0.0314118 0.999507 0
+    outer loop
+      vertex 0 -6 5
+      vertex 0.376742 -5.98816 0
+      vertex 0 -6 0
+    endloop
+  endfacet
+  facet normal -0.562092 0.827075 0
+    outer loop
+      vertex 3.52671 -4.8541 0
+      vertex 3.21496 -5.06597 5
+      vertex 3.52671 -4.8541 5
+    endloop
+  endfacet
+  facet normal -0.562092 0.827075 0
+    outer loop
+      vertex 3.21496 -5.06597 5
+      vertex 3.52671 -4.8541 0
+      vertex 3.21496 -5.06597 0
+    endloop
+  endfacet
+  facet normal 0.975919 0.218133 0
+    outer loop
+      vertex -5.8115 -1.49214 5
+      vertex -5.89372 -1.12429 0
+      vertex -5.89372 -1.12429 5
+    endloop
+  endfacet
+  facet normal 0.975919 0.218133 0
+    outer loop
+      vertex -5.89372 -1.12429 0
+      vertex -5.8115 -1.49214 5
+      vertex -5.8115 -1.49214 0
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 0
+    outer loop
+      vertex 4.10728 -4.37381 0
+      vertex 4.37381 -4.10728 5
+      vertex 4.37381 -4.10728 0
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 0
+    outer loop
+      vertex 4.37381 -4.10728 5
+      vertex 4.10728 -4.37381 0
+      vertex 4.10728 -4.37381 5
+    endloop
+  endfacet
+  facet normal -0.218133 0.975919 0
+    outer loop
+      vertex 1.49214 -5.8115 0
+      vertex 1.12429 -5.89372 5
+      vertex 1.49214 -5.8115 5
+    endloop
+  endfacet
+  facet normal -0.218133 0.975919 0
+    outer loop
+      vertex 1.12429 -5.89372 5
+      vertex 1.49214 -5.8115 0
+      vertex 1.12429 -5.89372 0
+    endloop
+  endfacet
+  facet normal -0.960293 0.278993 0
+    outer loop
+      vertex 5.70634 -1.8541 0
+      vertex 5.8115 -1.49214 5
+      vertex 5.8115 -1.49214 0
+    endloop
+  endfacet
+  facet normal -0.960293 0.278993 0
+    outer loop
+      vertex 5.8115 -1.49214 5
+      vertex 5.70634 -1.8541 0
+      vertex 5.70634 -1.8541 5
+    endloop
+  endfacet
+  facet normal -0.0941024 0.995563 0
+    outer loop
+      vertex 0.751999 -5.95269 0
+      vertex 0.376742 -5.98816 5
+      vertex 0.751999 -5.95269 5
+    endloop
+  endfacet
+  facet normal -0.0941024 0.995563 0
+    outer loop
+      vertex 0.376742 -5.98816 5
+      vertex 0.751999 -5.95269 0
+      vertex 0.376742 -5.98816 0
+    endloop
+  endfacet
+  facet normal 0.827075 0.562092 0
+    outer loop
+      vertex -4.8541 -3.52671 5
+      vertex -5.06597 -3.21496 0
+      vertex -5.06597 -3.21496 5
+    endloop
+  endfacet
+  facet normal 0.827075 0.562092 0
+    outer loop
+      vertex -5.06597 -3.21496 0
+      vertex -4.8541 -3.52671 5
+      vertex -4.8541 -3.52671 0
+    endloop
+  endfacet
+  facet normal 0.75011 0.661314 0
+    outer loop
+      vertex -4.37381 -4.10728 5
+      vertex -4.62308 -3.82454 0
+      vertex -4.62308 -3.82454 5
+    endloop
+  endfacet
+  facet normal 0.75011 0.661314 0
+    outer loop
+      vertex -4.62308 -3.82454 0
+      vertex -4.37381 -4.10728 5
+      vertex -4.37381 -4.10728 0
+    endloop
+  endfacet
+  facet normal -0.917752 0.397154 0
+    outer loop
+      vertex 5.42896 -2.55468 0
+      vertex 5.57866 -2.20875 5
+      vertex 5.57866 -2.20875 0
+    endloop
+  endfacet
+  facet normal -0.917752 0.397154 0
+    outer loop
+      vertex 5.57866 -2.20875 5
+      vertex 5.42896 -2.55468 0
+      vertex 5.42896 -2.55468 5
+    endloop
+  endfacet
+  facet normal -0.987686 0.156447 0
+    outer loop
+      vertex 5.89372 -1.12429 0
+      vertex 5.95269 -0.751999 5
+      vertex 5.95269 -0.751999 0
+    endloop
+  endfacet
+  facet normal -0.987686 0.156447 0
+    outer loop
+      vertex 5.95269 -0.751999 5
+      vertex 5.89372 -1.12429 0
+      vertex 5.89372 -1.12429 5
+    endloop
+  endfacet
+  facet normal -0.156447 0.987686 0
+    outer loop
+      vertex 1.12429 -5.89372 0
+      vertex 0.751999 -5.95269 5
+      vertex 1.12429 -5.89372 5
+    endloop
+  endfacet
+  facet normal -0.156447 0.987686 0
+    outer loop
+      vertex 0.751999 -5.95269 5
+      vertex 1.12429 -5.89372 0
+      vertex 0.751999 -5.95269 0
+    endloop
+  endfacet
+  facet normal 0.960293 0.278993 0
+    outer loop
+      vertex -5.70634 -1.8541 5
+      vertex -5.8115 -1.49214 0
+      vertex -5.8115 -1.49214 5
+    endloop
+  endfacet
+  facet normal 0.960293 0.278993 0
+    outer loop
+      vertex -5.8115 -1.49214 0
+      vertex -5.70634 -1.8541 5
+      vertex -5.70634 -1.8541 0
+    endloop
+  endfacet
+  facet normal -0.860746 0.509035 0
+    outer loop
+      vertex 5.06597 -3.21496 0
+      vertex 5.25784 -2.89052 5
+      vertex 5.25784 -2.89052 0
+    endloop
+  endfacet
+  facet normal -0.860746 0.509035 0
+    outer loop
+      vertex 5.25784 -2.89052 5
+      vertex 5.06597 -3.21496 0
+      vertex 5.06597 -3.21496 5
+    endloop
+  endfacet
+  facet normal 0.156447 0.987686 -0
+    outer loop
+      vertex -0.751999 -5.95269 0
+      vertex -1.12429 -5.89372 5
+      vertex -0.751999 -5.95269 5
+    endloop
+  endfacet
+  facet normal 0.156447 0.987686 0
+    outer loop
+      vertex -1.12429 -5.89372 5
+      vertex -0.751999 -5.95269 0
+      vertex -1.12429 -5.89372 0
+    endloop
+  endfacet
+  facet normal -0.397154 0.917752 0
+    outer loop
+      vertex 2.55468 -5.42896 0
+      vertex 2.20875 -5.57866 5
+      vertex 2.55468 -5.42896 5
+    endloop
+  endfacet
+  facet normal -0.397154 0.917752 0
+    outer loop
+      vertex 2.20875 -5.57866 5
+      vertex 2.55468 -5.42896 0
+      vertex 2.20875 -5.57866 0
+    endloop
+  endfacet
+  facet normal -0.999507 0.0314118 0
+    outer loop
+      vertex 5.98816 -0.376742 0
+      vertex 6 0 5
+      vertex 6 0 0
+    endloop
+  endfacet
+  facet normal -0.999507 0.0314118 0
+    outer loop
+      vertex 6 0 5
+      vertex 5.98816 -0.376742 0
+      vertex 5.98816 -0.376742 5
+    endloop
+  endfacet
+  facet normal -0.453993 0.891005 0
+    outer loop
+      vertex 2.89052 -5.25784 0
+      vertex 2.55468 -5.42896 5
+      vertex 2.89052 -5.25784 5
+    endloop
+  endfacet
+  facet normal -0.453993 0.891005 0
+    outer loop
+      vertex 2.55468 -5.42896 5
+      vertex 2.89052 -5.25784 0
+      vertex 2.55468 -5.42896 0
+    endloop
+  endfacet
+  facet normal 0.995563 0.0941024 0
+    outer loop
+      vertex -5.95269 -0.751999 5
+      vertex -5.98816 -0.376742 0
+      vertex -5.98816 -0.376742 5
+    endloop
+  endfacet
+  facet normal 0.995563 0.0941024 0
+    outer loop
+      vertex -5.98816 -0.376742 0
+      vertex -5.95269 -0.751999 5
+      vertex -5.95269 -0.751999 0
+    endloop
+  endfacet
+  facet normal 0.999507 -0.0314118 0
+    outer loop
+      vertex -6 0 5
+      vertex -5.98816 0.376742 0
+      vertex -5.98816 0.376742 5
+    endloop
+  endfacet
+  facet normal 0.999507 -0.0314118 0
+    outer loop
+      vertex -5.98816 0.376742 0
+      vertex -6 0 5
+      vertex -6 0 0
+    endloop
+  endfacet
+  facet normal 0.940882 0.338734 0
+    outer loop
+      vertex -5.57866 -2.20875 5
+      vertex -5.70634 -1.8541 0
+      vertex -5.70634 -1.8541 5
+    endloop
+  endfacet
+  facet normal 0.940882 0.338734 0
+    outer loop
+      vertex -5.70634 -1.8541 0
+      vertex -5.57866 -2.20875 5
+      vertex -5.57866 -2.20875 0
+    endloop
+  endfacet
+  facet normal 0.987686 -0.156447 0
+    outer loop
+      vertex -5.95269 0.751999 5
+      vertex -5.89372 1.12429 0
+      vertex -5.89372 1.12429 5
+    endloop
+  endfacet
+  facet normal 0.987686 -0.156447 0
+    outer loop
+      vertex -5.89372 1.12429 0
+      vertex -5.95269 0.751999 5
+      vertex -5.95269 0.751999 0
+    endloop
+  endfacet
+  facet normal 0.960293 -0.278993 0
+    outer loop
+      vertex -5.8115 1.49214 5
+      vertex -5.70634 1.8541 0
+      vertex -5.70634 1.8541 5
+    endloop
+  endfacet
+  facet normal 0.960293 -0.278993 0
+    outer loop
+      vertex -5.70634 1.8541 0
+      vertex -5.8115 1.49214 5
+      vertex -5.8115 1.49214 0
+    endloop
+  endfacet
+  facet normal 0.891005 0.453993 0
+    outer loop
+      vertex -5.25784 -2.89052 5
+      vertex -5.42896 -2.55468 0
+      vertex -5.42896 -2.55468 5
+    endloop
+  endfacet
+  facet normal 0.891005 0.453993 0
+    outer loop
+      vertex -5.42896 -2.55468 0
+      vertex -5.25784 -2.89052 5
+      vertex -5.25784 -2.89052 0
+    endloop
+  endfacet
+  facet normal 0.860746 0.509035 0
+    outer loop
+      vertex -5.06597 -3.21496 5
+      vertex -5.25784 -2.89052 0
+      vertex -5.25784 -2.89052 5
+    endloop
+  endfacet
+  facet normal 0.860746 0.509035 0
+    outer loop
+      vertex -5.25784 -2.89052 0
+      vertex -5.06597 -3.21496 5
+      vertex -5.06597 -3.21496 0
+    endloop
+  endfacet
+  facet normal -0.509035 0.860746 0
+    outer loop
+      vertex 3.21496 -5.06597 0
+      vertex 2.89052 -5.25784 5
+      vertex 3.21496 -5.06597 5
+    endloop
+  endfacet
+  facet normal -0.509035 0.860746 0
+    outer loop
+      vertex 2.89052 -5.25784 5
+      vertex 3.21496 -5.06597 0
+      vertex 2.89052 -5.25784 0
+    endloop
+  endfacet
+  facet normal -0.995563 0.0941024 0
+    outer loop
+      vertex 5.95269 -0.751999 0
+      vertex 5.98816 -0.376742 5
+      vertex 5.98816 -0.376742 0
+    endloop
+  endfacet
+  facet normal -0.995563 0.0941024 0
+    outer loop
+      vertex 5.98816 -0.376742 5
+      vertex 5.95269 -0.751999 0
+      vertex 5.95269 -0.751999 5
+    endloop
+  endfacet
+  facet normal 0.987686 0.156447 0
+    outer loop
+      vertex -5.89372 -1.12429 5
+      vertex -5.95269 -0.751999 0
+      vertex -5.95269 -0.751999 5
+    endloop
+  endfacet
+  facet normal 0.987686 0.156447 0
+    outer loop
+      vertex -5.95269 -0.751999 0
+      vertex -5.89372 -1.12429 5
+      vertex -5.89372 -1.12429 0
+    endloop
+  endfacet
+  facet normal 0.999507 0.0314118 0
+    outer loop
+      vertex -5.98816 -0.376742 5
+      vertex -6 0 0
+      vertex -6 0 5
+    endloop
+  endfacet
+  facet normal 0.999507 0.0314118 0
+    outer loop
+      vertex -6 0 0
+      vertex -5.98816 -0.376742 5
+      vertex -5.98816 -0.376742 0
+    endloop
+  endfacet
+  facet normal -0.891005 0.453993 0
+    outer loop
+      vertex 5.25784 -2.89052 0
+      vertex 5.42896 -2.55468 5
+      vertex 5.42896 -2.55468 0
+    endloop
+  endfacet
+  facet normal -0.891005 0.453993 0
+    outer loop
+      vertex 5.42896 -2.55468 5
+      vertex 5.25784 -2.89052 0
+      vertex 5.25784 -2.89052 5
+    endloop
+  endfacet
+  facet normal 0.0314118 0.999507 -0
+    outer loop
+      vertex 0 -6 0
+      vertex -0.376742 -5.98816 5
+      vertex 0 -6 5
+    endloop
+  endfacet
+  facet normal 0.0314118 0.999507 0
+    outer loop
+      vertex -0.376742 -5.98816 5
+      vertex 0 -6 0
+      vertex -0.376742 -5.98816 0
+    endloop
+  endfacet
+  facet normal -0.661314 0.75011 0
+    outer loop
+      vertex 4.10728 -4.37381 0
+      vertex 3.82454 -4.62308 5
+      vertex 4.10728 -4.37381 5
+    endloop
+  endfacet
+  facet normal -0.661314 0.75011 0
+    outer loop
+      vertex 3.82454 -4.62308 5
+      vertex 4.10728 -4.37381 0
+      vertex 3.82454 -4.62308 0
+    endloop
+  endfacet
+  facet normal -0.790156 0.612906 0
+    outer loop
+      vertex 4.62308 -3.82454 0
+      vertex 4.8541 -3.52671 5
+      vertex 4.8541 -3.52671 0
+    endloop
+  endfacet
+  facet normal -0.790156 0.612906 0
+    outer loop
+      vertex 4.8541 -3.52671 5
+      vertex 4.62308 -3.82454 0
+      vertex 4.62308 -3.82454 5
+    endloop
+  endfacet
+  facet normal -0.75011 0.661314 0
+    outer loop
+      vertex 4.37381 -4.10728 0
+      vertex 4.62308 -3.82454 5
+      vertex 4.62308 -3.82454 0
+    endloop
+  endfacet
+  facet normal -0.75011 0.661314 0
+    outer loop
+      vertex 4.62308 -3.82454 5
+      vertex 4.37381 -4.10728 0
+      vertex 4.37381 -4.10728 5
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 0
+    outer loop
+      vertex -4.10728 -4.37381 5
+      vertex -4.37381 -4.10728 0
+      vertex -4.37381 -4.10728 5
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 0
+    outer loop
+      vertex -4.37381 -4.10728 0
+      vertex -4.10728 -4.37381 5
+      vertex -4.10728 -4.37381 0
+    endloop
+  endfacet
+  facet normal 0.218133 0.975919 -0
+    outer loop
+      vertex -1.12429 -5.89372 0
+      vertex -1.49214 -5.8115 5
+      vertex -1.12429 -5.89372 5
+    endloop
+  endfacet
+  facet normal 0.218133 0.975919 0
+    outer loop
+      vertex -1.49214 -5.8115 5
+      vertex -1.12429 -5.89372 0
+      vertex -1.49214 -5.8115 0
+    endloop
+  endfacet
+  facet normal 0.917752 -0.397154 0
+    outer loop
+      vertex -5.57866 2.20875 5
+      vertex -5.42896 2.55468 0
+      vertex -5.42896 2.55468 5
+    endloop
+  endfacet
+  facet normal 0.917752 -0.397154 0
+    outer loop
+      vertex -5.42896 2.55468 0
+      vertex -5.57866 2.20875 5
+      vertex -5.57866 2.20875 0
+    endloop
+  endfacet
+  facet normal 0.338734 0.940882 -0
+    outer loop
+      vertex -1.8541 -5.70634 0
+      vertex -2.20875 -5.57866 5
+      vertex -1.8541 -5.70634 5
+    endloop
+  endfacet
+  facet normal 0.338734 0.940882 0
+    outer loop
+      vertex -2.20875 -5.57866 5
+      vertex -1.8541 -5.70634 0
+      vertex -2.20875 -5.57866 0
+    endloop
+  endfacet
+  facet normal 0.397154 0.917752 -0
+    outer loop
+      vertex -2.20875 -5.57866 0
+      vertex -2.55468 -5.42896 5
+      vertex -2.20875 -5.57866 5
+    endloop
+  endfacet
+  facet normal 0.397154 0.917752 0
+    outer loop
+      vertex -2.55468 -5.42896 5
+      vertex -2.20875 -5.57866 0
+      vertex -2.55468 -5.42896 0
+    endloop
+  endfacet
+  facet normal 0.278993 0.960293 -0
+    outer loop
+      vertex -1.49214 -5.8115 0
+      vertex -1.8541 -5.70634 5
+      vertex -1.49214 -5.8115 5
+    endloop
+  endfacet
+  facet normal 0.278993 0.960293 0
+    outer loop
+      vertex -1.8541 -5.70634 5
+      vertex -1.49214 -5.8115 0
+      vertex -1.8541 -5.70634 0
+    endloop
+  endfacet
+  facet normal -0.338734 0.940882 0
+    outer loop
+      vertex 2.20875 -5.57866 0
+      vertex 1.8541 -5.70634 5
+      vertex 2.20875 -5.57866 5
+    endloop
+  endfacet
+  facet normal -0.338734 0.940882 0
+    outer loop
+      vertex 1.8541 -5.70634 5
+      vertex 2.20875 -5.57866 0
+      vertex 1.8541 -5.70634 0
+    endloop
+  endfacet
+  facet normal 0.509035 0.860746 -0
+    outer loop
+      vertex -2.89052 -5.25784 0
+      vertex -3.21496 -5.06597 5
+      vertex -2.89052 -5.25784 5
+    endloop
+  endfacet
+  facet normal 0.509035 0.860746 0
+    outer loop
+      vertex -3.21496 -5.06597 5
+      vertex -2.89052 -5.25784 0
+      vertex -3.21496 -5.06597 0
+    endloop
+  endfacet
+  facet normal -0.827075 0.562092 0
+    outer loop
+      vertex 4.8541 -3.52671 0
+      vertex 5.06597 -3.21496 5
+      vertex 5.06597 -3.21496 0
+    endloop
+  endfacet
+  facet normal -0.827075 0.562092 0
+    outer loop
+      vertex 5.06597 -3.21496 5
+      vertex 4.8541 -3.52671 0
+      vertex 4.8541 -3.52671 5
+    endloop
+  endfacet
+  facet normal -0.940882 0.338734 0
+    outer loop
+      vertex 5.57866 -2.20875 0
+      vertex 5.70634 -1.8541 5
+      vertex 5.70634 -1.8541 0
+    endloop
+  endfacet
+  facet normal -0.940882 0.338734 0
+    outer loop
+      vertex 5.70634 -1.8541 5
+      vertex 5.57866 -2.20875 0
+      vertex 5.57866 -2.20875 5
+    endloop
+  endfacet
+  facet normal 0.790156 0.612906 0
+    outer loop
+      vertex -4.62308 -3.82454 5
+      vertex -4.8541 -3.52671 0
+      vertex -4.8541 -3.52671 5
+    endloop
+  endfacet
+  facet normal 0.790156 0.612906 0
+    outer loop
+      vertex -4.8541 -3.52671 0
+      vertex -4.62308 -3.82454 5
+      vertex -4.62308 -3.82454 0
+    endloop
+  endfacet
+  facet normal 0.995563 -0.0941024 0
+    outer loop
+      vertex -5.98816 0.376742 5
+      vertex -5.95269 0.751999 0
+      vertex -5.95269 0.751999 5
+    endloop
+  endfacet
+  facet normal 0.995563 -0.0941024 0
+    outer loop
+      vertex -5.95269 0.751999 0
+      vertex -5.98816 0.376742 5
+      vertex -5.98816 0.376742 0
+    endloop
+  endfacet
+  facet normal 0.453993 0.891005 -0
+    outer loop
+      vertex -2.55468 -5.42896 0
+      vertex -2.89052 -5.25784 5
+      vertex -2.55468 -5.42896 5
+    endloop
+  endfacet
+  facet normal 0.453993 0.891005 0
+    outer loop
+      vertex -2.89052 -5.25784 5
+      vertex -2.55468 -5.42896 0
+      vertex -2.89052 -5.25784 0
+    endloop
+  endfacet
+  facet normal 0.860727 -0.509067 0
+    outer loop
+      vertex -5.25784 2.89052 5
+      vertex -5.19387 2.99868 0
+      vertex -5.19387 2.99868 5
+    endloop
+  endfacet
+  facet normal 0.860727 -0.509067 0
+    outer loop
+      vertex -5.19387 2.99868 0
+      vertex -5.25784 2.89052 5
+      vertex -5.25784 2.89052 0
+    endloop
+  endfacet
+  facet normal -0.975919 0.218133 0
+    outer loop
+      vertex 5.8115 -1.49214 0
+      vertex 5.89372 -1.12429 5
+      vertex 5.89372 -1.12429 0
+    endloop
+  endfacet
+  facet normal -0.975919 0.218133 0
+    outer loop
+      vertex 5.89372 -1.12429 5
+      vertex 5.8115 -1.49214 0
+      vertex 5.8115 -1.49214 5
+    endloop
+  endfacet
+  facet normal 0.562092 0.827075 -0
+    outer loop
+      vertex -3.21496 -5.06597 0
+      vertex -3.52671 -4.8541 5
+      vertex -3.21496 -5.06597 5
+    endloop
+  endfacet
+  facet normal 0.562092 0.827075 0
+    outer loop
+      vertex -3.52671 -4.8541 5
+      vertex -3.21496 -5.06597 0
+      vertex -3.52671 -4.8541 0
+    endloop
+  endfacet
+  facet normal 0.612906 0.790156 -0
+    outer loop
+      vertex -3.52671 -4.8541 0
+      vertex -3.82454 -4.62308 5
+      vertex -3.52671 -4.8541 5
+    endloop
+  endfacet
+  facet normal 0.612906 0.790156 0
+    outer loop
+      vertex -3.82454 -4.62308 5
+      vertex -3.52671 -4.8541 0
+      vertex -3.82454 -4.62308 0
+    endloop
+  endfacet
+  facet normal 0.975919 -0.218133 0
+    outer loop
+      vertex -5.89372 1.12429 5
+      vertex -5.8115 1.49214 0
+      vertex -5.8115 1.49214 5
+    endloop
+  endfacet
+  facet normal 0.975919 -0.218133 0
+    outer loop
+      vertex -5.8115 1.49214 0
+      vertex -5.89372 1.12429 5
+      vertex -5.89372 1.12429 0
+    endloop
+  endfacet
+  facet normal 0.917752 0.397154 0
+    outer loop
+      vertex -5.42896 -2.55468 5
+      vertex -5.57866 -2.20875 0
+      vertex -5.57866 -2.20875 5
+    endloop
+  endfacet
+  facet normal 0.917752 0.397154 0
+    outer loop
+      vertex -5.57866 -2.20875 0
+      vertex -5.42896 -2.55468 5
+      vertex -5.42896 -2.55468 0
+    endloop
+  endfacet
+  facet normal -0.278993 0.960293 0
+    outer loop
+      vertex 1.8541 -5.70634 0
+      vertex 1.49214 -5.8115 5
+      vertex 1.8541 -5.70634 5
+    endloop
+  endfacet
+  facet normal -0.278993 0.960293 0
+    outer loop
+      vertex 1.49214 -5.8115 5
+      vertex 1.8541 -5.70634 0
+      vertex 1.49214 -5.8115 0
+    endloop
+  endfacet
+  facet normal 0.891005 -0.453993 0
+    outer loop
+      vertex -5.42896 2.55468 5
+      vertex -5.25784 2.89052 0
+      vertex -5.25784 2.89052 5
+    endloop
+  endfacet
+  facet normal 0.891005 -0.453993 0
+    outer loop
+      vertex -5.25784 2.89052 0
+      vertex -5.42896 2.55468 5
+      vertex -5.42896 2.55468 0
+    endloop
+  endfacet
+  facet normal 0.661314 0.75011 -0
+    outer loop
+      vertex -3.82454 -4.62308 0
+      vertex -4.10728 -4.37381 5
+      vertex -3.82454 -4.62308 5
+    endloop
+  endfacet
+  facet normal 0.661314 0.75011 0
+    outer loop
+      vertex -4.10728 -4.37381 5
+      vertex -3.82454 -4.62308 0
+      vertex -4.10728 -4.37381 0
+    endloop
+  endfacet
+  facet normal 0.940882 -0.338734 0
+    outer loop
+      vertex -5.70634 1.8541 5
+      vertex -5.57866 2.20875 0
+      vertex -5.57866 2.20875 5
+    endloop
+  endfacet
+  facet normal 0.940882 -0.338734 0
+    outer loop
+      vertex -5.57866 2.20875 0
+      vertex -5.70634 1.8541 5
+      vertex -5.70634 1.8541 0
+    endloop
+  endfacet
+  facet normal -0.612906 0.790156 0
+    outer loop
+      vertex 3.82454 -4.62308 0
+      vertex 3.52671 -4.8541 5
+      vertex 3.82454 -4.62308 5
+    endloop
+  endfacet
+  facet normal -0.612906 0.790156 0
+    outer loop
+      vertex 3.52671 -4.8541 5
+      vertex 3.82454 -4.62308 0
+      vertex 3.52671 -4.8541 0
+    endloop
+  endfacet
+  facet normal 0.501036 0.865426 -0
+    outer loop
+      vertex -5.19387 2.99868 0
+      vertex -5.19615 3 5
+      vertex -5.19387 2.99868 5
+    endloop
+  endfacet
+  facet normal 0.501036 0.865426 0
+    outer loop
+      vertex -5.19615 3 5
+      vertex -5.19387 2.99868 0
+      vertex -5.19615 3 0
+    endloop
+  endfacet
+  facet normal 0.982304 0.187293 0
+    outer loop
+      vertex 10.9803 0.313333 5
+      vertex 10.9215 0.621724 0
+      vertex 10.9215 0.621724 5
+    endloop
+  endfacet
+  facet normal 0.982304 0.187293 0
+    outer loop
+      vertex 10.9215 0.621724 0
+      vertex 10.9803 0.313333 5
+      vertex 10.9803 0.313333 0
+    endloop
+  endfacet
+  facet normal 0.998029 0.0627485 0
+    outer loop
+      vertex 11 0 5
+      vertex 10.9803 0.313333 0
+      vertex 10.9803 0.313333 5
+    endloop
+  endfacet
+  facet normal 0.998029 0.0627485 0
+    outer loop
+      vertex 10.9803 0.313333 0
+      vertex 11 0 5
+      vertex 11 0 0
+    endloop
+  endfacet
+  facet normal 0.950979 0.309257 0
+    outer loop
+      vertex 10.9215 0.621724 5
+      vertex 10.8244 0.920311 0
+      vertex 10.8244 0.920311 5
+    endloop
+  endfacet
+  facet normal 0.950979 0.309257 0
+    outer loop
+      vertex 10.8244 0.920311 0
+      vertex 10.9215 0.621724 5
+      vertex 10.9215 0.621724 0
+    endloop
+  endfacet
+  facet normal 0.84422 0.535997 0
+    outer loop
+      vertex 10.6908 1.20438 5
+      vertex 10.5225 1.46946 0
+      vertex 10.5225 1.46946 5
+    endloop
+  endfacet
+  facet normal 0.84422 0.535997 0
+    outer loop
+      vertex 10.5225 1.46946 0
+      vertex 10.6908 1.20438 5
+      vertex 10.6908 1.20438 0
+    endloop
+  endfacet
+  facet normal 0.684636 0.728885 -0
+    outer loop
+      vertex 10.3224 1.71137 0
+      vertex 10.0936 1.92628 5
+      vertex 10.3224 1.71137 5
+    endloop
+  endfacet
+  facet normal 0.684636 0.728885 0
+    outer loop
+      vertex 10.0936 1.92628 5
+      vertex 10.3224 1.71137 0
+      vertex 10.0936 1.92628 0
+    endloop
+  endfacet
+  facet normal 0.248699 0.968581 -0
+    outer loop
+      vertex 9.27254 2.37764 0
+      vertex 8.96845 2.45572 5
+      vertex 9.27254 2.37764 5
+    endloop
+  endfacet
+  facet normal 0.248699 0.968581 0
+    outer loop
+      vertex 8.96845 2.45572 5
+      vertex 9.27254 2.37764 0
+      vertex 8.96845 2.45572 0
+    endloop
+  endfacet
+  facet normal -0.248699 0.968581 0
+    outer loop
+      vertex 8.03155 2.45572 0
+      vertex 7.72746 2.37764 5
+      vertex 8.03155 2.45572 5
+    endloop
+  endfacet
+  facet normal -0.248699 0.968581 0
+    outer loop
+      vertex 7.72746 2.37764 5
+      vertex 8.03155 2.45572 0
+      vertex 7.72746 2.37764 0
+    endloop
+  endfacet
+  facet normal -0.481757 0.876305 0
+    outer loop
+      vertex 7.43555 2.26207 0
+      vertex 7.16043 2.11082 5
+      vertex 7.43555 2.26207 5
+    endloop
+  endfacet
+  facet normal -0.481757 0.876305 0
+    outer loop
+      vertex 7.16043 2.11082 5
+      vertex 7.43555 2.26207 0
+      vertex 7.16043 2.11082 0
+    endloop
+  endfacet
+  facet normal 0.36811 0.929782 -0
+    outer loop
+      vertex 9.56445 2.26207 0
+      vertex 9.27254 2.37764 5
+      vertex 9.56445 2.26207 5
+    endloop
+  endfacet
+  facet normal 0.36811 0.929782 0
+    outer loop
+      vertex 9.27254 2.37764 5
+      vertex 9.56445 2.26207 0
+      vertex 9.27254 2.37764 0
+    endloop
+  endfacet
+  facet normal 0.904916 0.42559 0
+    outer loop
+      vertex 10.8244 0.920311 5
+      vertex 10.6908 1.20438 0
+      vertex 10.6908 1.20438 5
+    endloop
+  endfacet
+  facet normal 0.904916 0.42559 0
+    outer loop
+      vertex 10.6908 1.20438 0
+      vertex 10.8244 0.920311 5
+      vertex 10.8244 0.920311 0
+    endloop
+  endfacet
+  facet normal -0.844321 0.535838 0
+    outer loop
+      vertex 6.30923 1.20438 0
+      vertex 6.47746 1.46946 5
+      vertex 6.47746 1.46946 0
+    endloop
+  endfacet
+  facet normal -0.844321 0.535838 0
+    outer loop
+      vertex 6.47746 1.46946 5
+      vertex 6.30923 1.20438 0
+      vertex 6.30923 1.20438 5
+    endloop
+  endfacet
+  facet normal -0.36811 0.929782 0
+    outer loop
+      vertex 7.72746 2.37764 0
+      vertex 7.43555 2.26207 5
+      vertex 7.72746 2.37764 5
+    endloop
+  endfacet
+  facet normal -0.36811 0.929782 0
+    outer loop
+      vertex 7.43555 2.26207 5
+      vertex 7.72746 2.37764 0
+      vertex 7.43555 2.26207 0
+    endloop
+  endfacet
+  facet normal -0.684541 0.728975 0
+    outer loop
+      vertex 6.90644 1.92628 0
+      vertex 6.67758 1.71137 5
+      vertex 6.90644 1.92628 5
+    endloop
+  endfacet
+  facet normal -0.684541 0.728975 0
+    outer loop
+      vertex 6.67758 1.71137 5
+      vertex 6.90644 1.92628 0
+      vertex 6.67758 1.71137 0
+    endloop
+  endfacet
+  facet normal 0.587736 0.809053 -0
+    outer loop
+      vertex 10.0936 1.92628 0
+      vertex 9.83957 2.11082 5
+      vertex 10.0936 1.92628 5
+    endloop
+  endfacet
+  facet normal 0.587736 0.809053 0
+    outer loop
+      vertex 9.83957 2.11082 5
+      vertex 10.0936 1.92628 0
+      vertex 9.83957 2.11082 0
+    endloop
+  endfacet
+  facet normal 0.12534 0.992114 -0
+    outer loop
+      vertex 8.96845 2.45572 0
+      vertex 8.65698 2.49507 5
+      vertex 8.96845 2.45572 5
+    endloop
+  endfacet
+  facet normal 0.12534 0.992114 0
+    outer loop
+      vertex 8.65698 2.49507 5
+      vertex 8.96845 2.45572 0
+      vertex 8.65698 2.49507 0
+    endloop
+  endfacet
+  facet normal -0.982287 0.187385 0
+    outer loop
+      vertex 6.01971 0.313333 0
+      vertex 6.07854 0.621724 5
+      vertex 6.07854 0.621724 0
+    endloop
+  endfacet
+  facet normal -0.982287 0.187385 0
+    outer loop
+      vertex 6.07854 0.621724 5
+      vertex 6.01971 0.313333 0
+      vertex 6.01971 0.313333 5
+    endloop
+  endfacet
+  facet normal -0.12534 0.992114 0
+    outer loop
+      vertex 8.34302 2.49507 0
+      vertex 8.03155 2.45572 5
+      vertex 8.34302 2.49507 5
+    endloop
+  endfacet
+  facet normal -0.12534 0.992114 0
+    outer loop
+      vertex 8.03155 2.45572 5
+      vertex 8.34302 2.49507 0
+      vertex 8.03155 2.45572 0
+    endloop
+  endfacet
+  facet normal 0.481757 0.876305 -0
+    outer loop
+      vertex 9.83957 2.11082 0
+      vertex 9.56445 2.26207 5
+      vertex 9.83957 2.11082 5
+    endloop
+  endfacet
+  facet normal 0.481757 0.876305 0
+    outer loop
+      vertex 9.56445 2.26207 5
+      vertex 9.83957 2.11082 0
+      vertex 9.56445 2.26207 0
+    endloop
+  endfacet
+  facet normal -0.998027 0.0627802 0
+    outer loop
+      vertex 6 0 0
+      vertex 6.01971 0.313333 5
+      vertex 6.01971 0.313333 0
+    endloop
+  endfacet
+  facet normal -0.998027 0.0627802 0
+    outer loop
+      vertex 6.01971 0.313333 5
+      vertex 6 0 0
+      vertex 6 0 5
+    endloop
+  endfacet
+  facet normal -0.587797 0.809009 0
+    outer loop
+      vertex 7.16043 2.11082 0
+      vertex 6.90644 1.92628 5
+      vertex 7.16043 2.11082 5
+    endloop
+  endfacet
+  facet normal -0.587797 0.809009 0
+    outer loop
+      vertex 6.90644 1.92628 5
+      vertex 7.16043 2.11082 0
+      vertex 6.90644 1.92628 0
+    endloop
+  endfacet
+  facet normal 0.770553 0.637376 0
+    outer loop
+      vertex 10.5225 1.46946 5
+      vertex 10.3224 1.71137 0
+      vertex 10.3224 1.71137 5
+    endloop
+  endfacet
+  facet normal 0.770553 0.637376 0
+    outer loop
+      vertex 10.3224 1.71137 0
+      vertex 10.5225 1.46946 5
+      vertex 10.5225 1.46946 0
+    endloop
+  endfacet
+  facet normal -0.951054 0.309026 0
+    outer loop
+      vertex 6.07854 0.621724 0
+      vertex 6.17556 0.920311 5
+      vertex 6.17556 0.920311 0
+    endloop
+  endfacet
+  facet normal -0.951054 0.309026 0
+    outer loop
+      vertex 6.17556 0.920311 5
+      vertex 6.07854 0.621724 0
+      vertex 6.07854 0.621724 5
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 8.65698 2.49507 0
+      vertex 8.34302 2.49507 5
+      vertex 8.65698 2.49507 5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 8.34302 2.49507 5
+      vertex 8.65698 2.49507 0
+      vertex 8.34302 2.49507 0
+    endloop
+  endfacet
+  facet normal -0.90483 0.425772 0
+    outer loop
+      vertex 6.17556 0.920311 0
+      vertex 6.30923 1.20438 5
+      vertex 6.30923 1.20438 0
+    endloop
+  endfacet
+  facet normal -0.90483 0.425772 0
+    outer loop
+      vertex 6.30923 1.20438 5
+      vertex 6.17556 0.920311 0
+      vertex 6.17556 0.920311 5
+    endloop
+  endfacet
+  facet normal -0.770522 0.637414 0
+    outer loop
+      vertex 6.47746 1.46946 0
+      vertex 6.67758 1.71137 5
+      vertex 6.67758 1.71137 0
+    endloop
+  endfacet
+  facet normal -0.770522 0.637414 0
+    outer loop
+      vertex 6.67758 1.71137 5
+      vertex 6.47746 1.46946 0
+      vertex 6.47746 1.46946 5
+    endloop
+  endfacet
+  facet normal -0.669109 0.743164 0
+    outer loop
+      vertex -8.91408 6.20923 0
+      vertex -9.1474 5.99916 5
+      vertex -8.91408 6.20923 5
+    endloop
+  endfacet
+  facet normal -0.669109 0.743164 0
+    outer loop
+      vertex -9.1474 5.99916 5
+      vertex -8.91408 6.20923 0
+      vertex -9.1474 5.99916 0
+    endloop
+  endfacet
+  facet normal -0.895729 0.444601 0
+    outer loop
+      vertex -9.55557 5.44099 0
+      vertex -9.52628 5.5 5
+      vertex -9.52628 5.5 0
+    endloop
+  endfacet
+  facet normal -0.895729 0.444601 0
+    outer loop
+      vertex -9.52628 5.5 5
+      vertex -9.55557 5.44099 0
+      vertex -9.55557 5.44099 5
+    endloop
+  endfacet
+  facet normal 0.944375 -0.32887 0
+    outer loop
+      vertex -5.05656 3.28121 5
+      vertex -4.95331 3.5777 0
+      vertex -4.95331 3.5777 5
+    endloop
+  endfacet
+  facet normal 0.944375 -0.32887 0
+    outer loop
+      vertex -4.95331 3.5777 0
+      vertex -5.05656 3.28121 5
+      vertex -5.05656 3.28121 0
+    endloop
+  endfacet
+  facet normal 0.387513 0.921864 -0
+    outer loop
+      vertex -6.24963 6.48928 0
+      vertex -6.53905 6.61094 5
+      vertex -6.24963 6.48928 5
+    endloop
+  endfacet
+  facet normal 0.387513 0.921864 0
+    outer loop
+      vertex -6.53905 6.61094 5
+      vertex -6.24963 6.48928 0
+      vertex -6.53905 6.61094 0
+    endloop
+  endfacet
+  facet normal 0.783704 0.621134 0
+    outer loop
+      vertex -5.30834 5.67678 5
+      vertex -5.50335 5.92283 0
+      vertex -5.50335 5.92283 5
+    endloop
+  endfacet
+  facet normal 0.783704 0.621134 0
+    outer loop
+      vertex -5.50335 5.92283 0
+      vertex -5.30834 5.67678 5
+      vertex -5.30834 5.67678 0
+    endloop
+  endfacet
+  facet normal -0.832922 0.553391 0
+    outer loop
+      vertex -9.52628 5.5 0
+      vertex -9.35254 5.7615 5
+      vertex -9.35254 5.7615 0
+    endloop
+  endfacet
+  facet normal -0.832922 0.553391 0
+    outer loop
+      vertex -9.35254 5.7615 5
+      vertex -9.52628 5.5 0
+      vertex -9.52628 5.5 5
+    endloop
+  endfacet
+  facet normal 0.146075 0.989273 -0
+    outer loop
+      vertex -6.84144 6.69537 0
+      vertex -7.15202 6.74123 5
+      vertex -6.84144 6.69537 5
+    endloop
+  endfacet
+  facet normal 0.146075 0.989273 0
+    outer loop
+      vertex -7.15202 6.74123 5
+      vertex -6.84144 6.69537 0
+      vertex -7.15202 6.74123 0
+    endloop
+  endfacet
+  facet normal 0.604577 0.796547 -0
+    outer loop
+      vertex -5.72766 6.14249 0
+      vertex -5.97774 6.3323 5
+      vertex -5.72766 6.14249 5
+    endloop
+  endfacet
+  facet normal 0.604577 0.796547 0
+    outer loop
+      vertex -5.97774 6.3323 5
+      vertex -5.72766 6.14249 0
+      vertex -5.97774 6.3323 0
+    endloop
+  endfacet
+  facet normal -0.756999 0.653416 0
+    outer loop
+      vertex -9.35254 5.7615 0
+      vertex -9.1474 5.99916 5
+      vertex -9.1474 5.99916 0
+    endloop
+  endfacet
+  facet normal -0.756999 0.653416 0
+    outer loop
+      vertex -9.1474 5.99916 5
+      vertex -9.35254 5.7615 0
+      vertex -9.35254 5.7615 5
+    endloop
+  endfacet
+  facet normal 0.699662 0.714474 -0
+    outer loop
+      vertex -5.50335 5.92283 0
+      vertex -5.72766 6.14249 5
+      vertex -5.50335 5.92283 5
+    endloop
+  endfacet
+  facet normal 0.699662 0.714474 0
+    outer loop
+      vertex -5.72766 6.14249 5
+      vertex -5.50335 5.92283 0
+      vertex -5.72766 6.14249 0
+    endloop
+  endfacet
+  facet normal 0.0209588 0.99978 -0
+    outer loop
+      vertex -7.15202 6.74123 0
+      vertex -7.4659 6.74781 5
+      vertex -7.15202 6.74123 5
+    endloop
+  endfacet
+  facet normal 0.0209588 0.99978 0
+    outer loop
+      vertex -7.4659 6.74781 5
+      vertex -7.15202 6.74123 0
+      vertex -7.4659 6.74781 0
+    endloop
+  endfacet
+  facet normal 0.268923 0.963162 -0
+    outer loop
+      vertex -6.53905 6.61094 0
+      vertex -6.84144 6.69537 5
+      vertex -6.53905 6.61094 5
+    endloop
+  endfacet
+  facet normal 0.268923 0.963162 0
+    outer loop
+      vertex -6.84144 6.69537 5
+      vertex -6.53905 6.61094 0
+      vertex -6.84144 6.69537 0
+    endloop
+  endfacet
+  facet normal -0.104536 0.994521 0
+    outer loop
+      vertex -7.4659 6.74781 0
+      vertex -7.77814 6.71499 5
+      vertex -7.4659 6.74781 5
+    endloop
+  endfacet
+  facet normal -0.104536 0.994521 0
+    outer loop
+      vertex -7.77814 6.71499 5
+      vertex -7.4659 6.74781 0
+      vertex -7.77814 6.71499 0
+    endloop
+  endfacet
+  facet normal -0.463296 0.886203 0
+    outer loop
+      vertex -8.37806 6.53386 0
+      vertex -8.65628 6.38841 5
+      vertex -8.37806 6.53386 5
+    endloop
+  endfacet
+  facet normal -0.463296 0.886203 0
+    outer loop
+      vertex -8.65628 6.38841 5
+      vertex -8.37806 6.53386 0
+      vertex -8.65628 6.38841 0
+    endloop
+  endfacet
+  facet normal 0.978144 -0.20793 0
+    outer loop
+      vertex -4.95331 3.5777 5
+      vertex -4.88803 3.88479 0
+      vertex -4.88803 3.88479 5
+    endloop
+  endfacet
+  facet normal 0.978144 -0.20793 0
+    outer loop
+      vertex -4.88803 3.88479 0
+      vertex -4.95331 3.5777 5
+      vertex -4.95331 3.5777 0
+    endloop
+  endfacet
+  facet normal 0.985995 0.166774 0
+    outer loop
+      vertex -4.87491 4.51132 5
+      vertex -4.92727 4.82088 0
+      vertex -4.92727 4.82088 5
+    endloop
+  endfacet
+  facet normal 0.985995 0.166774 0
+    outer loop
+      vertex -4.92727 4.82088 0
+      vertex -4.87491 4.51132 5
+      vertex -4.87491 4.51132 0
+    endloop
+  endfacet
+  facet normal -0.570723 0.821143 0
+    outer loop
+      vertex -8.65628 6.38841 0
+      vertex -8.91408 6.20923 5
+      vertex -8.65628 6.38841 5
+    endloop
+  endfacet
+  facet normal -0.570723 0.821143 0
+    outer loop
+      vertex -8.91408 6.20923 5
+      vertex -8.65628 6.38841 0
+      vertex -8.91408 6.20923 0
+    endloop
+  endfacet
+  facet normal 0.855369 0.518019 0
+    outer loop
+      vertex -5.14571 5.40824 5
+      vertex -5.30834 5.67678 0
+      vertex -5.30834 5.67678 5
+    endloop
+  endfacet
+  facet normal 0.855369 0.518019 0
+    outer loop
+      vertex -5.30834 5.67678 0
+      vertex -5.14571 5.40824 5
+      vertex -5.14571 5.40824 0
+    endloop
+  endfacet
+  facet normal 0.996493 -0.0836755 0
+    outer loop
+      vertex -4.88803 3.88479 5
+      vertex -4.86176 4.19764 0
+      vertex -4.86176 4.19764 5
+    endloop
+  endfacet
+  facet normal 0.996493 -0.0836755 0
+    outer loop
+      vertex -4.86176 4.19764 0
+      vertex -4.88803 3.88479 5
+      vertex -4.88803 3.88479 0
+    endloop
+  endfacet
+  facet normal 0.957321 0.289028 0
+    outer loop
+      vertex -4.92727 4.82088 5
+      vertex -5.01801 5.12143 0
+      vertex -5.01801 5.12143 5
+    endloop
+  endfacet
+  facet normal 0.957321 0.289028 0
+    outer loop
+      vertex -5.01801 5.12143 0
+      vertex -4.92727 4.82088 5
+      vertex -4.92727 4.82088 0
+    endloop
+  endfacet
+  facet normal 0.50001 0.86602 -0
+    outer loop
+      vertex -5.97774 6.3323 0
+      vertex -6.24963 6.48928 5
+      vertex -5.97774 6.3323 5
+    endloop
+  endfacet
+  facet normal 0.50001 0.86602 0
+    outer loop
+      vertex -6.24963 6.48928 5
+      vertex -5.97774 6.3323 0
+      vertex -6.24963 6.48928 0
+    endloop
+  endfacet
+  facet normal 0.895717 -0.444625 0
+    outer loop
+      vertex -5.19615 3 5
+      vertex -5.05656 3.28121 0
+      vertex -5.05656 3.28121 5
+    endloop
+  endfacet
+  facet normal 0.895717 -0.444625 0
+    outer loop
+      vertex -5.05656 3.28121 0
+      vertex -5.19615 3 5
+      vertex -5.19615 3 0
+    endloop
+  endfacet
+  facet normal 0.913541 0.406747 0
+    outer loop
+      vertex -5.01801 5.12143 5
+      vertex -5.14571 5.40824 0
+      vertex -5.14571 5.40824 5
+    endloop
+  endfacet
+  facet normal 0.913541 0.406747 0
+    outer loop
+      vertex -5.14571 5.40824 0
+      vertex -5.01801 5.12143 5
+      vertex -5.01801 5.12143 0
+    endloop
+  endfacet
+  facet normal 0.999122 0.0418849 0
+    outer loop
+      vertex -4.86176 4.19764 5
+      vertex -4.87491 4.51132 0
+      vertex -4.87491 4.51132 5
+    endloop
+  endfacet
+  facet normal 0.999122 0.0418849 0
+    outer loop
+      vertex -4.87491 4.51132 0
+      vertex -4.86176 4.19764 5
+      vertex -4.86176 4.19764 0
+    endloop
+  endfacet
+  facet normal -0.348578 0.93728 0
+    outer loop
+      vertex -8.08379 6.6433 0
+      vertex -8.37806 6.53386 5
+      vertex -8.08379 6.6433 5
+    endloop
+  endfacet
+  facet normal -0.348578 0.93728 0
+    outer loop
+      vertex -8.37806 6.53386 5
+      vertex -8.08379 6.6433 0
+      vertex -8.37806 6.53386 0
+    endloop
+  endfacet
+  facet normal -0.228352 0.973579 0
+    outer loop
+      vertex -7.77814 6.71499 0
+      vertex -8.08379 6.6433 5
+      vertex -7.77814 6.71499 5
+    endloop
+  endfacet
+  facet normal -0.228352 0.973579 0
+    outer loop
+      vertex -8.08379 6.6433 5
+      vertex -7.77814 6.71499 0
+      vertex -8.08379 6.6433 0
+    endloop
+  endfacet
+endsolid OpenSCAD_Model

--- a/Konstruktionsdateien/NistkastenV2.scad
+++ b/Konstruktionsdateien/NistkastenV2.scad
@@ -1,0 +1,37 @@
+//color("#00bb0077")translate([96,44,0.1])mirror([0,1,0])import("/git/Nistkasten-V2/Konstruktionsdateien/Nistkasten.stl");
+
+difference(){
+    union(){
+        cube([140,140,3]);
+        cube([140,12,40]);
+        translate([0,128,0])cube([140,12,40]);
+        translate([70,70,-1]){
+            translate([6.75,14,2])cylinder(d=4.7,h=6.5,$fn=50);
+            translate([6.75,-14,2])cylinder(d=4.7,h=6.5,$fn=50);
+            translate([-6.75,14,2])cylinder(d=4.7,h=6.5,$fn=50);
+            translate([-6.75,-14,2])cylinder(d=4.7,h=6.5,$fn=50);
+        }
+    }
+    translate([70,70,-1]){
+        cylinder(d=16,h=5,$fn=100);
+        translate([-12.5,-14,0])cylinder(d=6.5,h=5,$fn=100);
+        translate([0,30,0])cylinder(d=19,h=5,$fn=100);
+        translate([0,30,0])translate([-7,-11,0])cylinder(d=6.5,h=15,$fn=100);
+        translate([0,-30,0])cylinder(d=19,h=5,$fn=100);
+        translate([0,-30,0])translate([7,11,0])cylinder(d=6.5,h=15,$fn=100);
+        translate([6.75,14,0])cylinder(d=2.5,h=10,$fn=50);
+        translate([6.75,-14,0])cylinder(d=2.5,h=10,$fn=50);
+        translate([-6.75,14,0])cylinder(d=2.5,h=10,$fn=50);
+        translate([-6.75,-14,0])cylinder(d=2.5,h=10,$fn=50);
+        translate([30.5,0,2.5])cube([20.5,15.5,5],center=true);
+        translate([18,0,4])cube([5,15.5,3],center=true);
+        translate([45,0,3.5])cube([11,10,4],center=true);
+        translate([43,-29,0])cylinder(d=2.5,h=5,$fn=50);
+        translate([43,29,0])cylinder(d=2.5,h=5,$fn=50);
+        translate([20,-29,0])cylinder(d=2.5,h=5,$fn=50);
+        translate([20,29,0])cylinder(d=2.5,h=5,$fn=50);
+        translate([0,-64,0])cylinder(d=4,h=40,$fn=50);
+        translate([0,64,0])cylinder(d=4,h=40,$fn=50);
+    }
+        translate([0,0,11])rotate([0,-atan(29/140),0])translate([-1,-1,0])cube([144,142,40]);
+}

--- a/Konstruktionsdateien/NistkastenV2.stl
+++ b/Konstruktionsdateien/NistkastenV2.stl
@@ -1,0 +1,36962 @@
+solid OpenSCAD_Model
+  facet normal -0.995562 -0.0941049 0
+    outer loop
+      vertex 77.9842 70.5023 0
+      vertex 77.9369 71.0027 3
+      vertex 77.9369 71.0027 0
+    endloop
+  endfacet
+  facet normal -0.995562 -0.0941049 0
+    outer loop
+      vertex 77.9369 71.0027 3
+      vertex 77.9842 70.5023 0
+      vertex 77.9842 70.5023 3
+    endloop
+  endfacet
+  facet normal -0.999506 -0.0314398 0
+    outer loop
+      vertex 78 70 0
+      vertex 77.9842 70.5023 3
+      vertex 77.9842 70.5023 0
+    endloop
+  endfacet
+  facet normal -0.999506 -0.0314398 0
+    outer loop
+      vertex 77.9842 70.5023 3
+      vertex 78 70 0
+      vertex 78 70 3
+    endloop
+  endfacet
+  facet normal 0.891059 -0.453887 0
+    outer loop
+      vertex 62.7614 73.4062 3
+      vertex 62.9895 73.854 0
+      vertex 62.9895 73.854 3
+    endloop
+  endfacet
+  facet normal 0.891059 -0.453887 0
+    outer loop
+      vertex 62.9895 73.854 0
+      vertex 62.7614 73.4062 3
+      vertex 62.7614 73.4062 0
+    endloop
+  endfacet
+  facet normal 0.860689 -0.509131 0
+    outer loop
+      vertex 62.9895 73.854 3
+      vertex 63.2454 74.2866 0
+      vertex 63.2454 74.2866 3
+    endloop
+  endfacet
+  facet normal 0.860689 -0.509131 0
+    outer loop
+      vertex 63.2454 74.2866 0
+      vertex 62.9895 73.854 3
+      vertex 62.9895 73.854 0
+    endloop
+  endfacet
+  facet normal -0.278976 0.960298 0
+    outer loop
+      vertex 72.4721 62.3915 0
+      vertex 71.9895 62.2513 3
+      vertex 72.4721 62.3915 3
+    endloop
+  endfacet
+  facet normal -0.278976 0.960298 0
+    outer loop
+      vertex 71.9895 62.2513 3
+      vertex 72.4721 62.3915 0
+      vertex 71.9895 62.2513 0
+    endloop
+  endfacet
+  facet normal -0.940852 -0.338818 0
+    outer loop
+      vertex 77.6085 72.4721 0
+      vertex 77.4382 72.945 3
+      vertex 77.4382 72.945 0
+    endloop
+  endfacet
+  facet normal -0.940852 -0.338818 0
+    outer loop
+      vertex 77.4382 72.945 3
+      vertex 77.6085 72.4721 0
+      vertex 77.6085 72.4721 3
+    endloop
+  endfacet
+  facet normal 0.453887 0.891059 -0
+    outer loop
+      vertex 66.5938 62.7614 0
+      vertex 66.146 62.9895 3
+      vertex 66.5938 62.7614 3
+    endloop
+  endfacet
+  facet normal 0.453887 0.891059 0
+    outer loop
+      vertex 66.146 62.9895 3
+      vertex 66.5938 62.7614 0
+      vertex 66.146 62.9895 0
+    endloop
+  endfacet
+  facet normal -0.453887 0.891059 0
+    outer loop
+      vertex 73.854 62.9895 0
+      vertex 73.4062 62.7614 3
+      vertex 73.854 62.9895 3
+    endloop
+  endfacet
+  facet normal -0.453887 0.891059 0
+    outer loop
+      vertex 73.4062 62.7614 3
+      vertex 73.854 62.9895 0
+      vertex 73.4062 62.7614 0
+    endloop
+  endfacet
+  facet normal 0.509131 0.860689 -0
+    outer loop
+      vertex 66.146 62.9895 0
+      vertex 65.7134 63.2454 3
+      vertex 66.146 62.9895 3
+    endloop
+  endfacet
+  facet normal 0.509131 0.860689 0
+    outer loop
+      vertex 65.7134 63.2454 3
+      vertex 66.146 62.9895 0
+      vertex 65.7134 63.2454 0
+    endloop
+  endfacet
+  facet normal 0.940852 -0.338818 0
+    outer loop
+      vertex 62.3915 72.4721 3
+      vertex 62.5618 72.945 0
+      vertex 62.5618 72.945 3
+    endloop
+  endfacet
+  facet normal 0.940852 -0.338818 0
+    outer loop
+      vertex 62.5618 72.945 0
+      vertex 62.3915 72.4721 3
+      vertex 62.3915 72.4721 0
+    endloop
+  endfacet
+  facet normal -0.940852 0.338818 0
+    outer loop
+      vertex 77.4382 67.055 0
+      vertex 77.6085 67.5279 3
+      vertex 77.6085 67.5279 0
+    endloop
+  endfacet
+  facet normal -0.940852 0.338818 0
+    outer loop
+      vertex 77.6085 67.5279 3
+      vertex 77.4382 67.055 0
+      vertex 77.4382 67.055 3
+    endloop
+  endfacet
+  facet normal -0.917739 -0.397183 0
+    outer loop
+      vertex 77.4382 72.945 0
+      vertex 77.2386 73.4062 3
+      vertex 77.2386 73.4062 0
+    endloop
+  endfacet
+  facet normal -0.917739 -0.397183 0
+    outer loop
+      vertex 77.2386 73.4062 3
+      vertex 77.4382 72.945 0
+      vertex 77.4382 72.945 3
+    endloop
+  endfacet
+  facet normal -0.987695 0.156392 0
+    outer loop
+      vertex 77.8583 68.5009 0
+      vertex 77.9369 68.9973 3
+      vertex 77.9369 68.9973 0
+    endloop
+  endfacet
+  facet normal -0.987695 0.156392 0
+    outer loop
+      vertex 77.9369 68.9973 3
+      vertex 77.8583 68.5009 0
+      vertex 77.8583 68.5009 3
+    endloop
+  endfacet
+  facet normal -0.975924 -0.21811 0
+    outer loop
+      vertex 77.8583 71.4991 0
+      vertex 77.7487 71.9895 3
+      vertex 77.7487 71.9895 0
+    endloop
+  endfacet
+  facet normal -0.975924 -0.21811 0
+    outer loop
+      vertex 77.7487 71.9895 3
+      vertex 77.8583 71.4991 0
+      vertex 77.8583 71.4991 3
+    endloop
+  endfacet
+  facet normal 0.338818 -0.940852 0
+    outer loop
+      vertex 67.055 77.4382 0
+      vertex 67.5279 77.6085 3
+      vertex 67.055 77.4382 3
+    endloop
+  endfacet
+  facet normal 0.338818 -0.940852 0
+    outer loop
+      vertex 67.5279 77.6085 3
+      vertex 67.055 77.4382 0
+      vertex 67.5279 77.6085 0
+    endloop
+  endfacet
+  facet normal -0.397183 0.917739 0
+    outer loop
+      vertex 73.4062 62.7614 0
+      vertex 72.945 62.5618 3
+      vertex 73.4062 62.7614 3
+    endloop
+  endfacet
+  facet normal -0.397183 0.917739 0
+    outer loop
+      vertex 72.945 62.5618 3
+      vertex 73.4062 62.7614 0
+      vertex 72.945 62.5618 0
+    endloop
+  endfacet
+  facet normal -0.562071 -0.827089 0
+    outer loop
+      vertex 74.2866 76.7546 0
+      vertex 74.7023 76.4721 3
+      vertex 74.2866 76.7546 3
+    endloop
+  endfacet
+  facet normal -0.562071 -0.827089 -0
+    outer loop
+      vertex 74.7023 76.4721 3
+      vertex 74.2866 76.7546 0
+      vertex 74.7023 76.4721 0
+    endloop
+  endfacet
+  facet normal 0.940852 0.338818 0
+    outer loop
+      vertex 62.5618 67.055 3
+      vertex 62.3915 67.5279 0
+      vertex 62.3915 67.5279 3
+    endloop
+  endfacet
+  facet normal 0.940852 0.338818 0
+    outer loop
+      vertex 62.3915 67.5279 0
+      vertex 62.5618 67.055 3
+      vertex 62.5618 67.055 0
+    endloop
+  endfacet
+  facet normal -0.156392 -0.987695 0
+    outer loop
+      vertex 71.0027 77.9369 0
+      vertex 71.4991 77.8583 3
+      vertex 71.0027 77.9369 3
+    endloop
+  endfacet
+  facet normal -0.156392 -0.987695 -0
+    outer loop
+      vertex 71.4991 77.8583 3
+      vertex 71.0027 77.9369 0
+      vertex 71.4991 77.8583 0
+    endloop
+  endfacet
+  facet normal 0.338818 0.940852 -0
+    outer loop
+      vertex 67.5279 62.3915 0
+      vertex 67.055 62.5618 3
+      vertex 67.5279 62.3915 3
+    endloop
+  endfacet
+  facet normal 0.338818 0.940852 0
+    outer loop
+      vertex 67.055 62.5618 3
+      vertex 67.5279 62.3915 0
+      vertex 67.055 62.5618 0
+    endloop
+  endfacet
+  facet normal -0.397183 -0.917739 0
+    outer loop
+      vertex 72.945 77.4382 0
+      vertex 73.4062 77.2386 3
+      vertex 72.945 77.4382 3
+    endloop
+  endfacet
+  facet normal -0.397183 -0.917739 -0
+    outer loop
+      vertex 73.4062 77.2386 3
+      vertex 72.945 77.4382 0
+      vertex 73.4062 77.2386 0
+    endloop
+  endfacet
+  facet normal -0.509131 -0.860689 0
+    outer loop
+      vertex 73.854 77.0105 0
+      vertex 74.2866 76.7546 3
+      vertex 73.854 77.0105 3
+    endloop
+  endfacet
+  facet normal -0.509131 -0.860689 -0
+    outer loop
+      vertex 74.2866 76.7546 3
+      vertex 73.854 77.0105 0
+      vertex 74.2866 76.7546 0
+    endloop
+  endfacet
+  facet normal -0.960298 0.278976 0
+    outer loop
+      vertex 77.6085 67.5279 0
+      vertex 77.7487 68.0105 3
+      vertex 77.7487 68.0105 0
+    endloop
+  endfacet
+  facet normal -0.960298 0.278976 0
+    outer loop
+      vertex 77.7487 68.0105 3
+      vertex 77.6085 67.5279 0
+      vertex 77.6085 67.5279 3
+    endloop
+  endfacet
+  facet normal 0.750082 -0.661345 0
+    outer loop
+      vertex 63.8359 75.0994 3
+      vertex 64.1683 75.4764 0
+      vertex 64.1683 75.4764 3
+    endloop
+  endfacet
+  facet normal 0.750082 -0.661345 0
+    outer loop
+      vertex 64.1683 75.4764 0
+      vertex 63.8359 75.0994 3
+      vertex 63.8359 75.0994 0
+    endloop
+  endfacet
+  facet normal -0.453887 -0.891059 0
+    outer loop
+      vertex 73.4062 77.2386 0
+      vertex 73.854 77.0105 3
+      vertex 73.4062 77.2386 3
+    endloop
+  endfacet
+  facet normal -0.453887 -0.891059 -0
+    outer loop
+      vertex 73.854 77.0105 3
+      vertex 73.4062 77.2386 0
+      vertex 73.854 77.0105 0
+    endloop
+  endfacet
+  facet normal 0.750082 0.661345 0
+    outer loop
+      vertex 64.1683 64.5236 3
+      vertex 63.8359 64.9006 0
+      vertex 63.8359 64.9006 3
+    endloop
+  endfacet
+  facet normal 0.750082 0.661345 0
+    outer loop
+      vertex 63.8359 64.9006 0
+      vertex 64.1683 64.5236 3
+      vertex 64.1683 64.5236 0
+    endloop
+  endfacet
+  facet normal -0.0314398 0.999506 0
+    outer loop
+      vertex 70.5023 62.0158 0
+      vertex 70 62 3
+      vertex 70.5023 62.0158 3
+    endloop
+  endfacet
+  facet normal -0.0314398 0.999506 0
+    outer loop
+      vertex 70 62 3
+      vertex 70.5023 62.0158 0
+      vertex 70 62 0
+    endloop
+  endfacet
+  facet normal 0.0941049 -0.995562 0
+    outer loop
+      vertex 68.9973 77.9369 0
+      vertex 69.4977 77.9842 3
+      vertex 68.9973 77.9369 3
+    endloop
+  endfacet
+  facet normal 0.0941049 -0.995562 0
+    outer loop
+      vertex 69.4977 77.9842 3
+      vertex 68.9973 77.9369 0
+      vertex 69.4977 77.9842 0
+    endloop
+  endfacet
+  facet normal 0.891059 0.453887 0
+    outer loop
+      vertex 62.9895 66.146 3
+      vertex 62.7614 66.5938 0
+      vertex 62.7614 66.5938 3
+    endloop
+  endfacet
+  facet normal 0.891059 0.453887 0
+    outer loop
+      vertex 62.7614 66.5938 0
+      vertex 62.9895 66.146 3
+      vertex 62.9895 66.146 0
+    endloop
+  endfacet
+  facet normal 0.156392 0.987695 -0
+    outer loop
+      vertex 68.9973 62.0631 0
+      vertex 68.5009 62.1417 3
+      vertex 68.9973 62.0631 3
+    endloop
+  endfacet
+  facet normal 0.156392 0.987695 0
+    outer loop
+      vertex 68.5009 62.1417 3
+      vertex 68.9973 62.0631 0
+      vertex 68.5009 62.1417 0
+    endloop
+  endfacet
+  facet normal -0.278976 -0.960298 0
+    outer loop
+      vertex 71.9895 77.7487 0
+      vertex 72.4721 77.6085 3
+      vertex 71.9895 77.7487 3
+    endloop
+  endfacet
+  facet normal -0.278976 -0.960298 -0
+    outer loop
+      vertex 72.4721 77.6085 3
+      vertex 71.9895 77.7487 0
+      vertex 72.4721 77.6085 0
+    endloop
+  endfacet
+  facet normal -0.750082 0.661345 0
+    outer loop
+      vertex 75.8317 64.5236 0
+      vertex 76.1641 64.9006 3
+      vertex 76.1641 64.9006 0
+    endloop
+  endfacet
+  facet normal -0.750082 0.661345 0
+    outer loop
+      vertex 76.1641 64.9006 3
+      vertex 75.8317 64.5236 0
+      vertex 75.8317 64.5236 3
+    endloop
+  endfacet
+  facet normal -0.827089 0.562071 0
+    outer loop
+      vertex 76.4721 65.2977 0
+      vertex 76.7546 65.7134 3
+      vertex 76.7546 65.7134 0
+    endloop
+  endfacet
+  facet normal -0.827089 0.562071 0
+    outer loop
+      vertex 76.7546 65.7134 3
+      vertex 76.4721 65.2977 0
+      vertex 76.4721 65.2977 3
+    endloop
+  endfacet
+  facet normal -0.860689 0.509131 0
+    outer loop
+      vertex 76.7546 65.7134 0
+      vertex 77.0105 66.146 3
+      vertex 77.0105 66.146 0
+    endloop
+  endfacet
+  facet normal -0.860689 0.509131 0
+    outer loop
+      vertex 77.0105 66.146 3
+      vertex 76.7546 65.7134 0
+      vertex 76.7546 65.7134 3
+    endloop
+  endfacet
+  facet normal 0.156392 -0.987695 0
+    outer loop
+      vertex 68.5009 77.8583 0
+      vertex 68.9973 77.9369 3
+      vertex 68.5009 77.8583 3
+    endloop
+  endfacet
+  facet normal 0.156392 -0.987695 0
+    outer loop
+      vertex 68.9973 77.9369 3
+      vertex 68.5009 77.8583 0
+      vertex 68.9973 77.9369 0
+    endloop
+  endfacet
+  facet normal -0.891059 0.453887 0
+    outer loop
+      vertex 77.0105 66.146 0
+      vertex 77.2386 66.5938 3
+      vertex 77.2386 66.5938 0
+    endloop
+  endfacet
+  facet normal -0.891059 0.453887 0
+    outer loop
+      vertex 77.2386 66.5938 3
+      vertex 77.0105 66.146 0
+      vertex 77.0105 66.146 3
+    endloop
+  endfacet
+  facet normal -0.999506 0.0314398 0
+    outer loop
+      vertex 77.9842 69.4977 0
+      vertex 78 70 3
+      vertex 78 70 0
+    endloop
+  endfacet
+  facet normal -0.999506 0.0314398 0
+    outer loop
+      vertex 78 70 3
+      vertex 77.9842 69.4977 0
+      vertex 77.9842 69.4977 3
+    endloop
+  endfacet
+  facet normal -0.960298 -0.278976 0
+    outer loop
+      vertex 77.7487 71.9895 0
+      vertex 77.6085 72.4721 3
+      vertex 77.6085 72.4721 0
+    endloop
+  endfacet
+  facet normal -0.960298 -0.278976 0
+    outer loop
+      vertex 77.6085 72.4721 3
+      vertex 77.7487 71.9895 0
+      vertex 77.7487 71.9895 3
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex 75.8317 75.4764 0
+      vertex 75.4764 75.8317 3
+      vertex 75.4764 75.8317 0
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex 75.4764 75.8317 3
+      vertex 75.8317 75.4764 0
+      vertex 75.8317 75.4764 3
+    endloop
+  endfacet
+  facet normal -0.661345 -0.750082 0
+    outer loop
+      vertex 75.0994 76.1641 0
+      vertex 75.4764 75.8317 3
+      vertex 75.0994 76.1641 3
+    endloop
+  endfacet
+  facet normal -0.661345 -0.750082 -0
+    outer loop
+      vertex 75.4764 75.8317 3
+      vertex 75.0994 76.1641 0
+      vertex 75.4764 75.8317 0
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 0
+    outer loop
+      vertex 64.5236 64.1683 3
+      vertex 64.1683 64.5236 0
+      vertex 64.1683 64.5236 3
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 0
+    outer loop
+      vertex 64.1683 64.5236 0
+      vertex 64.5236 64.1683 3
+      vertex 64.5236 64.1683 0
+    endloop
+  endfacet
+  facet normal 0.562071 -0.827089 0
+    outer loop
+      vertex 65.2977 76.4721 0
+      vertex 65.7134 76.7546 3
+      vertex 65.2977 76.4721 3
+    endloop
+  endfacet
+  facet normal 0.562071 -0.827089 0
+    outer loop
+      vertex 65.7134 76.7546 3
+      vertex 65.2977 76.4721 0
+      vertex 65.7134 76.7546 0
+    endloop
+  endfacet
+  facet normal 0.827089 -0.562071 0
+    outer loop
+      vertex 63.2454 74.2866 3
+      vertex 63.5279 74.7023 0
+      vertex 63.5279 74.7023 3
+    endloop
+  endfacet
+  facet normal 0.827089 -0.562071 0
+    outer loop
+      vertex 63.5279 74.7023 0
+      vertex 63.2454 74.2866 3
+      vertex 63.2454 74.2866 0
+    endloop
+  endfacet
+  facet normal -0.790177 0.612879 0
+    outer loop
+      vertex 76.1641 64.9006 0
+      vertex 76.4721 65.2977 3
+      vertex 76.4721 65.2977 0
+    endloop
+  endfacet
+  facet normal -0.790177 0.612879 0
+    outer loop
+      vertex 76.4721 65.2977 3
+      vertex 76.1641 64.9006 0
+      vertex 76.1641 64.9006 3
+    endloop
+  endfacet
+  facet normal 0.999506 -0.0314398 0
+    outer loop
+      vertex 62 70 3
+      vertex 62.0158 70.5023 0
+      vertex 62.0158 70.5023 3
+    endloop
+  endfacet
+  facet normal 0.999506 -0.0314398 0
+    outer loop
+      vertex 62.0158 70.5023 0
+      vertex 62 70 3
+      vertex 62 70 0
+    endloop
+  endfacet
+  facet normal -0.338818 0.940852 0
+    outer loop
+      vertex 72.945 62.5618 0
+      vertex 72.4721 62.3915 3
+      vertex 72.945 62.5618 3
+    endloop
+  endfacet
+  facet normal -0.338818 0.940852 0
+    outer loop
+      vertex 72.4721 62.3915 3
+      vertex 72.945 62.5618 0
+      vertex 72.4721 62.3915 0
+    endloop
+  endfacet
+  facet normal 0.397183 0.917739 -0
+    outer loop
+      vertex 67.055 62.5618 0
+      vertex 66.5938 62.7614 3
+      vertex 67.055 62.5618 3
+    endloop
+  endfacet
+  facet normal 0.397183 0.917739 0
+    outer loop
+      vertex 66.5938 62.7614 3
+      vertex 67.055 62.5618 0
+      vertex 66.5938 62.7614 0
+    endloop
+  endfacet
+  facet normal -0.860689 -0.509131 0
+    outer loop
+      vertex 77.0105 73.854 0
+      vertex 76.7546 74.2866 3
+      vertex 76.7546 74.2866 0
+    endloop
+  endfacet
+  facet normal -0.860689 -0.509131 0
+    outer loop
+      vertex 76.7546 74.2866 3
+      vertex 77.0105 73.854 0
+      vertex 77.0105 73.854 3
+    endloop
+  endfacet
+  facet normal 0.975924 -0.21811 0
+    outer loop
+      vertex 62.1417 71.4991 3
+      vertex 62.2513 71.9895 0
+      vertex 62.2513 71.9895 3
+    endloop
+  endfacet
+  facet normal 0.975924 -0.21811 0
+    outer loop
+      vertex 62.2513 71.9895 0
+      vertex 62.1417 71.4991 3
+      vertex 62.1417 71.4991 0
+    endloop
+  endfacet
+  facet normal 0.995562 0.0941049 0
+    outer loop
+      vertex 62.0631 68.9973 3
+      vertex 62.0158 69.4977 0
+      vertex 62.0158 69.4977 3
+    endloop
+  endfacet
+  facet normal 0.995562 0.0941049 0
+    outer loop
+      vertex 62.0158 69.4977 0
+      vertex 62.0631 68.9973 3
+      vertex 62.0631 68.9973 0
+    endloop
+  endfacet
+  facet normal 0.21811 0.975924 -0
+    outer loop
+      vertex 68.5009 62.1417 0
+      vertex 68.0105 62.2513 3
+      vertex 68.5009 62.1417 3
+    endloop
+  endfacet
+  facet normal 0.21811 0.975924 0
+    outer loop
+      vertex 68.0105 62.2513 3
+      vertex 68.5009 62.1417 0
+      vertex 68.0105 62.2513 0
+    endloop
+  endfacet
+  facet normal 0.987695 0.156392 0
+    outer loop
+      vertex 62.1417 68.5009 3
+      vertex 62.0631 68.9973 0
+      vertex 62.0631 68.9973 3
+    endloop
+  endfacet
+  facet normal 0.987695 0.156392 0
+    outer loop
+      vertex 62.0631 68.9973 0
+      vertex 62.1417 68.5009 3
+      vertex 62.1417 68.5009 0
+    endloop
+  endfacet
+  facet normal -0.891059 -0.453887 0
+    outer loop
+      vertex 77.2386 73.4062 0
+      vertex 77.0105 73.854 3
+      vertex 77.0105 73.854 0
+    endloop
+  endfacet
+  facet normal -0.891059 -0.453887 0
+    outer loop
+      vertex 77.0105 73.854 3
+      vertex 77.2386 73.4062 0
+      vertex 77.2386 73.4062 3
+    endloop
+  endfacet
+  facet normal 0.509131 -0.860689 0
+    outer loop
+      vertex 65.7134 76.7546 0
+      vertex 66.146 77.0105 3
+      vertex 65.7134 76.7546 3
+    endloop
+  endfacet
+  facet normal 0.509131 -0.860689 0
+    outer loop
+      vertex 66.146 77.0105 3
+      vertex 65.7134 76.7546 0
+      vertex 66.146 77.0105 0
+    endloop
+  endfacet
+  facet normal -0.21811 0.975924 0
+    outer loop
+      vertex 71.9895 62.2513 0
+      vertex 71.4991 62.1417 3
+      vertex 71.9895 62.2513 3
+    endloop
+  endfacet
+  facet normal -0.21811 0.975924 0
+    outer loop
+      vertex 71.4991 62.1417 3
+      vertex 71.9895 62.2513 0
+      vertex 71.4991 62.1417 0
+    endloop
+  endfacet
+  facet normal 0.987695 -0.156392 0
+    outer loop
+      vertex 62.0631 71.0027 3
+      vertex 62.1417 71.4991 0
+      vertex 62.1417 71.4991 3
+    endloop
+  endfacet
+  facet normal 0.987695 -0.156392 0
+    outer loop
+      vertex 62.1417 71.4991 0
+      vertex 62.0631 71.0027 3
+      vertex 62.0631 71.0027 0
+    endloop
+  endfacet
+  facet normal -0.509131 0.860689 0
+    outer loop
+      vertex 74.2866 63.2454 0
+      vertex 73.854 62.9895 3
+      vertex 74.2866 63.2454 3
+    endloop
+  endfacet
+  facet normal -0.509131 0.860689 0
+    outer loop
+      vertex 73.854 62.9895 3
+      vertex 74.2866 63.2454 0
+      vertex 73.854 62.9895 0
+    endloop
+  endfacet
+  facet normal 0.960298 -0.278976 0
+    outer loop
+      vertex 62.2513 71.9895 3
+      vertex 62.3915 72.4721 0
+      vertex 62.3915 72.4721 3
+    endloop
+  endfacet
+  facet normal 0.960298 -0.278976 0
+    outer loop
+      vertex 62.3915 72.4721 0
+      vertex 62.2513 71.9895 3
+      vertex 62.2513 71.9895 0
+    endloop
+  endfacet
+  facet normal -0.156392 0.987695 0
+    outer loop
+      vertex 71.4991 62.1417 0
+      vertex 71.0027 62.0631 3
+      vertex 71.4991 62.1417 3
+    endloop
+  endfacet
+  facet normal -0.156392 0.987695 0
+    outer loop
+      vertex 71.0027 62.0631 3
+      vertex 71.4991 62.1417 0
+      vertex 71.0027 62.0631 0
+    endloop
+  endfacet
+  facet normal 0.397183 -0.917739 0
+    outer loop
+      vertex 66.5938 77.2386 0
+      vertex 67.055 77.4382 3
+      vertex 66.5938 77.2386 3
+    endloop
+  endfacet
+  facet normal 0.397183 -0.917739 0
+    outer loop
+      vertex 67.055 77.4382 3
+      vertex 66.5938 77.2386 0
+      vertex 67.055 77.4382 0
+    endloop
+  endfacet
+  facet normal 0.975924 0.21811 0
+    outer loop
+      vertex 62.2513 68.0105 3
+      vertex 62.1417 68.5009 0
+      vertex 62.1417 68.5009 3
+    endloop
+  endfacet
+  facet normal 0.975924 0.21811 0
+    outer loop
+      vertex 62.1417 68.5009 0
+      vertex 62.2513 68.0105 3
+      vertex 62.2513 68.0105 0
+    endloop
+  endfacet
+  facet normal 0.661345 0.750082 -0
+    outer loop
+      vertex 64.9006 63.8359 0
+      vertex 64.5236 64.1683 3
+      vertex 64.9006 63.8359 3
+    endloop
+  endfacet
+  facet normal 0.661345 0.750082 0
+    outer loop
+      vertex 64.5236 64.1683 3
+      vertex 64.9006 63.8359 0
+      vertex 64.5236 64.1683 0
+    endloop
+  endfacet
+  facet normal 0.827089 0.562071 0
+    outer loop
+      vertex 63.5279 65.2977 3
+      vertex 63.2454 65.7134 0
+      vertex 63.2454 65.7134 3
+    endloop
+  endfacet
+  facet normal 0.827089 0.562071 0
+    outer loop
+      vertex 63.2454 65.7134 0
+      vertex 63.5279 65.2977 3
+      vertex 63.5279 65.2977 0
+    endloop
+  endfacet
+  facet normal -0.562071 0.827089 0
+    outer loop
+      vertex 74.7023 63.5279 0
+      vertex 74.2866 63.2454 3
+      vertex 74.7023 63.5279 3
+    endloop
+  endfacet
+  facet normal -0.562071 0.827089 0
+    outer loop
+      vertex 74.2866 63.2454 3
+      vertex 74.7023 63.5279 0
+      vertex 74.2866 63.2454 0
+    endloop
+  endfacet
+  facet normal 0.661345 -0.750082 0
+    outer loop
+      vertex 64.5236 75.8317 0
+      vertex 64.9006 76.1641 3
+      vertex 64.5236 75.8317 3
+    endloop
+  endfacet
+  facet normal 0.661345 -0.750082 0
+    outer loop
+      vertex 64.9006 76.1641 3
+      vertex 64.5236 75.8317 0
+      vertex 64.9006 76.1641 0
+    endloop
+  endfacet
+  facet normal -0.0941049 0.995562 0
+    outer loop
+      vertex 71.0027 62.0631 0
+      vertex 70.5023 62.0158 3
+      vertex 71.0027 62.0631 3
+    endloop
+  endfacet
+  facet normal -0.0941049 0.995562 0
+    outer loop
+      vertex 70.5023 62.0158 3
+      vertex 71.0027 62.0631 0
+      vertex 70.5023 62.0158 0
+    endloop
+  endfacet
+  facet normal -0.975924 0.21811 0
+    outer loop
+      vertex 77.7487 68.0105 0
+      vertex 77.8583 68.5009 3
+      vertex 77.8583 68.5009 0
+    endloop
+  endfacet
+  facet normal -0.975924 0.21811 0
+    outer loop
+      vertex 77.8583 68.5009 3
+      vertex 77.7487 68.0105 0
+      vertex 77.7487 68.0105 3
+    endloop
+  endfacet
+  facet normal -0.995562 0.0941049 0
+    outer loop
+      vertex 77.9369 68.9973 0
+      vertex 77.9842 69.4977 3
+      vertex 77.9842 69.4977 0
+    endloop
+  endfacet
+  facet normal -0.995562 0.0941049 0
+    outer loop
+      vertex 77.9842 69.4977 3
+      vertex 77.9369 68.9973 0
+      vertex 77.9369 68.9973 3
+    endloop
+  endfacet
+  facet normal -0.612879 -0.790177 0
+    outer loop
+      vertex 74.7023 76.4721 0
+      vertex 75.0994 76.1641 3
+      vertex 74.7023 76.4721 3
+    endloop
+  endfacet
+  facet normal -0.612879 -0.790177 -0
+    outer loop
+      vertex 75.0994 76.1641 3
+      vertex 74.7023 76.4721 0
+      vertex 75.0994 76.1641 0
+    endloop
+  endfacet
+  facet normal -0.827089 -0.562071 0
+    outer loop
+      vertex 76.7546 74.2866 0
+      vertex 76.4721 74.7023 3
+      vertex 76.4721 74.7023 0
+    endloop
+  endfacet
+  facet normal -0.827089 -0.562071 0
+    outer loop
+      vertex 76.4721 74.7023 3
+      vertex 76.7546 74.2866 0
+      vertex 76.7546 74.2866 3
+    endloop
+  endfacet
+  facet normal -0.987695 -0.156392 0
+    outer loop
+      vertex 77.9369 71.0027 0
+      vertex 77.8583 71.4991 3
+      vertex 77.8583 71.4991 0
+    endloop
+  endfacet
+  facet normal -0.987695 -0.156392 0
+    outer loop
+      vertex 77.8583 71.4991 3
+      vertex 77.9369 71.0027 0
+      vertex 77.9369 71.0027 3
+    endloop
+  endfacet
+  facet normal 0.790177 -0.612879 0
+    outer loop
+      vertex 63.5279 74.7023 3
+      vertex 63.8359 75.0994 0
+      vertex 63.8359 75.0994 3
+    endloop
+  endfacet
+  facet normal 0.790177 -0.612879 0
+    outer loop
+      vertex 63.8359 75.0994 0
+      vertex 63.5279 74.7023 3
+      vertex 63.5279 74.7023 0
+    endloop
+  endfacet
+  facet normal 0.999506 0.0314398 0
+    outer loop
+      vertex 62.0158 69.4977 3
+      vertex 62 70 0
+      vertex 62 70 3
+    endloop
+  endfacet
+  facet normal 0.999506 0.0314398 0
+    outer loop
+      vertex 62 70 0
+      vertex 62.0158 69.4977 3
+      vertex 62.0158 69.4977 0
+    endloop
+  endfacet
+  facet normal -0.0314398 -0.999506 0
+    outer loop
+      vertex 70 78 0
+      vertex 70.5023 77.9842 3
+      vertex 70 78 3
+    endloop
+  endfacet
+  facet normal -0.0314398 -0.999506 -0
+    outer loop
+      vertex 70.5023 77.9842 3
+      vertex 70 78 0
+      vertex 70.5023 77.9842 0
+    endloop
+  endfacet
+  facet normal 0.612879 -0.790177 0
+    outer loop
+      vertex 64.9006 76.1641 0
+      vertex 65.2977 76.4721 3
+      vertex 64.9006 76.1641 3
+    endloop
+  endfacet
+  facet normal 0.612879 -0.790177 0
+    outer loop
+      vertex 65.2977 76.4721 3
+      vertex 64.9006 76.1641 0
+      vertex 65.2977 76.4721 0
+    endloop
+  endfacet
+  facet normal 0.860689 0.509131 0
+    outer loop
+      vertex 63.2454 65.7134 3
+      vertex 62.9895 66.146 0
+      vertex 62.9895 66.146 3
+    endloop
+  endfacet
+  facet normal 0.860689 0.509131 0
+    outer loop
+      vertex 62.9895 66.146 0
+      vertex 63.2454 65.7134 3
+      vertex 63.2454 65.7134 0
+    endloop
+  endfacet
+  facet normal 0.0314398 -0.999506 0
+    outer loop
+      vertex 69.4977 77.9842 0
+      vertex 70 78 3
+      vertex 69.4977 77.9842 3
+    endloop
+  endfacet
+  facet normal 0.0314398 -0.999506 0
+    outer loop
+      vertex 70 78 3
+      vertex 69.4977 77.9842 0
+      vertex 70 78 0
+    endloop
+  endfacet
+  facet normal 0.917739 -0.397183 0
+    outer loop
+      vertex 62.5618 72.945 3
+      vertex 62.7614 73.4062 0
+      vertex 62.7614 73.4062 3
+    endloop
+  endfacet
+  facet normal 0.917739 -0.397183 0
+    outer loop
+      vertex 62.7614 73.4062 0
+      vertex 62.5618 72.945 3
+      vertex 62.5618 72.945 0
+    endloop
+  endfacet
+  facet normal 0.562071 0.827089 -0
+    outer loop
+      vertex 65.7134 63.2454 0
+      vertex 65.2977 63.5279 3
+      vertex 65.7134 63.2454 3
+    endloop
+  endfacet
+  facet normal 0.562071 0.827089 0
+    outer loop
+      vertex 65.2977 63.5279 3
+      vertex 65.7134 63.2454 0
+      vertex 65.2977 63.5279 0
+    endloop
+  endfacet
+  facet normal 0.917739 0.397183 0
+    outer loop
+      vertex 62.7614 66.5938 3
+      vertex 62.5618 67.055 0
+      vertex 62.5618 67.055 3
+    endloop
+  endfacet
+  facet normal 0.917739 0.397183 0
+    outer loop
+      vertex 62.5618 67.055 0
+      vertex 62.7614 66.5938 3
+      vertex 62.7614 66.5938 0
+    endloop
+  endfacet
+  facet normal 0.278976 0.960298 -0
+    outer loop
+      vertex 68.0105 62.2513 0
+      vertex 67.5279 62.3915 3
+      vertex 68.0105 62.2513 3
+    endloop
+  endfacet
+  facet normal 0.278976 0.960298 0
+    outer loop
+      vertex 67.5279 62.3915 3
+      vertex 68.0105 62.2513 0
+      vertex 67.5279 62.3915 0
+    endloop
+  endfacet
+  facet normal 0.790177 0.612879 0
+    outer loop
+      vertex 63.8359 64.9006 3
+      vertex 63.5279 65.2977 0
+      vertex 63.5279 65.2977 3
+    endloop
+  endfacet
+  facet normal 0.790177 0.612879 0
+    outer loop
+      vertex 63.5279 65.2977 0
+      vertex 63.8359 64.9006 3
+      vertex 63.8359 64.9006 0
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 0
+    outer loop
+      vertex 75.4764 64.1683 0
+      vertex 75.8317 64.5236 3
+      vertex 75.8317 64.5236 0
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 0
+    outer loop
+      vertex 75.8317 64.5236 3
+      vertex 75.4764 64.1683 0
+      vertex 75.4764 64.1683 3
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 0
+    outer loop
+      vertex 64.1683 75.4764 3
+      vertex 64.5236 75.8317 0
+      vertex 64.5236 75.8317 3
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 0
+    outer loop
+      vertex 64.5236 75.8317 0
+      vertex 64.1683 75.4764 3
+      vertex 64.1683 75.4764 0
+    endloop
+  endfacet
+  facet normal -0.0941049 -0.995562 0
+    outer loop
+      vertex 70.5023 77.9842 0
+      vertex 71.0027 77.9369 3
+      vertex 70.5023 77.9842 3
+    endloop
+  endfacet
+  facet normal -0.0941049 -0.995562 -0
+    outer loop
+      vertex 71.0027 77.9369 3
+      vertex 70.5023 77.9842 0
+      vertex 71.0027 77.9369 0
+    endloop
+  endfacet
+  facet normal 0.453887 -0.891059 0
+    outer loop
+      vertex 66.146 77.0105 0
+      vertex 66.5938 77.2386 3
+      vertex 66.146 77.0105 3
+    endloop
+  endfacet
+  facet normal 0.453887 -0.891059 0
+    outer loop
+      vertex 66.5938 77.2386 3
+      vertex 66.146 77.0105 0
+      vertex 66.5938 77.2386 0
+    endloop
+  endfacet
+  facet normal -0.338818 -0.940852 0
+    outer loop
+      vertex 72.4721 77.6085 0
+      vertex 72.945 77.4382 3
+      vertex 72.4721 77.6085 3
+    endloop
+  endfacet
+  facet normal -0.338818 -0.940852 -0
+    outer loop
+      vertex 72.945 77.4382 3
+      vertex 72.4721 77.6085 0
+      vertex 72.945 77.4382 0
+    endloop
+  endfacet
+  facet normal -0.790177 -0.612879 0
+    outer loop
+      vertex 76.4721 74.7023 0
+      vertex 76.1641 75.0994 3
+      vertex 76.1641 75.0994 0
+    endloop
+  endfacet
+  facet normal -0.790177 -0.612879 0
+    outer loop
+      vertex 76.1641 75.0994 3
+      vertex 76.4721 74.7023 0
+      vertex 76.4721 74.7023 3
+    endloop
+  endfacet
+  facet normal -0.750082 -0.661345 0
+    outer loop
+      vertex 76.1641 75.0994 0
+      vertex 75.8317 75.4764 3
+      vertex 75.8317 75.4764 0
+    endloop
+  endfacet
+  facet normal -0.750082 -0.661345 0
+    outer loop
+      vertex 75.8317 75.4764 3
+      vertex 76.1641 75.0994 0
+      vertex 76.1641 75.0994 3
+    endloop
+  endfacet
+  facet normal 0.0941049 0.995562 -0
+    outer loop
+      vertex 69.4977 62.0158 0
+      vertex 68.9973 62.0631 3
+      vertex 69.4977 62.0158 3
+    endloop
+  endfacet
+  facet normal 0.0941049 0.995562 0
+    outer loop
+      vertex 68.9973 62.0631 3
+      vertex 69.4977 62.0158 0
+      vertex 68.9973 62.0631 0
+    endloop
+  endfacet
+  facet normal 0.0314398 0.999506 -0
+    outer loop
+      vertex 70 62 0
+      vertex 69.4977 62.0158 3
+      vertex 70 62 3
+    endloop
+  endfacet
+  facet normal 0.0314398 0.999506 0
+    outer loop
+      vertex 69.4977 62.0158 3
+      vertex 70 62 0
+      vertex 69.4977 62.0158 0
+    endloop
+  endfacet
+  facet normal 0.278976 -0.960298 0
+    outer loop
+      vertex 67.5279 77.6085 0
+      vertex 68.0105 77.7487 3
+      vertex 67.5279 77.6085 3
+    endloop
+  endfacet
+  facet normal 0.278976 -0.960298 0
+    outer loop
+      vertex 68.0105 77.7487 3
+      vertex 67.5279 77.6085 0
+      vertex 68.0105 77.7487 0
+    endloop
+  endfacet
+  facet normal 0.21811 -0.975924 0
+    outer loop
+      vertex 68.0105 77.7487 0
+      vertex 68.5009 77.8583 3
+      vertex 68.0105 77.7487 3
+    endloop
+  endfacet
+  facet normal 0.21811 -0.975924 0
+    outer loop
+      vertex 68.5009 77.8583 3
+      vertex 68.0105 77.7487 0
+      vertex 68.5009 77.8583 0
+    endloop
+  endfacet
+  facet normal -0.612879 0.790177 0
+    outer loop
+      vertex 75.0994 63.8359 0
+      vertex 74.7023 63.5279 3
+      vertex 75.0994 63.8359 3
+    endloop
+  endfacet
+  facet normal -0.612879 0.790177 0
+    outer loop
+      vertex 74.7023 63.5279 3
+      vertex 75.0994 63.8359 0
+      vertex 74.7023 63.5279 0
+    endloop
+  endfacet
+  facet normal -0.661345 0.750082 0
+    outer loop
+      vertex 75.4764 64.1683 0
+      vertex 75.0994 63.8359 3
+      vertex 75.4764 64.1683 3
+    endloop
+  endfacet
+  facet normal -0.661345 0.750082 0
+    outer loop
+      vertex 75.0994 63.8359 3
+      vertex 75.4764 64.1683 0
+      vertex 75.0994 63.8359 0
+    endloop
+  endfacet
+  facet normal 0.995562 -0.0941049 0
+    outer loop
+      vertex 62.0158 70.5023 3
+      vertex 62.0631 71.0027 0
+      vertex 62.0631 71.0027 3
+    endloop
+  endfacet
+  facet normal 0.995562 -0.0941049 0
+    outer loop
+      vertex 62.0631 71.0027 0
+      vertex 62.0158 70.5023 3
+      vertex 62.0158 70.5023 0
+    endloop
+  endfacet
+  facet normal -0.917739 0.397183 0
+    outer loop
+      vertex 77.2386 66.5938 0
+      vertex 77.4382 67.055 3
+      vertex 77.4382 67.055 0
+    endloop
+  endfacet
+  facet normal -0.917739 0.397183 0
+    outer loop
+      vertex 77.4382 67.055 3
+      vertex 77.2386 66.5938 0
+      vertex 77.2386 66.5938 3
+    endloop
+  endfacet
+  facet normal 0.960298 0.278976 0
+    outer loop
+      vertex 62.3915 67.5279 3
+      vertex 62.2513 68.0105 0
+      vertex 62.2513 68.0105 3
+    endloop
+  endfacet
+  facet normal 0.960298 0.278976 0
+    outer loop
+      vertex 62.2513 68.0105 0
+      vertex 62.3915 67.5279 3
+      vertex 62.3915 67.5279 0
+    endloop
+  endfacet
+  facet normal -0.21811 -0.975924 0
+    outer loop
+      vertex 71.4991 77.8583 0
+      vertex 71.9895 77.7487 3
+      vertex 71.4991 77.8583 3
+    endloop
+  endfacet
+  facet normal -0.21811 -0.975924 -0
+    outer loop
+      vertex 71.9895 77.7487 3
+      vertex 71.4991 77.8583 0
+      vertex 71.9895 77.7487 0
+    endloop
+  endfacet
+  facet normal 0.612879 0.790177 -0
+    outer loop
+      vertex 65.2977 63.5279 0
+      vertex 64.9006 63.8359 3
+      vertex 65.2977 63.5279 3
+    endloop
+  endfacet
+  facet normal 0.612879 0.790177 0
+    outer loop
+      vertex 64.9006 63.8359 3
+      vertex 65.2977 63.5279 0
+      vertex 64.9006 63.8359 0
+    endloop
+  endfacet
+  facet normal -0.827045 -0.562136 0
+    outer loop
+      vertex 60.2441 57.7414 0
+      vertex 60.1293 57.9103 3
+      vertex 60.1293 57.9103 0
+    endloop
+  endfacet
+  facet normal -0.827045 -0.562136 0
+    outer loop
+      vertex 60.1293 57.9103 3
+      vertex 60.2441 57.7414 0
+      vertex 60.2441 57.7414 3
+    endloop
+  endfacet
+  facet normal -0.995566 -0.0940692 0
+    outer loop
+      vertex 60.7436 56.2041 0
+      vertex 60.7244 56.4073 3
+      vertex 60.7244 56.4073 0
+    endloop
+  endfacet
+  facet normal -0.995566 -0.0940692 0
+    outer loop
+      vertex 60.7244 56.4073 3
+      vertex 60.7436 56.2041 0
+      vertex 60.7436 56.2041 3
+    endloop
+  endfacet
+  facet normal -0.999509 -0.0313418 0
+    outer loop
+      vertex 60.75 56 0
+      vertex 60.7436 56.2041 3
+      vertex 60.7436 56.2041 0
+    endloop
+  endfacet
+  facet normal -0.999509 -0.0313418 0
+    outer loop
+      vertex 60.7436 56.2041 3
+      vertex 60.75 56 0
+      vertex 60.75 56 3
+    endloop
+  endfacet
+  facet normal -0.987648 -0.156692 0
+    outer loop
+      vertex 60.7244 56.4073 0
+      vertex 60.6924 56.609 3
+      vertex 60.6924 56.609 0
+    endloop
+  endfacet
+  facet normal -0.987648 -0.156692 0
+    outer loop
+      vertex 60.6924 56.609 3
+      vertex 60.7244 56.4073 0
+      vertex 60.7244 56.4073 3
+    endloop
+  endfacet
+  facet normal 0.827045 0.562136 0
+    outer loop
+      vertex 54.8707 54.0897 3
+      vertex 54.7559 54.2586 0
+      vertex 54.7559 54.2586 3
+    endloop
+  endfacet
+  facet normal 0.827045 0.562136 0
+    outer loop
+      vertex 54.7559 54.2586 0
+      vertex 54.8707 54.0897 3
+      vertex 54.8707 54.0897 0
+    endloop
+  endfacet
+  facet normal -0.790196 -0.612855 0
+    outer loop
+      vertex 60.1293 57.9103 0
+      vertex 60.0042 58.0716 3
+      vertex 60.0042 58.0716 0
+    endloop
+  endfacet
+  facet normal -0.790196 -0.612855 0
+    outer loop
+      vertex 60.0042 58.0716 3
+      vertex 60.1293 57.9103 0
+      vertex 60.1293 57.9103 3
+    endloop
+  endfacet
+  facet normal 0.999509 0.0313418 0
+    outer loop
+      vertex 54.2564 55.7959 3
+      vertex 54.25 56 0
+      vertex 54.25 56 3
+    endloop
+  endfacet
+  facet normal 0.999509 0.0313418 0
+    outer loop
+      vertex 54.25 56 0
+      vertex 54.2564 55.7959 3
+      vertex 54.2564 55.7959 0
+    endloop
+  endfacet
+  facet normal -0.0940692 -0.995566 0
+    outer loop
+      vertex 57.7041 59.2436 0
+      vertex 57.9073 59.2244 3
+      vertex 57.7041 59.2436 3
+    endloop
+  endfacet
+  facet normal -0.0940692 -0.995566 -0
+    outer loop
+      vertex 57.9073 59.2244 3
+      vertex 57.7041 59.2436 0
+      vertex 57.9073 59.2244 0
+    endloop
+  endfacet
+  facet normal 0.454058 0.890972 -0
+    outer loop
+      vertex 56.1162 53.0593 0
+      vertex 55.9343 53.152 3
+      vertex 56.1162 53.0593 3
+    endloop
+  endfacet
+  facet normal 0.454058 0.890972 0
+    outer loop
+      vertex 55.9343 53.152 3
+      vertex 56.1162 53.0593 0
+      vertex 55.9343 53.152 0
+    endloop
+  endfacet
+  facet normal -0.0313418 -0.999509 0
+    outer loop
+      vertex 57.5 59.25 0
+      vertex 57.7041 59.2436 3
+      vertex 57.5 59.25 3
+    endloop
+  endfacet
+  facet normal -0.0313418 -0.999509 -0
+    outer loop
+      vertex 57.7041 59.2436 3
+      vertex 57.5 59.25 0
+      vertex 57.7041 59.2436 0
+    endloop
+  endfacet
+  facet normal 0.917746 0.397168 0
+    outer loop
+      vertex 54.5593 54.6162 3
+      vertex 54.4782 54.8036 0
+      vertex 54.4782 54.8036 3
+    endloop
+  endfacet
+  facet normal 0.917746 0.397168 0
+    outer loop
+      vertex 54.4782 54.8036 0
+      vertex 54.5593 54.6162 3
+      vertex 54.5593 54.6162 0
+    endloop
+  endfacet
+  facet normal -0.21802 0.975944 0
+    outer loop
+      vertex 58.3082 52.8521 0
+      vertex 58.109 52.8076 3
+      vertex 58.3082 52.8521 3
+    endloop
+  endfacet
+  facet normal -0.21802 0.975944 0
+    outer loop
+      vertex 58.109 52.8076 3
+      vertex 58.3082 52.8521 0
+      vertex 58.109 52.8076 0
+    endloop
+  endfacet
+  facet normal -0.960257 0.279116 0
+    outer loop
+      vertex 60.5909 54.9957 0
+      vertex 60.6479 55.1918 3
+      vertex 60.6479 55.1918 0
+    endloop
+  endfacet
+  facet normal -0.960257 0.279116 0
+    outer loop
+      vertex 60.6479 55.1918 3
+      vertex 60.5909 54.9957 0
+      vertex 60.5909 54.9957 3
+    endloop
+  endfacet
+  facet normal 0.999509 -0.0313418 0
+    outer loop
+      vertex 54.25 56 3
+      vertex 54.2564 56.2041 0
+      vertex 54.2564 56.2041 3
+    endloop
+  endfacet
+  facet normal 0.999509 -0.0313418 0
+    outer loop
+      vertex 54.2564 56.2041 0
+      vertex 54.25 56 3
+      vertex 54.25 56 0
+    endloop
+  endfacet
+  facet normal 0.279116 0.960257 -0
+    outer loop
+      vertex 56.6918 52.8521 0
+      vertex 56.4957 52.9091 3
+      vertex 56.6918 52.8521 3
+    endloop
+  endfacet
+  facet normal 0.279116 0.960257 0
+    outer loop
+      vertex 56.4957 52.9091 3
+      vertex 56.6918 52.8521 0
+      vertex 56.4957 52.9091 0
+    endloop
+  endfacet
+  facet normal -0.279116 -0.960257 0
+    outer loop
+      vertex 58.3082 59.1479 0
+      vertex 58.5043 59.0909 3
+      vertex 58.3082 59.1479 3
+    endloop
+  endfacet
+  facet normal -0.279116 -0.960257 -0
+    outer loop
+      vertex 58.5043 59.0909 3
+      vertex 58.3082 59.1479 0
+      vertex 58.5043 59.0909 0
+    endloop
+  endfacet
+  facet normal 0.562136 -0.827045 0
+    outer loop
+      vertex 55.5897 58.6293 0
+      vertex 55.7586 58.7441 3
+      vertex 55.5897 58.6293 3
+    endloop
+  endfacet
+  facet normal 0.562136 -0.827045 0
+    outer loop
+      vertex 55.7586 58.7441 3
+      vertex 55.5897 58.6293 0
+      vertex 55.7586 58.7441 0
+    endloop
+  endfacet
+  facet normal 0.995566 -0.0940692 0
+    outer loop
+      vertex 54.2564 56.2041 3
+      vertex 54.2756 56.4073 0
+      vertex 54.2756 56.4073 3
+    endloop
+  endfacet
+  facet normal 0.995566 -0.0940692 0
+    outer loop
+      vertex 54.2756 56.4073 0
+      vertex 54.2564 56.2041 3
+      vertex 54.2564 56.2041 0
+    endloop
+  endfacet
+  facet normal -0.562136 -0.827045 0
+    outer loop
+      vertex 59.2414 58.7441 0
+      vertex 59.4103 58.6293 3
+      vertex 59.2414 58.7441 3
+    endloop
+  endfacet
+  facet normal -0.562136 -0.827045 -0
+    outer loop
+      vertex 59.4103 58.6293 3
+      vertex 59.2414 58.7441 0
+      vertex 59.4103 58.6293 0
+    endloop
+  endfacet
+  facet normal 0.940975 0.338477 0
+    outer loop
+      vertex 54.4782 54.8036 3
+      vertex 54.4091 54.9957 0
+      vertex 54.4091 54.9957 3
+    endloop
+  endfacet
+  facet normal 0.940975 0.338477 0
+    outer loop
+      vertex 54.4091 54.9957 0
+      vertex 54.4782 54.8036 3
+      vertex 54.4782 54.8036 0
+    endloop
+  endfacet
+  facet normal 0.50901 0.860761 -0
+    outer loop
+      vertex 55.9343 53.152 0
+      vertex 55.7586 53.2559 3
+      vertex 55.9343 53.152 3
+    endloop
+  endfacet
+  facet normal 0.50901 0.860761 0
+    outer loop
+      vertex 55.7586 53.2559 3
+      vertex 55.9343 53.152 0
+      vertex 55.7586 53.2559 0
+    endloop
+  endfacet
+  facet normal 0.156692 -0.987648 0
+    outer loop
+      vertex 56.891 59.1924 0
+      vertex 57.0927 59.2244 3
+      vertex 56.891 59.1924 3
+    endloop
+  endfacet
+  facet normal 0.156692 -0.987648 0
+    outer loop
+      vertex 57.0927 59.2244 3
+      vertex 56.891 59.1924 0
+      vertex 57.0927 59.2244 0
+    endloop
+  endfacet
+  facet normal -0.750024 0.661411 0
+    outer loop
+      vertex 59.8691 53.7752 0
+      vertex 60.0042 53.9284 3
+      vertex 60.0042 53.9284 0
+    endloop
+  endfacet
+  facet normal -0.750024 0.661411 0
+    outer loop
+      vertex 60.0042 53.9284 3
+      vertex 59.8691 53.7752 0
+      vertex 59.8691 53.7752 3
+    endloop
+  endfacet
+  facet normal -0.454058 -0.890972 0
+    outer loop
+      vertex 58.8838 58.9407 0
+      vertex 59.0657 58.848 3
+      vertex 58.8838 58.9407 3
+    endloop
+  endfacet
+  facet normal -0.454058 -0.890972 -0
+    outer loop
+      vertex 59.0657 58.848 3
+      vertex 58.8838 58.9407 0
+      vertex 59.0657 58.848 0
+    endloop
+  endfacet
+  facet normal -0.975944 -0.21802 0
+    outer loop
+      vertex 60.6924 56.609 0
+      vertex 60.6479 56.8082 3
+      vertex 60.6479 56.8082 0
+    endloop
+  endfacet
+  facet normal -0.975944 -0.21802 0
+    outer loop
+      vertex 60.6479 56.8082 3
+      vertex 60.6924 56.609 0
+      vertex 60.6924 56.609 3
+    endloop
+  endfacet
+  facet normal -0.279116 0.960257 0
+    outer loop
+      vertex 58.5043 52.9091 0
+      vertex 58.3082 52.8521 3
+      vertex 58.5043 52.9091 3
+    endloop
+  endfacet
+  facet normal -0.279116 0.960257 0
+    outer loop
+      vertex 58.3082 52.8521 3
+      vertex 58.5043 52.9091 0
+      vertex 58.3082 52.8521 0
+    endloop
+  endfacet
+  facet normal 0.750024 -0.661411 0
+    outer loop
+      vertex 54.9958 58.0716 3
+      vertex 55.1309 58.2248 0
+      vertex 55.1309 58.2248 3
+    endloop
+  endfacet
+  facet normal 0.750024 -0.661411 0
+    outer loop
+      vertex 55.1309 58.2248 0
+      vertex 54.9958 58.0716 3
+      vertex 54.9958 58.0716 0
+    endloop
+  endfacet
+  facet normal 0.975944 0.21802 0
+    outer loop
+      vertex 54.3521 55.1918 3
+      vertex 54.3076 55.391 0
+      vertex 54.3076 55.391 3
+    endloop
+  endfacet
+  facet normal 0.975944 0.21802 0
+    outer loop
+      vertex 54.3076 55.391 0
+      vertex 54.3521 55.1918 3
+      vertex 54.3521 55.1918 0
+    endloop
+  endfacet
+  facet normal -0.50901 0.860761 0
+    outer loop
+      vertex 59.2414 53.2559 0
+      vertex 59.0657 53.152 3
+      vertex 59.2414 53.2559 3
+    endloop
+  endfacet
+  facet normal -0.50901 0.860761 0
+    outer loop
+      vertex 59.0657 53.152 3
+      vertex 59.2414 53.2559 0
+      vertex 59.0657 53.152 0
+    endloop
+  endfacet
+  facet normal -0.995566 0.0940692 0
+    outer loop
+      vertex 60.7244 55.5927 0
+      vertex 60.7436 55.7959 3
+      vertex 60.7436 55.7959 0
+    endloop
+  endfacet
+  facet normal -0.995566 0.0940692 0
+    outer loop
+      vertex 60.7436 55.7959 3
+      vertex 60.7244 55.5927 0
+      vertex 60.7244 55.5927 3
+    endloop
+  endfacet
+  facet normal 0.612855 -0.790196 0
+    outer loop
+      vertex 55.4284 58.5042 0
+      vertex 55.5897 58.6293 3
+      vertex 55.4284 58.5042 3
+    endloop
+  endfacet
+  facet normal 0.612855 -0.790196 0
+    outer loop
+      vertex 55.5897 58.6293 3
+      vertex 55.4284 58.5042 0
+      vertex 55.5897 58.6293 0
+    endloop
+  endfacet
+  facet normal 0.21802 -0.975944 0
+    outer loop
+      vertex 56.6918 59.1479 0
+      vertex 56.891 59.1924 3
+      vertex 56.6918 59.1479 3
+    endloop
+  endfacet
+  facet normal 0.21802 -0.975944 0
+    outer loop
+      vertex 56.891 59.1924 3
+      vertex 56.6918 59.1479 0
+      vertex 56.891 59.1924 0
+    endloop
+  endfacet
+  facet normal 0.987648 0.156692 0
+    outer loop
+      vertex 54.3076 55.391 3
+      vertex 54.2756 55.5927 0
+      vertex 54.2756 55.5927 3
+    endloop
+  endfacet
+  facet normal 0.987648 0.156692 0
+    outer loop
+      vertex 54.2756 55.5927 0
+      vertex 54.3076 55.391 3
+      vertex 54.3076 55.391 0
+    endloop
+  endfacet
+  facet normal 0.661411 -0.750024 0
+    outer loop
+      vertex 55.2752 58.3691 0
+      vertex 55.4284 58.5042 3
+      vertex 55.2752 58.3691 3
+    endloop
+  endfacet
+  facet normal 0.661411 -0.750024 0
+    outer loop
+      vertex 55.4284 58.5042 3
+      vertex 55.2752 58.3691 0
+      vertex 55.4284 58.5042 0
+    endloop
+  endfacet
+  facet normal 0.0940692 -0.995566 0
+    outer loop
+      vertex 57.0927 59.2244 0
+      vertex 57.2959 59.2436 3
+      vertex 57.0927 59.2244 3
+    endloop
+  endfacet
+  facet normal 0.0940692 -0.995566 0
+    outer loop
+      vertex 57.2959 59.2436 3
+      vertex 57.0927 59.2244 0
+      vertex 57.2959 59.2436 0
+    endloop
+  endfacet
+  facet normal 0.0940692 0.995566 -0
+    outer loop
+      vertex 57.2959 52.7564 0
+      vertex 57.0927 52.7756 3
+      vertex 57.2959 52.7564 3
+    endloop
+  endfacet
+  facet normal 0.0940692 0.995566 0
+    outer loop
+      vertex 57.0927 52.7756 3
+      vertex 57.2959 52.7564 0
+      vertex 57.0927 52.7756 0
+    endloop
+  endfacet
+  facet normal -0.338477 -0.940975 0
+    outer loop
+      vertex 58.5043 59.0909 0
+      vertex 58.6964 59.0218 3
+      vertex 58.5043 59.0909 3
+    endloop
+  endfacet
+  facet normal -0.338477 -0.940975 -0
+    outer loop
+      vertex 58.6964 59.0218 3
+      vertex 58.5043 59.0909 0
+      vertex 58.6964 59.0218 0
+    endloop
+  endfacet
+  facet normal 0.890972 -0.454058 0
+    outer loop
+      vertex 54.5593 57.3838 3
+      vertex 54.652 57.5657 0
+      vertex 54.652 57.5657 3
+    endloop
+  endfacet
+  facet normal 0.890972 -0.454058 0
+    outer loop
+      vertex 54.652 57.5657 0
+      vertex 54.5593 57.3838 3
+      vertex 54.5593 57.3838 0
+    endloop
+  endfacet
+  facet normal -0.827045 0.562136 0
+    outer loop
+      vertex 60.1293 54.0897 0
+      vertex 60.2441 54.2586 3
+      vertex 60.2441 54.2586 0
+    endloop
+  endfacet
+  facet normal -0.827045 0.562136 0
+    outer loop
+      vertex 60.2441 54.2586 3
+      vertex 60.1293 54.0897 0
+      vertex 60.1293 54.0897 3
+    endloop
+  endfacet
+  facet normal 0.790196 0.612855 0
+    outer loop
+      vertex 54.9958 53.9284 3
+      vertex 54.8707 54.0897 0
+      vertex 54.8707 54.0897 3
+    endloop
+  endfacet
+  facet normal 0.790196 0.612855 0
+    outer loop
+      vertex 54.8707 54.0897 0
+      vertex 54.9958 53.9284 3
+      vertex 54.9958 53.9284 0
+    endloop
+  endfacet
+  facet normal -0.960257 -0.279116 0
+    outer loop
+      vertex 60.6479 56.8082 0
+      vertex 60.5909 57.0043 3
+      vertex 60.5909 57.0043 0
+    endloop
+  endfacet
+  facet normal -0.960257 -0.279116 0
+    outer loop
+      vertex 60.5909 57.0043 3
+      vertex 60.6479 56.8082 0
+      vertex 60.6479 56.8082 3
+    endloop
+  endfacet
+  facet normal -0.397168 -0.917746 0
+    outer loop
+      vertex 58.6964 59.0218 0
+      vertex 58.8838 58.9407 3
+      vertex 58.6964 59.0218 3
+    endloop
+  endfacet
+  facet normal -0.397168 -0.917746 -0
+    outer loop
+      vertex 58.8838 58.9407 3
+      vertex 58.6964 59.0218 0
+      vertex 58.8838 58.9407 0
+    endloop
+  endfacet
+  facet normal 0.827045 -0.562136 0
+    outer loop
+      vertex 54.7559 57.7414 3
+      vertex 54.8707 57.9103 0
+      vertex 54.8707 57.9103 3
+    endloop
+  endfacet
+  facet normal 0.827045 -0.562136 0
+    outer loop
+      vertex 54.8707 57.9103 0
+      vertex 54.7559 57.7414 3
+      vertex 54.7559 57.7414 0
+    endloop
+  endfacet
+  facet normal -0.975944 0.21802 0
+    outer loop
+      vertex 60.6479 55.1918 0
+      vertex 60.6924 55.391 3
+      vertex 60.6924 55.391 0
+    endloop
+  endfacet
+  facet normal -0.975944 0.21802 0
+    outer loop
+      vertex 60.6924 55.391 3
+      vertex 60.6479 55.1918 0
+      vertex 60.6479 55.1918 3
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 0
+    outer loop
+      vertex 59.7248 53.6309 0
+      vertex 59.8691 53.7752 3
+      vertex 59.8691 53.7752 0
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 0
+    outer loop
+      vertex 59.8691 53.7752 3
+      vertex 59.7248 53.6309 0
+      vertex 59.7248 53.6309 3
+    endloop
+  endfacet
+  facet normal -0.987648 0.156692 0
+    outer loop
+      vertex 60.6924 55.391 0
+      vertex 60.7244 55.5927 3
+      vertex 60.7244 55.5927 0
+    endloop
+  endfacet
+  facet normal -0.987648 0.156692 0
+    outer loop
+      vertex 60.7244 55.5927 3
+      vertex 60.6924 55.391 0
+      vertex 60.6924 55.391 3
+    endloop
+  endfacet
+  facet normal -0.0313418 0.999509 0
+    outer loop
+      vertex 57.7041 52.7564 0
+      vertex 57.5 52.75 3
+      vertex 57.7041 52.7564 3
+    endloop
+  endfacet
+  facet normal -0.0313418 0.999509 0
+    outer loop
+      vertex 57.5 52.75 3
+      vertex 57.7041 52.7564 0
+      vertex 57.5 52.75 0
+    endloop
+  endfacet
+  facet normal -0.890972 -0.454058 0
+    outer loop
+      vertex 60.4407 57.3838 0
+      vertex 60.348 57.5657 3
+      vertex 60.348 57.5657 0
+    endloop
+  endfacet
+  facet normal -0.890972 -0.454058 0
+    outer loop
+      vertex 60.348 57.5657 3
+      vertex 60.4407 57.3838 0
+      vertex 60.4407 57.3838 3
+    endloop
+  endfacet
+  facet normal -0.860761 0.50901 0
+    outer loop
+      vertex 60.2441 54.2586 0
+      vertex 60.348 54.4343 3
+      vertex 60.348 54.4343 0
+    endloop
+  endfacet
+  facet normal -0.860761 0.50901 0
+    outer loop
+      vertex 60.348 54.4343 3
+      vertex 60.2441 54.2586 0
+      vertex 60.2441 54.2586 3
+    endloop
+  endfacet
+  facet normal -0.50901 -0.860761 0
+    outer loop
+      vertex 59.0657 58.848 0
+      vertex 59.2414 58.7441 3
+      vertex 59.0657 58.848 3
+    endloop
+  endfacet
+  facet normal -0.50901 -0.860761 -0
+    outer loop
+      vertex 59.2414 58.7441 3
+      vertex 59.0657 58.848 0
+      vertex 59.2414 58.7441 0
+    endloop
+  endfacet
+  facet normal 0.338477 -0.940975 0
+    outer loop
+      vertex 56.3036 59.0218 0
+      vertex 56.4957 59.0909 3
+      vertex 56.3036 59.0218 3
+    endloop
+  endfacet
+  facet normal 0.338477 -0.940975 0
+    outer loop
+      vertex 56.4957 59.0909 3
+      vertex 56.3036 59.0218 0
+      vertex 56.4957 59.0909 0
+    endloop
+  endfacet
+  facet normal 0.790196 -0.612855 0
+    outer loop
+      vertex 54.8707 57.9103 3
+      vertex 54.9958 58.0716 0
+      vertex 54.9958 58.0716 3
+    endloop
+  endfacet
+  facet normal 0.790196 -0.612855 0
+    outer loop
+      vertex 54.9958 58.0716 0
+      vertex 54.8707 57.9103 3
+      vertex 54.8707 57.9103 0
+    endloop
+  endfacet
+  facet normal -0.999509 0.0313418 0
+    outer loop
+      vertex 60.7436 55.7959 0
+      vertex 60.75 56 3
+      vertex 60.75 56 0
+    endloop
+  endfacet
+  facet normal -0.999509 0.0313418 0
+    outer loop
+      vertex 60.75 56 3
+      vertex 60.7436 55.7959 0
+      vertex 60.7436 55.7959 3
+    endloop
+  endfacet
+  facet normal -0.917746 -0.397168 0
+    outer loop
+      vertex 60.5218 57.1964 0
+      vertex 60.4407 57.3838 3
+      vertex 60.4407 57.3838 0
+    endloop
+  endfacet
+  facet normal -0.917746 -0.397168 0
+    outer loop
+      vertex 60.4407 57.3838 3
+      vertex 60.5218 57.1964 0
+      vertex 60.5218 57.1964 3
+    endloop
+  endfacet
+  facet normal -0.156692 -0.987648 0
+    outer loop
+      vertex 57.9073 59.2244 0
+      vertex 58.109 59.1924 3
+      vertex 57.9073 59.2244 3
+    endloop
+  endfacet
+  facet normal -0.156692 -0.987648 -0
+    outer loop
+      vertex 58.109 59.1924 3
+      vertex 57.9073 59.2244 0
+      vertex 58.109 59.1924 0
+    endloop
+  endfacet
+  facet normal 0.50901 -0.860761 0
+    outer loop
+      vertex 55.7586 58.7441 0
+      vertex 55.9343 58.848 3
+      vertex 55.7586 58.7441 3
+    endloop
+  endfacet
+  facet normal 0.50901 -0.860761 0
+    outer loop
+      vertex 55.9343 58.848 3
+      vertex 55.7586 58.7441 0
+      vertex 55.9343 58.848 0
+    endloop
+  endfacet
+  facet normal 0.156692 0.987648 -0
+    outer loop
+      vertex 57.0927 52.7756 0
+      vertex 56.891 52.8076 3
+      vertex 57.0927 52.7756 3
+    endloop
+  endfacet
+  facet normal 0.156692 0.987648 0
+    outer loop
+      vertex 56.891 52.8076 3
+      vertex 57.0927 52.7756 0
+      vertex 56.891 52.8076 0
+    endloop
+  endfacet
+  facet normal 0.975944 -0.21802 0
+    outer loop
+      vertex 54.3076 56.609 3
+      vertex 54.3521 56.8082 0
+      vertex 54.3521 56.8082 3
+    endloop
+  endfacet
+  facet normal 0.975944 -0.21802 0
+    outer loop
+      vertex 54.3521 56.8082 0
+      vertex 54.3076 56.609 3
+      vertex 54.3076 56.609 0
+    endloop
+  endfacet
+  facet normal 0.454058 -0.890972 0
+    outer loop
+      vertex 55.9343 58.848 0
+      vertex 56.1162 58.9407 3
+      vertex 55.9343 58.848 3
+    endloop
+  endfacet
+  facet normal 0.454058 -0.890972 0
+    outer loop
+      vertex 56.1162 58.9407 3
+      vertex 55.9343 58.848 0
+      vertex 56.1162 58.9407 0
+    endloop
+  endfacet
+  facet normal 0.338477 0.940975 -0
+    outer loop
+      vertex 56.4957 52.9091 0
+      vertex 56.3036 52.9782 3
+      vertex 56.4957 52.9091 3
+    endloop
+  endfacet
+  facet normal 0.338477 0.940975 0
+    outer loop
+      vertex 56.3036 52.9782 3
+      vertex 56.4957 52.9091 0
+      vertex 56.3036 52.9782 0
+    endloop
+  endfacet
+  facet normal -0.454058 0.890972 0
+    outer loop
+      vertex 59.0657 53.152 0
+      vertex 58.8838 53.0593 3
+      vertex 59.0657 53.152 3
+    endloop
+  endfacet
+  facet normal -0.454058 0.890972 0
+    outer loop
+      vertex 58.8838 53.0593 3
+      vertex 59.0657 53.152 0
+      vertex 58.8838 53.0593 0
+    endloop
+  endfacet
+  facet normal -0.397168 0.917746 0
+    outer loop
+      vertex 58.8838 53.0593 0
+      vertex 58.6964 52.9782 3
+      vertex 58.8838 53.0593 3
+    endloop
+  endfacet
+  facet normal -0.397168 0.917746 0
+    outer loop
+      vertex 58.6964 52.9782 3
+      vertex 58.8838 53.0593 0
+      vertex 58.6964 52.9782 0
+    endloop
+  endfacet
+  facet normal 0.397168 -0.917746 0
+    outer loop
+      vertex 56.1162 58.9407 0
+      vertex 56.3036 59.0218 3
+      vertex 56.1162 58.9407 3
+    endloop
+  endfacet
+  facet normal 0.397168 -0.917746 0
+    outer loop
+      vertex 56.3036 59.0218 3
+      vertex 56.1162 58.9407 0
+      vertex 56.3036 59.0218 0
+    endloop
+  endfacet
+  facet normal -0.0940692 0.995566 0
+    outer loop
+      vertex 57.9073 52.7756 0
+      vertex 57.7041 52.7564 3
+      vertex 57.9073 52.7756 3
+    endloop
+  endfacet
+  facet normal -0.0940692 0.995566 0
+    outer loop
+      vertex 57.7041 52.7564 3
+      vertex 57.9073 52.7756 0
+      vertex 57.7041 52.7564 0
+    endloop
+  endfacet
+  facet normal 0.0313418 -0.999509 0
+    outer loop
+      vertex 57.2959 59.2436 0
+      vertex 57.5 59.25 3
+      vertex 57.2959 59.2436 3
+    endloop
+  endfacet
+  facet normal 0.0313418 -0.999509 0
+    outer loop
+      vertex 57.5 59.25 3
+      vertex 57.2959 59.2436 0
+      vertex 57.5 59.25 0
+    endloop
+  endfacet
+  facet normal 0.940975 -0.338477 0
+    outer loop
+      vertex 54.4091 57.0043 3
+      vertex 54.4782 57.1964 0
+      vertex 54.4782 57.1964 3
+    endloop
+  endfacet
+  facet normal 0.940975 -0.338477 0
+    outer loop
+      vertex 54.4782 57.1964 0
+      vertex 54.4091 57.0043 3
+      vertex 54.4091 57.0043 0
+    endloop
+  endfacet
+  facet normal -0.790196 0.612855 0
+    outer loop
+      vertex 60.0042 53.9284 0
+      vertex 60.1293 54.0897 3
+      vertex 60.1293 54.0897 0
+    endloop
+  endfacet
+  facet normal -0.790196 0.612855 0
+    outer loop
+      vertex 60.1293 54.0897 3
+      vertex 60.0042 53.9284 0
+      vertex 60.0042 53.9284 3
+    endloop
+  endfacet
+  facet normal 0.860761 0.50901 0
+    outer loop
+      vertex 54.7559 54.2586 3
+      vertex 54.652 54.4343 0
+      vertex 54.652 54.4343 3
+    endloop
+  endfacet
+  facet normal 0.860761 0.50901 0
+    outer loop
+      vertex 54.652 54.4343 0
+      vertex 54.7559 54.2586 3
+      vertex 54.7559 54.2586 0
+    endloop
+  endfacet
+  facet normal -0.612855 -0.790196 0
+    outer loop
+      vertex 59.4103 58.6293 0
+      vertex 59.5716 58.5042 3
+      vertex 59.4103 58.6293 3
+    endloop
+  endfacet
+  facet normal -0.612855 -0.790196 -0
+    outer loop
+      vertex 59.5716 58.5042 3
+      vertex 59.4103 58.6293 0
+      vertex 59.5716 58.5042 0
+    endloop
+  endfacet
+  facet normal 0.750024 0.661411 0
+    outer loop
+      vertex 55.1309 53.7752 3
+      vertex 54.9958 53.9284 0
+      vertex 54.9958 53.9284 3
+    endloop
+  endfacet
+  facet normal 0.750024 0.661411 0
+    outer loop
+      vertex 54.9958 53.9284 0
+      vertex 55.1309 53.7752 3
+      vertex 55.1309 53.7752 0
+    endloop
+  endfacet
+  facet normal -0.661411 -0.750024 0
+    outer loop
+      vertex 59.5716 58.5042 0
+      vertex 59.7248 58.3691 3
+      vertex 59.5716 58.5042 3
+    endloop
+  endfacet
+  facet normal -0.661411 -0.750024 -0
+    outer loop
+      vertex 59.7248 58.3691 3
+      vertex 59.5716 58.5042 0
+      vertex 59.7248 58.3691 0
+    endloop
+  endfacet
+  facet normal -0.562136 0.827045 0
+    outer loop
+      vertex 59.4103 53.3707 0
+      vertex 59.2414 53.2559 3
+      vertex 59.4103 53.3707 3
+    endloop
+  endfacet
+  facet normal -0.562136 0.827045 0
+    outer loop
+      vertex 59.2414 53.2559 3
+      vertex 59.4103 53.3707 0
+      vertex 59.2414 53.2559 0
+    endloop
+  endfacet
+  facet normal -0.940975 0.338477 0
+    outer loop
+      vertex 60.5218 54.8036 0
+      vertex 60.5909 54.9957 3
+      vertex 60.5909 54.9957 0
+    endloop
+  endfacet
+  facet normal -0.940975 0.338477 0
+    outer loop
+      vertex 60.5909 54.9957 3
+      vertex 60.5218 54.8036 0
+      vertex 60.5218 54.8036 3
+    endloop
+  endfacet
+  facet normal 0.397168 0.917746 -0
+    outer loop
+      vertex 56.3036 52.9782 0
+      vertex 56.1162 53.0593 3
+      vertex 56.3036 52.9782 3
+    endloop
+  endfacet
+  facet normal 0.397168 0.917746 0
+    outer loop
+      vertex 56.1162 53.0593 3
+      vertex 56.3036 52.9782 0
+      vertex 56.1162 53.0593 0
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 0
+    outer loop
+      vertex 55.1309 58.2248 3
+      vertex 55.2752 58.3691 0
+      vertex 55.2752 58.3691 3
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 0
+    outer loop
+      vertex 55.2752 58.3691 0
+      vertex 55.1309 58.2248 3
+      vertex 55.1309 58.2248 0
+    endloop
+  endfacet
+  facet normal -0.890972 0.454058 0
+    outer loop
+      vertex 60.348 54.4343 0
+      vertex 60.4407 54.6162 3
+      vertex 60.4407 54.6162 0
+    endloop
+  endfacet
+  facet normal -0.890972 0.454058 0
+    outer loop
+      vertex 60.4407 54.6162 3
+      vertex 60.348 54.4343 0
+      vertex 60.348 54.4343 3
+    endloop
+  endfacet
+  facet normal -0.917746 0.397168 0
+    outer loop
+      vertex 60.4407 54.6162 0
+      vertex 60.5218 54.8036 3
+      vertex 60.5218 54.8036 0
+    endloop
+  endfacet
+  facet normal -0.917746 0.397168 0
+    outer loop
+      vertex 60.5218 54.8036 3
+      vertex 60.4407 54.6162 0
+      vertex 60.4407 54.6162 3
+    endloop
+  endfacet
+  facet normal -0.860761 -0.50901 0
+    outer loop
+      vertex 60.348 57.5657 0
+      vertex 60.2441 57.7414 3
+      vertex 60.2441 57.7414 0
+    endloop
+  endfacet
+  facet normal -0.860761 -0.50901 0
+    outer loop
+      vertex 60.2441 57.7414 3
+      vertex 60.348 57.5657 0
+      vertex 60.348 57.5657 3
+    endloop
+  endfacet
+  facet normal 0.960257 0.279116 0
+    outer loop
+      vertex 54.4091 54.9957 3
+      vertex 54.3521 55.1918 0
+      vertex 54.3521 55.1918 3
+    endloop
+  endfacet
+  facet normal 0.960257 0.279116 0
+    outer loop
+      vertex 54.3521 55.1918 0
+      vertex 54.4091 54.9957 3
+      vertex 54.4091 54.9957 0
+    endloop
+  endfacet
+  facet normal -0.940975 -0.338477 0
+    outer loop
+      vertex 60.5909 57.0043 0
+      vertex 60.5218 57.1964 3
+      vertex 60.5218 57.1964 0
+    endloop
+  endfacet
+  facet normal -0.940975 -0.338477 0
+    outer loop
+      vertex 60.5218 57.1964 3
+      vertex 60.5909 57.0043 0
+      vertex 60.5909 57.0043 3
+    endloop
+  endfacet
+  facet normal 0.987648 -0.156692 0
+    outer loop
+      vertex 54.2756 56.4073 3
+      vertex 54.3076 56.609 0
+      vertex 54.3076 56.609 3
+    endloop
+  endfacet
+  facet normal 0.987648 -0.156692 0
+    outer loop
+      vertex 54.3076 56.609 0
+      vertex 54.2756 56.4073 3
+      vertex 54.2756 56.4073 0
+    endloop
+  endfacet
+  facet normal -0.156692 0.987648 0
+    outer loop
+      vertex 58.109 52.8076 0
+      vertex 57.9073 52.7756 3
+      vertex 58.109 52.8076 3
+    endloop
+  endfacet
+  facet normal -0.156692 0.987648 0
+    outer loop
+      vertex 57.9073 52.7756 3
+      vertex 58.109 52.8076 0
+      vertex 57.9073 52.7756 0
+    endloop
+  endfacet
+  facet normal 0.890972 0.454058 0
+    outer loop
+      vertex 54.652 54.4343 3
+      vertex 54.5593 54.6162 0
+      vertex 54.5593 54.6162 3
+    endloop
+  endfacet
+  facet normal 0.890972 0.454058 0
+    outer loop
+      vertex 54.5593 54.6162 0
+      vertex 54.652 54.4343 3
+      vertex 54.652 54.4343 0
+    endloop
+  endfacet
+  facet normal 0.960257 -0.279116 0
+    outer loop
+      vertex 54.3521 56.8082 3
+      vertex 54.4091 57.0043 0
+      vertex 54.4091 57.0043 3
+    endloop
+  endfacet
+  facet normal 0.960257 -0.279116 0
+    outer loop
+      vertex 54.4091 57.0043 0
+      vertex 54.3521 56.8082 3
+      vertex 54.3521 56.8082 0
+    endloop
+  endfacet
+  facet normal -0.661411 0.750024 0
+    outer loop
+      vertex 59.7248 53.6309 0
+      vertex 59.5716 53.4958 3
+      vertex 59.7248 53.6309 3
+    endloop
+  endfacet
+  facet normal -0.661411 0.750024 0
+    outer loop
+      vertex 59.5716 53.4958 3
+      vertex 59.7248 53.6309 0
+      vertex 59.5716 53.4958 0
+    endloop
+  endfacet
+  facet normal 0.21802 0.975944 -0
+    outer loop
+      vertex 56.891 52.8076 0
+      vertex 56.6918 52.8521 3
+      vertex 56.891 52.8076 3
+    endloop
+  endfacet
+  facet normal 0.21802 0.975944 0
+    outer loop
+      vertex 56.6918 52.8521 3
+      vertex 56.891 52.8076 0
+      vertex 56.6918 52.8521 0
+    endloop
+  endfacet
+  facet normal 0.612855 0.790196 -0
+    outer loop
+      vertex 55.5897 53.3707 0
+      vertex 55.4284 53.4958 3
+      vertex 55.5897 53.3707 3
+    endloop
+  endfacet
+  facet normal 0.612855 0.790196 0
+    outer loop
+      vertex 55.4284 53.4958 3
+      vertex 55.5897 53.3707 0
+      vertex 55.4284 53.4958 0
+    endloop
+  endfacet
+  facet normal 0.860761 -0.50901 0
+    outer loop
+      vertex 54.652 57.5657 3
+      vertex 54.7559 57.7414 0
+      vertex 54.7559 57.7414 3
+    endloop
+  endfacet
+  facet normal 0.860761 -0.50901 0
+    outer loop
+      vertex 54.7559 57.7414 0
+      vertex 54.652 57.5657 3
+      vertex 54.652 57.5657 0
+    endloop
+  endfacet
+  facet normal 0.0313418 0.999509 -0
+    outer loop
+      vertex 57.5 52.75 0
+      vertex 57.2959 52.7564 3
+      vertex 57.5 52.75 3
+    endloop
+  endfacet
+  facet normal 0.0313418 0.999509 0
+    outer loop
+      vertex 57.2959 52.7564 3
+      vertex 57.5 52.75 0
+      vertex 57.2959 52.7564 0
+    endloop
+  endfacet
+  facet normal 0.995566 0.0940692 0
+    outer loop
+      vertex 54.2756 55.5927 3
+      vertex 54.2564 55.7959 0
+      vertex 54.2564 55.7959 3
+    endloop
+  endfacet
+  facet normal 0.995566 0.0940692 0
+    outer loop
+      vertex 54.2564 55.7959 0
+      vertex 54.2756 55.5927 3
+      vertex 54.2756 55.5927 0
+    endloop
+  endfacet
+  facet normal 0.661411 0.750024 -0
+    outer loop
+      vertex 55.4284 53.4958 0
+      vertex 55.2752 53.6309 3
+      vertex 55.4284 53.4958 3
+    endloop
+  endfacet
+  facet normal 0.661411 0.750024 0
+    outer loop
+      vertex 55.2752 53.6309 3
+      vertex 55.4284 53.4958 0
+      vertex 55.2752 53.6309 0
+    endloop
+  endfacet
+  facet normal 0.279116 -0.960257 0
+    outer loop
+      vertex 56.4957 59.0909 0
+      vertex 56.6918 59.1479 3
+      vertex 56.4957 59.0909 3
+    endloop
+  endfacet
+  facet normal 0.279116 -0.960257 0
+    outer loop
+      vertex 56.6918 59.1479 3
+      vertex 56.4957 59.0909 0
+      vertex 56.6918 59.1479 0
+    endloop
+  endfacet
+  facet normal -0.612855 0.790196 0
+    outer loop
+      vertex 59.5716 53.4958 0
+      vertex 59.4103 53.3707 3
+      vertex 59.5716 53.4958 3
+    endloop
+  endfacet
+  facet normal -0.612855 0.790196 0
+    outer loop
+      vertex 59.4103 53.3707 3
+      vertex 59.5716 53.4958 0
+      vertex 59.4103 53.3707 0
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 0
+    outer loop
+      vertex 55.2752 53.6309 3
+      vertex 55.1309 53.7752 0
+      vertex 55.1309 53.7752 3
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 0
+    outer loop
+      vertex 55.1309 53.7752 0
+      vertex 55.2752 53.6309 3
+      vertex 55.2752 53.6309 0
+    endloop
+  endfacet
+  facet normal -0.21802 -0.975944 0
+    outer loop
+      vertex 58.109 59.1924 0
+      vertex 58.3082 59.1479 3
+      vertex 58.109 59.1924 3
+    endloop
+  endfacet
+  facet normal -0.21802 -0.975944 -0
+    outer loop
+      vertex 58.3082 59.1479 3
+      vertex 58.109 59.1924 0
+      vertex 58.3082 59.1479 0
+    endloop
+  endfacet
+  facet normal 0.562136 0.827045 -0
+    outer loop
+      vertex 55.7586 53.2559 0
+      vertex 55.5897 53.3707 3
+      vertex 55.7586 53.2559 3
+    endloop
+  endfacet
+  facet normal 0.562136 0.827045 0
+    outer loop
+      vertex 55.5897 53.3707 3
+      vertex 55.7586 53.2559 0
+      vertex 55.5897 53.3707 0
+    endloop
+  endfacet
+  facet normal -0.338477 0.940975 0
+    outer loop
+      vertex 58.6964 52.9782 0
+      vertex 58.5043 52.9091 3
+      vertex 58.6964 52.9782 3
+    endloop
+  endfacet
+  facet normal -0.338477 0.940975 0
+    outer loop
+      vertex 58.5043 52.9091 3
+      vertex 58.6964 52.9782 0
+      vertex 58.5043 52.9091 0
+    endloop
+  endfacet
+  facet normal 0.917746 -0.397168 0
+    outer loop
+      vertex 54.4782 57.1964 3
+      vertex 54.5593 57.3838 0
+      vertex 54.5593 57.3838 3
+    endloop
+  endfacet
+  facet normal 0.917746 -0.397168 0
+    outer loop
+      vertex 54.5593 57.3838 0
+      vertex 54.4782 57.1964 3
+      vertex 54.4782 57.1964 0
+    endloop
+  endfacet
+  facet normal -0.750024 -0.661411 0
+    outer loop
+      vertex 60.0042 58.0716 0
+      vertex 59.8691 58.2248 3
+      vertex 59.8691 58.2248 0
+    endloop
+  endfacet
+  facet normal -0.750024 -0.661411 0
+    outer loop
+      vertex 59.8691 58.2248 3
+      vertex 60.0042 58.0716 0
+      vertex 60.0042 58.0716 3
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex 59.8691 58.2248 0
+      vertex 59.7248 58.3691 3
+      vertex 59.7248 58.3691 0
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex 59.7248 58.3691 3
+      vertex 59.8691 58.2248 0
+      vertex 59.8691 58.2248 3
+    endloop
+  endfacet
+  facet normal -0.999509 0.0313341 0
+    outer loop
+      vertex 79.4813 99.4035 0
+      vertex 79.5 100 3
+      vertex 79.5 100 0
+    endloop
+  endfacet
+  facet normal -0.999509 0.0313341 0
+    outer loop
+      vertex 79.5 100 3
+      vertex 79.4813 99.4035 0
+      vertex 79.4813 99.4035 3
+    endloop
+  endfacet
+  facet normal -0.995554 -0.0941921 0
+    outer loop
+      vertex 79.4813 100.597 0
+      vertex 79.4251 101.191 3
+      vertex 79.4251 101.191 0
+    endloop
+  endfacet
+  facet normal -0.995554 -0.0941921 0
+    outer loop
+      vertex 79.4251 101.191 3
+      vertex 79.4813 100.597 0
+      vertex 79.4813 100.597 3
+    endloop
+  endfacet
+  facet normal -0.99951 -0.0313079 0
+    outer loop
+      vertex 79.5 100 0
+      vertex 79.4813 100.597 3
+      vertex 79.4813 100.597 0
+    endloop
+  endfacet
+  facet normal -0.99951 -0.0313079 0
+    outer loop
+      vertex 79.4813 100.597 3
+      vertex 79.5 100 0
+      vertex 79.5 100 3
+    endloop
+  endfacet
+  facet normal -0.790415 -0.612572 0
+    outer loop
+      vertex 77.6857 105.584 0
+      vertex 77.3199 106.056 3
+      vertex 77.3199 106.056 0
+    endloop
+  endfacet
+  facet normal -0.790415 -0.612572 0
+    outer loop
+      vertex 77.3199 106.056 3
+      vertex 77.6857 105.584 0
+      vertex 77.6857 105.584 3
+    endloop
+  endfacet
+  facet normal -0.860743 0.50904 0
+    outer loop
+      vertex 78.0211 94.9096 0
+      vertex 78.3249 95.4233 3
+      vertex 78.3249 95.4233 0
+    endloop
+  endfacet
+  facet normal -0.860743 0.50904 0
+    outer loop
+      vertex 78.3249 95.4233 3
+      vertex 78.0211 94.9096 0
+      vertex 78.0211 94.9096 3
+    endloop
+  endfacet
+  facet normal -0.397132 -0.917761 0
+    outer loop
+      vertex 73.4972 108.833 0
+      vertex 74.0449 108.596 3
+      vertex 73.4972 108.833 3
+    endloop
+  endfacet
+  facet normal -0.397132 -0.917761 -0
+    outer loop
+      vertex 74.0449 108.596 3
+      vertex 73.4972 108.833 0
+      vertex 74.0449 108.596 0
+    endloop
+  endfacet
+  facet normal 0.749598 -0.661893 0
+    outer loop
+      vertex 62.6801 106.056 3
+      vertex 63.0748 106.503 0
+      vertex 63.0748 106.503 3
+    endloop
+  endfacet
+  facet normal 0.749598 -0.661893 0
+    outer loop
+      vertex 63.0748 106.503 0
+      vertex 62.6801 106.056 3
+      vertex 62.6801 106.056 0
+    endloop
+  endfacet
+  facet normal -0.27899 0.960294 0
+    outer loop
+      vertex 72.9357 90.965 0
+      vertex 72.3626 90.7985 3
+      vertex 72.9357 90.965 3
+    endloop
+  endfacet
+  facet normal -0.27899 0.960294 0
+    outer loop
+      vertex 72.3626 90.7985 3
+      vertex 72.9357 90.965 0
+      vertex 72.3626 90.7985 0
+    endloop
+  endfacet
+  facet normal 0.860439 -0.509554 0
+    outer loop
+      vertex 61.6751 104.577 3
+      vertex 61.9789 105.09 0
+      vertex 61.9789 105.09 3
+    endloop
+  endfacet
+  facet normal 0.860439 -0.509554 0
+    outer loop
+      vertex 61.9789 105.09 0
+      vertex 61.6751 104.577 3
+      vertex 61.6751 104.577 0
+    endloop
+  endfacet
+  facet normal 0.661311 0.750112 -0
+    outer loop
+      vertex 63.9445 92.6801 0
+      vertex 63.4968 93.0748 3
+      vertex 63.9445 92.6801 3
+    endloop
+  endfacet
+  facet normal 0.661311 0.750112 0
+    outer loop
+      vertex 63.4968 93.0748 3
+      vertex 63.9445 92.6801 0
+      vertex 63.4968 93.0748 0
+    endloop
+  endfacet
+  facet normal -0.562026 0.82712 0
+    outer loop
+      vertex 75.584 92.3143 0
+      vertex 75.0904 91.9789 3
+      vertex 75.584 92.3143 3
+    endloop
+  endfacet
+  facet normal -0.562026 0.82712 0
+    outer loop
+      vertex 75.0904 91.9789 3
+      vertex 75.584 92.3143 0
+      vertex 75.0904 91.9789 0
+    endloop
+  endfacet
+  facet normal 0.338512 -0.940962 0
+    outer loop
+      vertex 66.5028 108.833 0
+      vertex 67.0643 109.035 3
+      vertex 66.5028 108.833 3
+    endloop
+  endfacet
+  facet normal 0.338512 -0.940962 0
+    outer loop
+      vertex 67.0643 109.035 3
+      vertex 66.5028 108.833 0
+      vertex 67.0643 109.035 0
+    endloop
+  endfacet
+  facet normal -0.917841 -0.396949 0
+    outer loop
+      vertex 78.8329 103.497 0
+      vertex 78.5959 104.045 3
+      vertex 78.5959 104.045 0
+    endloop
+  endfacet
+  facet normal -0.917841 -0.396949 0
+    outer loop
+      vertex 78.5959 104.045 3
+      vertex 78.8329 103.497 0
+      vertex 78.8329 103.497 3
+    endloop
+  endfacet
+  facet normal -0.0938286 -0.995588 0
+    outer loop
+      vertex 70.5965 109.481 0
+      vertex 71.1907 109.425 3
+      vertex 70.5965 109.481 3
+    endloop
+  endfacet
+  facet normal -0.0938286 -0.995588 -0
+    outer loop
+      vertex 71.1907 109.425 3
+      vertex 70.5965 109.481 0
+      vertex 71.1907 109.425 0
+    endloop
+  endfacet
+  facet normal -0.790101 0.612977 0
+    outer loop
+      vertex 77.3199 93.9445 0
+      vertex 77.6857 94.416 3
+      vertex 77.6857 94.416 0
+    endloop
+  endfacet
+  facet normal -0.790101 0.612977 0
+    outer loop
+      vertex 77.6857 94.416 3
+      vertex 77.3199 93.9445 0
+      vertex 77.3199 93.9445 3
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex 76.9252 106.503 0
+      vertex 76.5032 106.925 3
+      vertex 76.5032 106.925 0
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex 76.5032 106.925 3
+      vertex 76.9252 106.503 0
+      vertex 76.9252 106.503 3
+    endloop
+  endfacet
+  facet normal -0.613186 -0.789938 0
+    outer loop
+      vertex 75.584 107.686 0
+      vertex 76.0555 107.32 3
+      vertex 75.584 107.686 3
+    endloop
+  endfacet
+  facet normal -0.613186 -0.789938 -0
+    outer loop
+      vertex 76.0555 107.32 3
+      vertex 75.584 107.686 0
+      vertex 76.0555 107.32 0
+    endloop
+  endfacet
+  facet normal 0.987659 -0.156617 0
+    outer loop
+      vertex 60.5749 101.191 3
+      vertex 60.6683 101.78 0
+      vertex 60.6683 101.78 3
+    endloop
+  endfacet
+  facet normal 0.987659 -0.156617 0
+    outer loop
+      vertex 60.6683 101.78 0
+      vertex 60.5749 101.191 3
+      vertex 60.5749 101.191 0
+    endloop
+  endfacet
+  facet normal 0.454036 -0.890983 0
+    outer loop
+      vertex 65.4233 108.325 0
+      vertex 65.9551 108.596 3
+      vertex 65.4233 108.325 3
+    endloop
+  endfacet
+  facet normal 0.454036 -0.890983 0
+    outer loop
+      vertex 65.9551 108.596 3
+      vertex 65.4233 108.325 0
+      vertex 65.9551 108.596 0
+    endloop
+  endfacet
+  facet normal 0.975918 0.218137 0
+    outer loop
+      vertex 60.7985 97.6374 3
+      vertex 60.6683 98.2199 0
+      vertex 60.6683 98.2199 3
+    endloop
+  endfacet
+  facet normal 0.975918 0.218137 0
+    outer loop
+      vertex 60.6683 98.2199 0
+      vertex 60.7985 97.6374 3
+      vertex 60.7985 97.6374 0
+    endloop
+  endfacet
+  facet normal -0.217817 -0.97599 0
+    outer loop
+      vertex 71.7801 109.332 0
+      vertex 72.3626 109.202 3
+      vertex 71.7801 109.332 3
+    endloop
+  endfacet
+  facet normal -0.217817 -0.97599 -0
+    outer loop
+      vertex 72.3626 109.202 3
+      vertex 71.7801 109.332 0
+      vertex 72.3626 109.202 0
+    endloop
+  endfacet
+  facet normal 0.155859 -0.987779 0
+    outer loop
+      vertex 68.2199 109.332 0
+      vertex 68.8093 109.425 3
+      vertex 68.2199 109.332 3
+    endloop
+  endfacet
+  facet normal 0.155859 -0.987779 0
+    outer loop
+      vertex 68.8093 109.425 3
+      vertex 68.2199 109.332 0
+      vertex 68.8093 109.425 0
+    endloop
+  endfacet
+  facet normal -0.338512 -0.940962 0
+    outer loop
+      vertex 72.9357 109.035 0
+      vertex 73.4972 108.833 3
+      vertex 72.9357 109.035 3
+    endloop
+  endfacet
+  facet normal -0.338512 -0.940962 -0
+    outer loop
+      vertex 73.4972 108.833 3
+      vertex 72.9357 109.035 0
+      vertex 73.4972 108.833 0
+    endloop
+  endfacet
+  facet normal -0.50904 0.860743 0
+    outer loop
+      vertex 75.0904 91.9789 0
+      vertex 74.5767 91.6751 3
+      vertex 75.0904 91.9789 3
+    endloop
+  endfacet
+  facet normal -0.50904 0.860743 0
+    outer loop
+      vertex 74.5767 91.6751 3
+      vertex 75.0904 91.9789 0
+      vertex 74.5767 91.6751 0
+    endloop
+  endfacet
+  facet normal -0.827331 -0.561714 0
+    outer loop
+      vertex 78.0211 105.09 0
+      vertex 77.6857 105.584 3
+      vertex 77.6857 105.584 0
+    endloop
+  endfacet
+  facet normal -0.827331 -0.561714 0
+    outer loop
+      vertex 77.6857 105.584 3
+      vertex 78.0211 105.09 0
+      vertex 78.0211 105.09 3
+    endloop
+  endfacet
+  facet normal 0.0938286 -0.995588 0
+    outer loop
+      vertex 68.8093 109.425 0
+      vertex 69.4035 109.481 3
+      vertex 68.8093 109.425 3
+    endloop
+  endfacet
+  facet normal 0.0938286 -0.995588 0
+    outer loop
+      vertex 69.4035 109.481 3
+      vertex 68.8093 109.425 0
+      vertex 69.4035 109.481 0
+    endloop
+  endfacet
+  facet normal -0.661594 -0.749862 0
+    outer loop
+      vertex 76.0555 107.32 0
+      vertex 76.5032 106.925 3
+      vertex 76.0555 107.32 3
+    endloop
+  endfacet
+  facet normal -0.661594 -0.749862 -0
+    outer loop
+      vertex 76.5032 106.925 3
+      vertex 76.0555 107.32 0
+      vertex 76.5032 106.925 0
+    endloop
+  endfacet
+  facet normal -0.397132 0.917761 0
+    outer loop
+      vertex 74.0449 91.4041 0
+      vertex 73.4972 91.1671 3
+      vertex 74.0449 91.4041 3
+    endloop
+  endfacet
+  facet normal -0.397132 0.917761 0
+    outer loop
+      vertex 73.4972 91.1671 3
+      vertex 74.0449 91.4041 0
+      vertex 73.4972 91.1671 0
+    endloop
+  endfacet
+  facet normal -0.975918 0.218137 0
+    outer loop
+      vertex 79.2015 97.6374 0
+      vertex 79.3317 98.2199 3
+      vertex 79.3317 98.2199 0
+    endloop
+  endfacet
+  facet normal -0.975918 0.218137 0
+    outer loop
+      vertex 79.3317 98.2199 3
+      vertex 79.2015 97.6374 0
+      vertex 79.2015 97.6374 3
+    endloop
+  endfacet
+  facet normal 0.917761 0.397132 0
+    outer loop
+      vertex 61.4041 95.9551 3
+      vertex 61.1671 96.5028 0
+      vertex 61.1671 96.5028 3
+    endloop
+  endfacet
+  facet normal 0.917761 0.397132 0
+    outer loop
+      vertex 61.1671 96.5028 0
+      vertex 61.4041 95.9551 3
+      vertex 61.4041 95.9551 0
+    endloop
+  endfacet
+  facet normal -0.960281 -0.279035 0
+    outer loop
+      vertex 79.2015 102.363 0
+      vertex 79.035 102.936 3
+      vertex 79.035 102.936 0
+    endloop
+  endfacet
+  facet normal -0.960281 -0.279035 0
+    outer loop
+      vertex 79.035 102.936 3
+      vertex 79.2015 102.363 0
+      vertex 79.2015 102.363 3
+    endloop
+  endfacet
+  facet normal 0.940813 -0.338927 0
+    outer loop
+      vertex 60.965 102.936 3
+      vertex 61.1671 103.497 0
+      vertex 61.1671 103.497 3
+    endloop
+  endfacet
+  facet normal 0.940813 -0.338927 0
+    outer loop
+      vertex 61.1671 103.497 0
+      vertex 60.965 102.936 3
+      vertex 60.965 102.936 0
+    endloop
+  endfacet
+  facet normal -0.561567 -0.827431 0
+    outer loop
+      vertex 75.0904 108.021 0
+      vertex 75.584 107.686 3
+      vertex 75.0904 108.021 3
+    endloop
+  endfacet
+  facet normal -0.561567 -0.827431 -0
+    outer loop
+      vertex 75.584 107.686 3
+      vertex 75.0904 108.021 0
+      vertex 75.584 107.686 0
+    endloop
+  endfacet
+  facet normal 0.612977 0.790101 -0
+    outer loop
+      vertex 64.416 92.3143 0
+      vertex 63.9445 92.6801 3
+      vertex 64.416 92.3143 3
+    endloop
+  endfacet
+  facet normal 0.612977 0.790101 0
+    outer loop
+      vertex 63.9445 92.6801 3
+      vertex 64.416 92.3143 0
+      vertex 63.9445 92.6801 0
+    endloop
+  endfacet
+  facet normal 0.279762 -0.960069 0
+    outer loop
+      vertex 67.0643 109.035 0
+      vertex 67.6374 109.202 3
+      vertex 67.0643 109.035 3
+    endloop
+  endfacet
+  facet normal 0.279762 -0.960069 0
+    outer loop
+      vertex 67.6374 109.202 3
+      vertex 67.0643 109.035 0
+      vertex 67.6374 109.202 0
+    endloop
+  endfacet
+  facet normal 0.917841 -0.396949 0
+    outer loop
+      vertex 61.1671 103.497 3
+      vertex 61.4041 104.045 0
+      vertex 61.4041 104.045 3
+    endloop
+  endfacet
+  facet normal 0.917841 -0.396949 0
+    outer loop
+      vertex 61.4041 104.045 0
+      vertex 61.1671 103.497 3
+      vertex 61.1671 103.497 0
+    endloop
+  endfacet
+  facet normal 0.891052 -0.453901 0
+    outer loop
+      vertex 61.4041 104.045 3
+      vertex 61.6751 104.577 0
+      vertex 61.6751 104.577 3
+    endloop
+  endfacet
+  facet normal 0.891052 -0.453901 0
+    outer loop
+      vertex 61.6751 104.577 0
+      vertex 61.4041 104.045 3
+      vertex 61.4041 104.045 0
+    endloop
+  endfacet
+  facet normal -0.960294 0.27899 0
+    outer loop
+      vertex 79.035 97.0643 0
+      vertex 79.2015 97.6374 3
+      vertex 79.2015 97.6374 0
+    endloop
+  endfacet
+  facet normal -0.960294 0.27899 0
+    outer loop
+      vertex 79.2015 97.6374 3
+      vertex 79.035 97.0643 0
+      vertex 79.035 97.0643 3
+    endloop
+  endfacet
+  facet normal -0.33866 0.940909 0
+    outer loop
+      vertex 73.4972 91.1671 0
+      vertex 72.9357 90.965 3
+      vertex 73.4972 91.1671 3
+    endloop
+  endfacet
+  facet normal -0.33866 0.940909 0
+    outer loop
+      vertex 72.9357 90.965 3
+      vertex 73.4972 91.1671 0
+      vertex 72.9357 90.965 0
+    endloop
+  endfacet
+  facet normal -0.612977 0.790101 0
+    outer loop
+      vertex 76.0555 92.6801 0
+      vertex 75.584 92.3143 3
+      vertex 76.0555 92.6801 3
+    endloop
+  endfacet
+  facet normal -0.612977 0.790101 0
+    outer loop
+      vertex 75.584 92.3143 3
+      vertex 76.0555 92.6801 0
+      vertex 75.584 92.3143 0
+    endloop
+  endfacet
+  facet normal -0.995557 0.0941607 0
+    outer loop
+      vertex 79.4251 98.8093 0
+      vertex 79.4813 99.4035 3
+      vertex 79.4813 99.4035 0
+    endloop
+  endfacet
+  facet normal -0.995557 0.0941607 0
+    outer loop
+      vertex 79.4813 99.4035 3
+      vertex 79.4251 98.8093 0
+      vertex 79.4251 98.8093 3
+    endloop
+  endfacet
+  facet normal 0.661594 -0.749862 0
+    outer loop
+      vertex 63.4968 106.925 0
+      vertex 63.9445 107.32 3
+      vertex 63.4968 106.925 3
+    endloop
+  endfacet
+  facet normal 0.661594 -0.749862 0
+    outer loop
+      vertex 63.9445 107.32 3
+      vertex 63.4968 106.925 0
+      vertex 63.9445 107.32 0
+    endloop
+  endfacet
+  facet normal -0.155859 -0.987779 0
+    outer loop
+      vertex 71.1907 109.425 0
+      vertex 71.7801 109.332 3
+      vertex 71.1907 109.425 3
+    endloop
+  endfacet
+  facet normal -0.155859 -0.987779 -0
+    outer loop
+      vertex 71.7801 109.332 3
+      vertex 71.1907 109.425 0
+      vertex 71.7801 109.332 0
+    endloop
+  endfacet
+  facet normal -0.0941607 0.995557 0
+    outer loop
+      vertex 71.1907 90.5749 0
+      vertex 70.5965 90.5187 3
+      vertex 71.1907 90.5749 3
+    endloop
+  endfacet
+  facet normal -0.0941607 0.995557 0
+    outer loop
+      vertex 70.5965 90.5187 3
+      vertex 71.1907 90.5749 0
+      vertex 70.5965 90.5187 0
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 0
+    outer loop
+      vertex 63.0748 106.503 3
+      vertex 63.4968 106.925 0
+      vertex 63.4968 106.925 3
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 0
+    outer loop
+      vertex 63.4968 106.925 0
+      vertex 63.0748 106.503 3
+      vertex 63.0748 106.503 0
+    endloop
+  endfacet
+  facet normal 0.790101 0.612977 0
+    outer loop
+      vertex 62.6801 93.9445 3
+      vertex 62.3143 94.416 0
+      vertex 62.3143 94.416 3
+    endloop
+  endfacet
+  facet normal 0.790101 0.612977 0
+    outer loop
+      vertex 62.3143 94.416 0
+      vertex 62.6801 93.9445 3
+      vertex 62.6801 93.9445 0
+    endloop
+  endfacet
+  facet normal -0.454036 -0.890983 0
+    outer loop
+      vertex 74.0449 108.596 0
+      vertex 74.5767 108.325 3
+      vertex 74.0449 108.596 3
+    endloop
+  endfacet
+  facet normal -0.454036 -0.890983 -0
+    outer loop
+      vertex 74.5767 108.325 3
+      vertex 74.0449 108.596 0
+      vertex 74.5767 108.325 0
+    endloop
+  endfacet
+  facet normal 0.217817 -0.97599 0
+    outer loop
+      vertex 67.6374 109.202 0
+      vertex 68.2199 109.332 3
+      vertex 67.6374 109.202 3
+    endloop
+  endfacet
+  facet normal 0.217817 -0.97599 0
+    outer loop
+      vertex 68.2199 109.332 3
+      vertex 67.6374 109.202 0
+      vertex 68.2199 109.332 0
+    endloop
+  endfacet
+  facet normal 0.940909 0.33866 0
+    outer loop
+      vertex 61.1671 96.5028 3
+      vertex 60.965 97.0643 0
+      vertex 60.965 97.0643 3
+    endloop
+  endfacet
+  facet normal 0.940909 0.33866 0
+    outer loop
+      vertex 60.965 97.0643 0
+      vertex 61.1671 96.5028 3
+      vertex 61.1671 96.5028 0
+    endloop
+  endfacet
+  facet normal 0.613186 -0.789938 0
+    outer loop
+      vertex 63.9445 107.32 0
+      vertex 64.416 107.686 3
+      vertex 63.9445 107.32 3
+    endloop
+  endfacet
+  facet normal 0.613186 -0.789938 0
+    outer loop
+      vertex 64.416 107.686 3
+      vertex 63.9445 107.32 0
+      vertex 64.416 107.686 0
+    endloop
+  endfacet
+  facet normal 0.397132 -0.917761 0
+    outer loop
+      vertex 65.9551 108.596 0
+      vertex 66.5028 108.833 3
+      vertex 65.9551 108.596 3
+    endloop
+  endfacet
+  facet normal 0.397132 -0.917761 0
+    outer loop
+      vertex 66.5028 108.833 3
+      vertex 65.9551 108.596 0
+      vertex 66.5028 108.833 0
+    endloop
+  endfacet
+  facet normal 0.27899 0.960294 -0
+    outer loop
+      vertex 67.6374 90.7985 0
+      vertex 67.0643 90.965 3
+      vertex 67.6374 90.7985 3
+    endloop
+  endfacet
+  facet normal 0.27899 0.960294 0
+    outer loop
+      vertex 67.0643 90.965 3
+      vertex 67.6374 90.7985 0
+      vertex 67.0643 90.965 0
+    endloop
+  endfacet
+  facet normal 0.218137 0.975918 -0
+    outer loop
+      vertex 68.2199 90.6683 0
+      vertex 67.6374 90.7985 3
+      vertex 68.2199 90.6683 3
+    endloop
+  endfacet
+  facet normal 0.218137 0.975918 0
+    outer loop
+      vertex 67.6374 90.7985 3
+      vertex 68.2199 90.6683 0
+      vertex 67.6374 90.7985 0
+    endloop
+  endfacet
+  facet normal -0.279762 -0.960069 0
+    outer loop
+      vertex 72.3626 109.202 0
+      vertex 72.9357 109.035 3
+      vertex 72.3626 109.202 3
+    endloop
+  endfacet
+  facet normal -0.279762 -0.960069 -0
+    outer loop
+      vertex 72.9357 109.035 3
+      vertex 72.3626 109.202 0
+      vertex 72.9357 109.035 0
+    endloop
+  endfacet
+  facet normal -0.82712 0.562026 0
+    outer loop
+      vertex 77.6857 94.416 0
+      vertex 78.0211 94.9096 3
+      vertex 78.0211 94.9096 0
+    endloop
+  endfacet
+  facet normal -0.82712 0.562026 0
+    outer loop
+      vertex 78.0211 94.9096 3
+      vertex 77.6857 94.416 0
+      vertex 77.6857 94.416 3
+    endloop
+  endfacet
+  facet normal -0.891052 -0.453901 0
+    outer loop
+      vertex 78.5959 104.045 0
+      vertex 78.3249 104.577 3
+      vertex 78.3249 104.577 0
+    endloop
+  endfacet
+  facet normal -0.891052 -0.453901 0
+    outer loop
+      vertex 78.3249 104.577 3
+      vertex 78.5959 104.045 0
+      vertex 78.5959 104.045 3
+    endloop
+  endfacet
+  facet normal 0.33866 0.940909 -0
+    outer loop
+      vertex 67.0643 90.965 0
+      vertex 66.5028 91.1671 3
+      vertex 67.0643 90.965 3
+    endloop
+  endfacet
+  facet normal 0.33866 0.940909 0
+    outer loop
+      vertex 66.5028 91.1671 3
+      vertex 67.0643 90.965 0
+      vertex 66.5028 91.1671 0
+    endloop
+  endfacet
+  facet normal 0.995557 0.0941607 0
+    outer loop
+      vertex 60.5749 98.8093 3
+      vertex 60.5187 99.4035 0
+      vertex 60.5187 99.4035 3
+    endloop
+  endfacet
+  facet normal 0.995557 0.0941607 0
+    outer loop
+      vertex 60.5187 99.4035 0
+      vertex 60.5749 98.8093 3
+      vertex 60.5749 98.8093 0
+    endloop
+  endfacet
+  facet normal 0.975958 -0.217958 0
+    outer loop
+      vertex 60.6683 101.78 3
+      vertex 60.7985 102.363 0
+      vertex 60.7985 102.363 3
+    endloop
+  endfacet
+  facet normal 0.975958 -0.217958 0
+    outer loop
+      vertex 60.7985 102.363 0
+      vertex 60.6683 101.78 3
+      vertex 60.6683 101.78 0
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 0
+    outer loop
+      vertex 76.5032 93.0748 0
+      vertex 76.9252 93.4968 3
+      vertex 76.9252 93.4968 0
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 0
+    outer loop
+      vertex 76.9252 93.4968 3
+      vertex 76.5032 93.0748 0
+      vertex 76.5032 93.0748 3
+    endloop
+  endfacet
+  facet normal 0.960294 0.27899 0
+    outer loop
+      vertex 60.965 97.0643 3
+      vertex 60.7985 97.6374 0
+      vertex 60.7985 97.6374 3
+    endloop
+  endfacet
+  facet normal 0.960294 0.27899 0
+    outer loop
+      vertex 60.7985 97.6374 0
+      vertex 60.965 97.0643 3
+      vertex 60.965 97.0643 0
+    endloop
+  endfacet
+  facet normal -0.890983 0.454036 0
+    outer loop
+      vertex 78.3249 95.4233 0
+      vertex 78.5959 95.9551 3
+      vertex 78.5959 95.9551 0
+    endloop
+  endfacet
+  facet normal -0.890983 0.454036 0
+    outer loop
+      vertex 78.5959 95.9551 3
+      vertex 78.3249 95.4233 0
+      vertex 78.3249 95.4233 3
+    endloop
+  endfacet
+  facet normal -0.987676 0.156513 0
+    outer loop
+      vertex 79.3317 98.2199 0
+      vertex 79.4251 98.8093 3
+      vertex 79.4251 98.8093 0
+    endloop
+  endfacet
+  facet normal -0.987676 0.156513 0
+    outer loop
+      vertex 79.4251 98.8093 3
+      vertex 79.3317 98.2199 0
+      vertex 79.3317 98.2199 3
+    endloop
+  endfacet
+  facet normal -0.156513 0.987676 0
+    outer loop
+      vertex 71.7801 90.6683 0
+      vertex 71.1907 90.5749 3
+      vertex 71.7801 90.6683 3
+    endloop
+  endfacet
+  facet normal -0.156513 0.987676 0
+    outer loop
+      vertex 71.1907 90.5749 3
+      vertex 71.7801 90.6683 0
+      vertex 71.1907 90.5749 0
+    endloop
+  endfacet
+  facet normal -0.0318363 -0.999493 0
+    outer loop
+      vertex 70 109.5 0
+      vertex 70.5965 109.481 3
+      vertex 70 109.5 3
+    endloop
+  endfacet
+  facet normal -0.0318363 -0.999493 -0
+    outer loop
+      vertex 70.5965 109.481 3
+      vertex 70 109.5 0
+      vertex 70.5965 109.481 0
+    endloop
+  endfacet
+  facet normal -0.509288 -0.860596 0
+    outer loop
+      vertex 74.5767 108.325 0
+      vertex 75.0904 108.021 3
+      vertex 74.5767 108.325 3
+    endloop
+  endfacet
+  facet normal -0.509288 -0.860596 -0
+    outer loop
+      vertex 75.0904 108.021 3
+      vertex 74.5767 108.325 0
+      vertex 75.0904 108.021 0
+    endloop
+  endfacet
+  facet normal -0.917761 0.397132 0
+    outer loop
+      vertex 78.5959 95.9551 0
+      vertex 78.8329 96.5028 3
+      vertex 78.8329 96.5028 0
+    endloop
+  endfacet
+  facet normal -0.917761 0.397132 0
+    outer loop
+      vertex 78.8329 96.5028 3
+      vertex 78.5959 95.9551 0
+      vertex 78.5959 95.9551 3
+    endloop
+  endfacet
+  facet normal -0.940909 0.33866 0
+    outer loop
+      vertex 78.8329 96.5028 0
+      vertex 79.035 97.0643 3
+      vertex 79.035 97.0643 0
+    endloop
+  endfacet
+  facet normal -0.940909 0.33866 0
+    outer loop
+      vertex 79.035 97.0643 3
+      vertex 78.8329 96.5028 0
+      vertex 78.8329 96.5028 3
+    endloop
+  endfacet
+  facet normal -0.750112 0.661311 0
+    outer loop
+      vertex 76.9252 93.4968 0
+      vertex 77.3199 93.9445 3
+      vertex 77.3199 93.9445 0
+    endloop
+  endfacet
+  facet normal -0.750112 0.661311 0
+    outer loop
+      vertex 77.3199 93.9445 3
+      vertex 76.9252 93.4968 0
+      vertex 76.9252 93.4968 3
+    endloop
+  endfacet
+  facet normal -0.860439 -0.509554 0
+    outer loop
+      vertex 78.3249 104.577 0
+      vertex 78.0211 105.09 3
+      vertex 78.0211 105.09 0
+    endloop
+  endfacet
+  facet normal -0.860439 -0.509554 0
+    outer loop
+      vertex 78.0211 105.09 3
+      vertex 78.3249 104.577 0
+      vertex 78.3249 104.577 3
+    endloop
+  endfacet
+  facet normal 0.860743 0.50904 0
+    outer loop
+      vertex 61.9789 94.9096 3
+      vertex 61.6751 95.4233 0
+      vertex 61.6751 95.4233 3
+    endloop
+  endfacet
+  facet normal 0.860743 0.50904 0
+    outer loop
+      vertex 61.6751 95.4233 0
+      vertex 61.9789 94.9096 3
+      vertex 61.9789 94.9096 0
+    endloop
+  endfacet
+  facet normal 0.960281 -0.279035 0
+    outer loop
+      vertex 60.7985 102.363 3
+      vertex 60.965 102.936 0
+      vertex 60.965 102.936 3
+    endloop
+  endfacet
+  facet normal 0.960281 -0.279035 0
+    outer loop
+      vertex 60.965 102.936 0
+      vertex 60.7985 102.363 3
+      vertex 60.7985 102.363 0
+    endloop
+  endfacet
+  facet normal 0.397132 0.917761 -0
+    outer loop
+      vertex 66.5028 91.1671 0
+      vertex 65.9551 91.4041 3
+      vertex 66.5028 91.1671 3
+    endloop
+  endfacet
+  facet normal 0.397132 0.917761 0
+    outer loop
+      vertex 65.9551 91.4041 3
+      vertex 66.5028 91.1671 0
+      vertex 65.9551 91.4041 0
+    endloop
+  endfacet
+  facet normal 0.827331 -0.561714 0
+    outer loop
+      vertex 61.9789 105.09 3
+      vertex 62.3143 105.584 0
+      vertex 62.3143 105.584 3
+    endloop
+  endfacet
+  facet normal 0.827331 -0.561714 0
+    outer loop
+      vertex 62.3143 105.584 0
+      vertex 61.9789 105.09 3
+      vertex 61.9789 105.09 0
+    endloop
+  endfacet
+  facet normal -0.975958 -0.217958 0
+    outer loop
+      vertex 79.3317 101.78 0
+      vertex 79.2015 102.363 3
+      vertex 79.2015 102.363 0
+    endloop
+  endfacet
+  facet normal -0.975958 -0.217958 0
+    outer loop
+      vertex 79.2015 102.363 3
+      vertex 79.3317 101.78 0
+      vertex 79.3317 101.78 3
+    endloop
+  endfacet
+  facet normal 0.0318363 -0.999493 0
+    outer loop
+      vertex 69.4035 109.481 0
+      vertex 70 109.5 3
+      vertex 69.4035 109.481 3
+    endloop
+  endfacet
+  facet normal 0.0318363 -0.999493 0
+    outer loop
+      vertex 70 109.5 3
+      vertex 69.4035 109.481 0
+      vertex 70 109.5 0
+    endloop
+  endfacet
+  facet normal -0.940813 -0.338927 0
+    outer loop
+      vertex 79.035 102.936 0
+      vertex 78.8329 103.497 3
+      vertex 78.8329 103.497 0
+    endloop
+  endfacet
+  facet normal -0.940813 -0.338927 0
+    outer loop
+      vertex 78.8329 103.497 3
+      vertex 79.035 102.936 0
+      vertex 79.035 102.936 3
+    endloop
+  endfacet
+  facet normal -0.987659 -0.156617 0
+    outer loop
+      vertex 79.4251 101.191 0
+      vertex 79.3317 101.78 3
+      vertex 79.3317 101.78 0
+    endloop
+  endfacet
+  facet normal -0.987659 -0.156617 0
+    outer loop
+      vertex 79.3317 101.78 3
+      vertex 79.4251 101.191 0
+      vertex 79.4251 101.191 3
+    endloop
+  endfacet
+  facet normal 0.750112 0.661311 0
+    outer loop
+      vertex 63.0748 93.4968 3
+      vertex 62.6801 93.9445 0
+      vertex 62.6801 93.9445 3
+    endloop
+  endfacet
+  facet normal 0.750112 0.661311 0
+    outer loop
+      vertex 62.6801 93.9445 0
+      vertex 63.0748 93.4968 3
+      vertex 63.0748 93.4968 0
+    endloop
+  endfacet
+  facet normal -0.454036 0.890983 0
+    outer loop
+      vertex 74.5767 91.6751 0
+      vertex 74.0449 91.4041 3
+      vertex 74.5767 91.6751 3
+    endloop
+  endfacet
+  facet normal -0.454036 0.890983 0
+    outer loop
+      vertex 74.0449 91.4041 3
+      vertex 74.5767 91.6751 0
+      vertex 74.0449 91.4041 0
+    endloop
+  endfacet
+  facet normal 0.987676 0.156513 0
+    outer loop
+      vertex 60.6683 98.2199 3
+      vertex 60.5749 98.8093 0
+      vertex 60.5749 98.8093 3
+    endloop
+  endfacet
+  facet normal 0.987676 0.156513 0
+    outer loop
+      vertex 60.5749 98.8093 0
+      vertex 60.6683 98.2199 3
+      vertex 60.6683 98.2199 0
+    endloop
+  endfacet
+  facet normal 0.999509 0.0313341 0
+    outer loop
+      vertex 60.5187 99.4035 3
+      vertex 60.5 100 0
+      vertex 60.5 100 3
+    endloop
+  endfacet
+  facet normal 0.999509 0.0313341 0
+    outer loop
+      vertex 60.5 100 0
+      vertex 60.5187 99.4035 3
+      vertex 60.5187 99.4035 0
+    endloop
+  endfacet
+  facet normal 0.156513 0.987676 -0
+    outer loop
+      vertex 68.8093 90.5749 0
+      vertex 68.2199 90.6683 3
+      vertex 68.8093 90.5749 3
+    endloop
+  endfacet
+  facet normal 0.156513 0.987676 0
+    outer loop
+      vertex 68.2199 90.6683 3
+      vertex 68.8093 90.5749 0
+      vertex 68.2199 90.6683 0
+    endloop
+  endfacet
+  facet normal 0.995554 -0.0941921 0
+    outer loop
+      vertex 60.5187 100.597 3
+      vertex 60.5749 101.191 0
+      vertex 60.5749 101.191 3
+    endloop
+  endfacet
+  facet normal 0.995554 -0.0941921 0
+    outer loop
+      vertex 60.5749 101.191 0
+      vertex 60.5187 100.597 3
+      vertex 60.5187 100.597 0
+    endloop
+  endfacet
+  facet normal 0.790415 -0.612572 0
+    outer loop
+      vertex 62.3143 105.584 3
+      vertex 62.6801 106.056 0
+      vertex 62.6801 106.056 3
+    endloop
+  endfacet
+  facet normal 0.790415 -0.612572 0
+    outer loop
+      vertex 62.6801 106.056 0
+      vertex 62.3143 105.584 3
+      vertex 62.3143 105.584 0
+    endloop
+  endfacet
+  facet normal -0.218137 0.975918 0
+    outer loop
+      vertex 72.3626 90.7985 0
+      vertex 71.7801 90.6683 3
+      vertex 72.3626 90.7985 3
+    endloop
+  endfacet
+  facet normal -0.218137 0.975918 0
+    outer loop
+      vertex 71.7801 90.6683 3
+      vertex 72.3626 90.7985 0
+      vertex 71.7801 90.6683 0
+    endloop
+  endfacet
+  facet normal 0.0941607 0.995557 -0
+    outer loop
+      vertex 69.4035 90.5187 0
+      vertex 68.8093 90.5749 3
+      vertex 69.4035 90.5187 3
+    endloop
+  endfacet
+  facet normal 0.0941607 0.995557 0
+    outer loop
+      vertex 68.8093 90.5749 3
+      vertex 69.4035 90.5187 0
+      vertex 68.8093 90.5749 0
+    endloop
+  endfacet
+  facet normal -0.749598 -0.661893 0
+    outer loop
+      vertex 77.3199 106.056 0
+      vertex 76.9252 106.503 3
+      vertex 76.9252 106.503 0
+    endloop
+  endfacet
+  facet normal -0.749598 -0.661893 0
+    outer loop
+      vertex 76.9252 106.503 3
+      vertex 77.3199 106.056 0
+      vertex 77.3199 106.056 3
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 0
+    outer loop
+      vertex 63.4968 93.0748 3
+      vertex 63.0748 93.4968 0
+      vertex 63.0748 93.4968 3
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 0
+    outer loop
+      vertex 63.0748 93.4968 0
+      vertex 63.4968 93.0748 3
+      vertex 63.4968 93.0748 0
+    endloop
+  endfacet
+  facet normal 0.509288 -0.860596 0
+    outer loop
+      vertex 64.9096 108.021 0
+      vertex 65.4233 108.325 3
+      vertex 64.9096 108.021 3
+    endloop
+  endfacet
+  facet normal 0.509288 -0.860596 0
+    outer loop
+      vertex 65.4233 108.325 3
+      vertex 64.9096 108.021 0
+      vertex 65.4233 108.325 0
+    endloop
+  endfacet
+  facet normal 0.890983 0.454036 0
+    outer loop
+      vertex 61.6751 95.4233 3
+      vertex 61.4041 95.9551 0
+      vertex 61.4041 95.9551 3
+    endloop
+  endfacet
+  facet normal 0.890983 0.454036 0
+    outer loop
+      vertex 61.4041 95.9551 0
+      vertex 61.6751 95.4233 3
+      vertex 61.6751 95.4233 0
+    endloop
+  endfacet
+  facet normal 0.561567 -0.827431 0
+    outer loop
+      vertex 64.416 107.686 0
+      vertex 64.9096 108.021 3
+      vertex 64.416 107.686 3
+    endloop
+  endfacet
+  facet normal 0.561567 -0.827431 0
+    outer loop
+      vertex 64.9096 108.021 3
+      vertex 64.416 107.686 0
+      vertex 64.9096 108.021 0
+    endloop
+  endfacet
+  facet normal 0.99951 -0.0313079 0
+    outer loop
+      vertex 60.5 100 3
+      vertex 60.5187 100.597 0
+      vertex 60.5187 100.597 3
+    endloop
+  endfacet
+  facet normal 0.99951 -0.0313079 0
+    outer loop
+      vertex 60.5187 100.597 0
+      vertex 60.5 100 3
+      vertex 60.5 100 0
+    endloop
+  endfacet
+  facet normal 0.82712 0.562026 0
+    outer loop
+      vertex 62.3143 94.416 3
+      vertex 61.9789 94.9096 0
+      vertex 61.9789 94.9096 3
+    endloop
+  endfacet
+  facet normal 0.82712 0.562026 0
+    outer loop
+      vertex 61.9789 94.9096 0
+      vertex 62.3143 94.416 3
+      vertex 62.3143 94.416 0
+    endloop
+  endfacet
+  facet normal -0.0313341 0.999509 0
+    outer loop
+      vertex 70.5965 90.5187 0
+      vertex 70 90.5 3
+      vertex 70.5965 90.5187 3
+    endloop
+  endfacet
+  facet normal -0.0313341 0.999509 0
+    outer loop
+      vertex 70 90.5 3
+      vertex 70.5965 90.5187 0
+      vertex 70 90.5 0
+    endloop
+  endfacet
+  facet normal 0.0313341 0.999509 -0
+    outer loop
+      vertex 70 90.5 0
+      vertex 69.4035 90.5187 3
+      vertex 70 90.5 3
+    endloop
+  endfacet
+  facet normal 0.0313341 0.999509 0
+    outer loop
+      vertex 69.4035 90.5187 3
+      vertex 70 90.5 0
+      vertex 69.4035 90.5187 0
+    endloop
+  endfacet
+  facet normal 0.454036 0.890983 -0
+    outer loop
+      vertex 65.9551 91.4041 0
+      vertex 65.4233 91.6751 3
+      vertex 65.9551 91.4041 3
+    endloop
+  endfacet
+  facet normal 0.454036 0.890983 0
+    outer loop
+      vertex 65.4233 91.6751 3
+      vertex 65.9551 91.4041 0
+      vertex 65.4233 91.6751 0
+    endloop
+  endfacet
+  facet normal -0.661311 0.750112 0
+    outer loop
+      vertex 76.5032 93.0748 0
+      vertex 76.0555 92.6801 3
+      vertex 76.5032 93.0748 3
+    endloop
+  endfacet
+  facet normal -0.661311 0.750112 0
+    outer loop
+      vertex 76.0555 92.6801 3
+      vertex 76.5032 93.0748 0
+      vertex 76.0555 92.6801 0
+    endloop
+  endfacet
+  facet normal 0.562026 0.82712 -0
+    outer loop
+      vertex 64.9096 91.9789 0
+      vertex 64.416 92.3143 3
+      vertex 64.9096 91.9789 3
+    endloop
+  endfacet
+  facet normal 0.562026 0.82712 0
+    outer loop
+      vertex 64.416 92.3143 3
+      vertex 64.9096 91.9789 0
+      vertex 64.416 92.3143 0
+    endloop
+  endfacet
+  facet normal 0.50904 0.860743 -0
+    outer loop
+      vertex 65.4233 91.6751 0
+      vertex 64.9096 91.9789 3
+      vertex 65.4233 91.6751 3
+    endloop
+  endfacet
+  facet normal 0.50904 0.860743 0
+    outer loop
+      vertex 64.9096 91.9789 3
+      vertex 65.4233 91.6751 0
+      vertex 64.9096 91.9789 0
+    endloop
+  endfacet
+  facet normal -0.338477 0.940975 0
+    outer loop
+      vertex 64.1964 85.9782 0
+      vertex 64.0043 85.9091 7.5
+      vertex 64.1964 85.9782 7.5
+    endloop
+  endfacet
+  facet normal -0.338477 0.940975 0
+    outer loop
+      vertex 64.0043 85.9091 7.5
+      vertex 64.1964 85.9782 0
+      vertex 64.0043 85.9091 0
+    endloop
+  endfacet
+  facet normal -0.999509 0.0313418 0
+    outer loop
+      vertex 66.2436 88.7959 0
+      vertex 66.25 89 3
+      vertex 66.25 89 0
+    endloop
+  endfacet
+  facet normal -0.999509 0.0313418 0
+    outer loop
+      vertex 66.25 89 3
+      vertex 66.2436 88.7959 0
+      vertex 66.2436 88.7959 3
+    endloop
+  endfacet
+  facet normal -0.995566 -0.0940692 0
+    outer loop
+      vertex 66.2436 89.2041 0
+      vertex 66.2244 89.4073 3
+      vertex 66.2244 89.4073 0
+    endloop
+  endfacet
+  facet normal -0.995566 -0.0940692 0
+    outer loop
+      vertex 66.2244 89.4073 3
+      vertex 66.2436 89.2041 0
+      vertex 66.2436 89.2041 3
+    endloop
+  endfacet
+  facet normal -0.999509 -0.0313418 0
+    outer loop
+      vertex 66.25 89 0
+      vertex 66.2436 89.2041 3
+      vertex 66.2436 89.2041 0
+    endloop
+  endfacet
+  facet normal -0.999509 -0.0313418 0
+    outer loop
+      vertex 66.2436 89.2041 3
+      vertex 66.25 89 0
+      vertex 66.25 89 3
+    endloop
+  endfacet
+  facet normal -0.987648 -0.156692 0
+    outer loop
+      vertex 66.2244 89.4073 0
+      vertex 66.1924 89.609 3
+      vertex 66.1924 89.609 0
+    endloop
+  endfacet
+  facet normal -0.987648 -0.156692 0
+    outer loop
+      vertex 66.1924 89.609 3
+      vertex 66.2244 89.4073 0
+      vertex 66.2244 89.4073 3
+    endloop
+  endfacet
+  facet normal -0.975944 -0.21802 0
+    outer loop
+      vertex 66.1924 89.609 0
+      vertex 66.1479 89.8082 3
+      vertex 66.1479 89.8082 0
+    endloop
+  endfacet
+  facet normal -0.975944 -0.21802 0
+    outer loop
+      vertex 66.1479 89.8082 3
+      vertex 66.1924 89.609 0
+      vertex 66.1924 89.609 3
+    endloop
+  endfacet
+  facet normal -0.987648 0.156692 0
+    outer loop
+      vertex 66.1924 88.391 0
+      vertex 66.2244 88.5927 3
+      vertex 66.2244 88.5927 0
+    endloop
+  endfacet
+  facet normal -0.987648 0.156692 0
+    outer loop
+      vertex 66.2244 88.5927 3
+      vertex 66.1924 88.391 0
+      vertex 66.1924 88.391 3
+    endloop
+  endfacet
+  facet normal -0.890972 -0.454058 0
+    outer loop
+      vertex 65.9407 90.3838 0
+      vertex 65.848 90.5657 3
+      vertex 65.848 90.5657 0
+    endloop
+  endfacet
+  facet normal -0.890972 -0.454058 0
+    outer loop
+      vertex 65.848 90.5657 3
+      vertex 65.9407 90.3838 0
+      vertex 65.9407 90.3838 3
+    endloop
+  endfacet
+  facet normal -0.790196 0.612855 0
+    outer loop
+      vertex 65.5042 86.9284 0
+      vertex 65.6293 87.0897 3
+      vertex 65.6293 87.0897 0
+    endloop
+  endfacet
+  facet normal -0.790196 0.612855 0
+    outer loop
+      vertex 65.6293 87.0897 3
+      vertex 65.5042 86.9284 0
+      vertex 65.5042 86.9284 3
+    endloop
+  endfacet
+  facet normal -0.750024 -0.661411 0
+    outer loop
+      vertex 65.5042 91.0716 0
+      vertex 65.3691 91.2248 3
+      vertex 65.3691 91.2248 0
+    endloop
+  endfacet
+  facet normal -0.750024 -0.661411 0
+    outer loop
+      vertex 65.3691 91.2248 3
+      vertex 65.5042 91.0716 0
+      vertex 65.5042 91.0716 3
+    endloop
+  endfacet
+  facet normal 0.827045 -0.562136 0
+    outer loop
+      vertex 60.2559 90.7414 3
+      vertex 60.3707 90.9103 0
+      vertex 60.3707 90.9103 3
+    endloop
+  endfacet
+  facet normal 0.827045 -0.562136 0
+    outer loop
+      vertex 60.3707 90.9103 0
+      vertex 60.2559 90.7414 3
+      vertex 60.2559 90.7414 0
+    endloop
+  endfacet
+  facet normal -0.860761 0.50901 0
+    outer loop
+      vertex 65.7441 87.2586 0
+      vertex 65.848 87.4343 3
+      vertex 65.848 87.4343 0
+    endloop
+  endfacet
+  facet normal -0.860761 0.50901 0
+    outer loop
+      vertex 65.848 87.4343 3
+      vertex 65.7441 87.2586 0
+      vertex 65.7441 87.2586 3
+    endloop
+  endfacet
+  facet normal -0.750024 0.661411 0
+    outer loop
+      vertex 65.3691 86.7752 0
+      vertex 65.5042 86.9284 3
+      vertex 65.5042 86.9284 0
+    endloop
+  endfacet
+  facet normal -0.750024 0.661411 0
+    outer loop
+      vertex 65.5042 86.9284 3
+      vertex 65.3691 86.7752 0
+      vertex 65.3691 86.7752 3
+    endloop
+  endfacet
+  facet normal 0.279116 -0.960257 0
+    outer loop
+      vertex 61.9957 92.0909 0
+      vertex 62.1918 92.1479 3
+      vertex 61.9957 92.0909 3
+    endloop
+  endfacet
+  facet normal 0.279116 -0.960257 0
+    outer loop
+      vertex 62.1918 92.1479 3
+      vertex 61.9957 92.0909 0
+      vertex 62.1918 92.1479 0
+    endloop
+  endfacet
+  facet normal -0.156692 -0.987648 0
+    outer loop
+      vertex 63.4073 92.2244 0
+      vertex 63.609 92.1924 3
+      vertex 63.4073 92.2244 3
+    endloop
+  endfacet
+  facet normal -0.156692 -0.987648 -0
+    outer loop
+      vertex 63.609 92.1924 3
+      vertex 63.4073 92.2244 0
+      vertex 63.609 92.1924 0
+    endloop
+  endfacet
+  facet normal 0.279116 0.960257 -0
+    outer loop
+      vertex 62.1918 85.8521 0
+      vertex 61.9957 85.9091 7.5
+      vertex 62.1918 85.8521 7.5
+    endloop
+  endfacet
+  facet normal 0.279116 0.960257 0
+    outer loop
+      vertex 61.9957 85.9091 7.5
+      vertex 62.1918 85.8521 0
+      vertex 61.9957 85.9091 0
+    endloop
+  endfacet
+  facet normal 0.995566 -0.0940692 0
+    outer loop
+      vertex 59.7564 89.2041 3
+      vertex 59.7756 89.4073 0
+      vertex 59.7756 89.4073 3
+    endloop
+  endfacet
+  facet normal 0.995566 -0.0940692 0
+    outer loop
+      vertex 59.7756 89.4073 0
+      vertex 59.7564 89.2041 3
+      vertex 59.7564 89.2041 0
+    endloop
+  endfacet
+  facet normal -0.917746 -0.397168 0
+    outer loop
+      vertex 66.0218 90.1964 0
+      vertex 65.9407 90.3838 3
+      vertex 65.9407 90.3838 0
+    endloop
+  endfacet
+  facet normal -0.917746 -0.397168 0
+    outer loop
+      vertex 65.9407 90.3838 3
+      vertex 66.0218 90.1964 0
+      vertex 66.0218 90.1964 3
+    endloop
+  endfacet
+  facet normal 0.397168 0.917746 -0
+    outer loop
+      vertex 61.8036 85.9782 0
+      vertex 61.6162 86.0593 3
+      vertex 61.8036 85.9782 3
+    endloop
+  endfacet
+  facet normal 0.397168 0.917746 0
+    outer loop
+      vertex 61.6162 86.0593 3
+      vertex 61.8036 85.9782 0
+      vertex 61.6162 86.0593 0
+    endloop
+  endfacet
+  facet normal -0.827045 -0.562136 0
+    outer loop
+      vertex 65.7441 90.7414 0
+      vertex 65.6293 90.9103 3
+      vertex 65.6293 90.9103 0
+    endloop
+  endfacet
+  facet normal -0.827045 -0.562136 0
+    outer loop
+      vertex 65.6293 90.9103 3
+      vertex 65.7441 90.7414 0
+      vertex 65.7441 90.7414 3
+    endloop
+  endfacet
+  facet normal 0.50901 0.860761 -0
+    outer loop
+      vertex 61.4343 86.152 0
+      vertex 61.2586 86.2559 3
+      vertex 61.4343 86.152 3
+    endloop
+  endfacet
+  facet normal 0.50901 0.860761 0
+    outer loop
+      vertex 61.2586 86.2559 3
+      vertex 61.4343 86.152 0
+      vertex 61.2586 86.2559 0
+    endloop
+  endfacet
+  facet normal 0.661411 -0.750024 0
+    outer loop
+      vertex 60.7752 91.3691 0
+      vertex 60.9284 91.5042 3
+      vertex 60.7752 91.3691 3
+    endloop
+  endfacet
+  facet normal 0.661411 -0.750024 0
+    outer loop
+      vertex 60.9284 91.5042 3
+      vertex 60.7752 91.3691 0
+      vertex 60.9284 91.5042 0
+    endloop
+  endfacet
+  facet normal -0.454058 -0.890972 0
+    outer loop
+      vertex 64.3838 91.9407 0
+      vertex 64.5657 91.848 3
+      vertex 64.3838 91.9407 3
+    endloop
+  endfacet
+  facet normal -0.454058 -0.890972 -0
+    outer loop
+      vertex 64.5657 91.848 3
+      vertex 64.3838 91.9407 0
+      vertex 64.5657 91.848 0
+    endloop
+  endfacet
+  facet normal -0.562136 -0.827045 0
+    outer loop
+      vertex 64.7414 91.7441 0
+      vertex 64.9103 91.6293 3
+      vertex 64.7414 91.7441 3
+    endloop
+  endfacet
+  facet normal -0.562136 -0.827045 -0
+    outer loop
+      vertex 64.9103 91.6293 3
+      vertex 64.7414 91.7441 0
+      vertex 64.9103 91.6293 0
+    endloop
+  endfacet
+  facet normal -0.940975 -0.338477 0
+    outer loop
+      vertex 66.0909 90.0043 0
+      vertex 66.0218 90.1964 3
+      vertex 66.0218 90.1964 0
+    endloop
+  endfacet
+  facet normal -0.940975 -0.338477 0
+    outer loop
+      vertex 66.0218 90.1964 3
+      vertex 66.0909 90.0043 0
+      vertex 66.0909 90.0043 3
+    endloop
+  endfacet
+  facet normal -0.0313418 -0.999509 0
+    outer loop
+      vertex 63 92.25 0
+      vertex 63.2041 92.2436 3
+      vertex 63 92.25 3
+    endloop
+  endfacet
+  facet normal -0.0313418 -0.999509 -0
+    outer loop
+      vertex 63.2041 92.2436 3
+      vertex 63 92.25 0
+      vertex 63.2041 92.2436 0
+    endloop
+  endfacet
+  facet normal 0.827045 0.562136 0
+    outer loop
+      vertex 60.3707 87.0897 3
+      vertex 60.2559 87.2586 0
+      vertex 60.2559 87.2586 3
+    endloop
+  endfacet
+  facet normal 0.827045 0.562136 0
+    outer loop
+      vertex 60.2559 87.2586 0
+      vertex 60.3707 87.0897 3
+      vertex 60.3707 87.0897 0
+    endloop
+  endfacet
+  facet normal -0.21802 0.975944 0
+    outer loop
+      vertex 63.8082 85.8521 0
+      vertex 63.609 85.8076 7.5
+      vertex 63.8082 85.8521 7.5
+    endloop
+  endfacet
+  facet normal -0.21802 0.975944 0
+    outer loop
+      vertex 63.609 85.8076 7.5
+      vertex 63.8082 85.8521 0
+      vertex 63.609 85.8076 0
+    endloop
+  endfacet
+  facet normal -0.50901 -0.860761 0
+    outer loop
+      vertex 64.5657 91.848 0
+      vertex 64.7414 91.7441 3
+      vertex 64.5657 91.848 3
+    endloop
+  endfacet
+  facet normal -0.50901 -0.860761 -0
+    outer loop
+      vertex 64.7414 91.7441 3
+      vertex 64.5657 91.848 0
+      vertex 64.7414 91.7441 0
+    endloop
+  endfacet
+  facet normal -0.827045 0.562136 0
+    outer loop
+      vertex 65.6293 87.0897 0
+      vertex 65.7441 87.2586 3
+      vertex 65.7441 87.2586 0
+    endloop
+  endfacet
+  facet normal -0.827045 0.562136 0
+    outer loop
+      vertex 65.7441 87.2586 3
+      vertex 65.6293 87.0897 0
+      vertex 65.6293 87.0897 3
+    endloop
+  endfacet
+  facet normal -0.0940692 0.995566 0
+    outer loop
+      vertex 63.4073 85.7756 0
+      vertex 63.2041 85.7564 7.5
+      vertex 63.4073 85.7756 7.5
+    endloop
+  endfacet
+  facet normal -0.0940692 0.995566 0
+    outer loop
+      vertex 63.2041 85.7564 7.5
+      vertex 63.4073 85.7756 0
+      vertex 63.2041 85.7564 0
+    endloop
+  endfacet
+  facet normal 0.397168 -0.917746 0
+    outer loop
+      vertex 61.6162 91.9407 0
+      vertex 61.8036 92.0218 3
+      vertex 61.6162 91.9407 3
+    endloop
+  endfacet
+  facet normal 0.397168 -0.917746 0
+    outer loop
+      vertex 61.8036 92.0218 3
+      vertex 61.6162 91.9407 0
+      vertex 61.8036 92.0218 0
+    endloop
+  endfacet
+  facet normal 0.975944 0.21802 0
+    outer loop
+      vertex 59.8521 88.1918 3
+      vertex 59.8076 88.391 0
+      vertex 59.8076 88.391 3
+    endloop
+  endfacet
+  facet normal 0.975944 0.21802 0
+    outer loop
+      vertex 59.8076 88.391 0
+      vertex 59.8521 88.1918 3
+      vertex 59.8521 88.1918 0
+    endloop
+  endfacet
+  facet normal 0.454058 0.890972 -0
+    outer loop
+      vertex 61.6162 86.0593 0
+      vertex 61.4343 86.152 3
+      vertex 61.6162 86.0593 3
+    endloop
+  endfacet
+  facet normal 0.454058 0.890972 0
+    outer loop
+      vertex 61.4343 86.152 3
+      vertex 61.6162 86.0593 0
+      vertex 61.4343 86.152 0
+    endloop
+  endfacet
+  facet normal 0.50901 -0.860761 0
+    outer loop
+      vertex 61.2586 91.7441 0
+      vertex 61.4343 91.848 3
+      vertex 61.2586 91.7441 3
+    endloop
+  endfacet
+  facet normal 0.50901 -0.860761 0
+    outer loop
+      vertex 61.4343 91.848 3
+      vertex 61.2586 91.7441 0
+      vertex 61.4343 91.848 0
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 0
+    outer loop
+      vertex 65.2248 86.6309 0
+      vertex 65.3691 86.7752 3
+      vertex 65.3691 86.7752 0
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 0
+    outer loop
+      vertex 65.3691 86.7752 3
+      vertex 65.2248 86.6309 0
+      vertex 65.2248 86.6309 3
+    endloop
+  endfacet
+  facet normal 0.156692 0.987648 -0
+    outer loop
+      vertex 62.5927 85.7756 0
+      vertex 62.391 85.8076 7.5
+      vertex 62.5927 85.7756 7.5
+    endloop
+  endfacet
+  facet normal 0.156692 0.987648 0
+    outer loop
+      vertex 62.391 85.8076 7.5
+      vertex 62.5927 85.7756 0
+      vertex 62.391 85.8076 0
+    endloop
+  endfacet
+  facet normal 0.999509 -0.0313418 0
+    outer loop
+      vertex 59.75 89 3
+      vertex 59.7564 89.2041 0
+      vertex 59.7564 89.2041 3
+    endloop
+  endfacet
+  facet normal 0.999509 -0.0313418 0
+    outer loop
+      vertex 59.7564 89.2041 0
+      vertex 59.75 89 3
+      vertex 59.75 89 0
+    endloop
+  endfacet
+  facet normal -0.279116 0.960257 0
+    outer loop
+      vertex 64.0043 85.9091 0
+      vertex 63.8082 85.8521 7.5
+      vertex 64.0043 85.9091 7.5
+    endloop
+  endfacet
+  facet normal -0.279116 0.960257 0
+    outer loop
+      vertex 63.8082 85.8521 7.5
+      vertex 64.0043 85.9091 0
+      vertex 63.8082 85.8521 0
+    endloop
+  endfacet
+  facet normal -0.661411 0.750024 0
+    outer loop
+      vertex 65.2248 86.6309 0
+      vertex 65.0716 86.4958 3
+      vertex 65.2248 86.6309 3
+    endloop
+  endfacet
+  facet normal -0.661411 0.750024 0
+    outer loop
+      vertex 65.0716 86.4958 3
+      vertex 65.2248 86.6309 0
+      vertex 65.0716 86.4958 0
+    endloop
+  endfacet
+  facet normal 0.0940692 -0.995566 0
+    outer loop
+      vertex 62.5927 92.2244 0
+      vertex 62.7959 92.2436 3
+      vertex 62.5927 92.2244 3
+    endloop
+  endfacet
+  facet normal 0.0940692 -0.995566 0
+    outer loop
+      vertex 62.7959 92.2436 3
+      vertex 62.5927 92.2244 0
+      vertex 62.7959 92.2436 0
+    endloop
+  endfacet
+  facet normal -0.661411 -0.750024 0
+    outer loop
+      vertex 65.0716 91.5042 0
+      vertex 65.2248 91.3691 3
+      vertex 65.0716 91.5042 3
+    endloop
+  endfacet
+  facet normal -0.661411 -0.750024 -0
+    outer loop
+      vertex 65.2248 91.3691 3
+      vertex 65.0716 91.5042 0
+      vertex 65.2248 91.3691 0
+    endloop
+  endfacet
+  facet normal -0.612855 0.790196 0
+    outer loop
+      vertex 65.0716 86.4958 0
+      vertex 64.9103 86.3707 3
+      vertex 65.0716 86.4958 3
+    endloop
+  endfacet
+  facet normal -0.612855 0.790196 0
+    outer loop
+      vertex 64.9103 86.3707 3
+      vertex 65.0716 86.4958 0
+      vertex 64.9103 86.3707 0
+    endloop
+  endfacet
+  facet normal 0.21802 0.975944 -0
+    outer loop
+      vertex 62.391 85.8076 0
+      vertex 62.1918 85.8521 7.5
+      vertex 62.391 85.8076 7.5
+    endloop
+  endfacet
+  facet normal 0.21802 0.975944 0
+    outer loop
+      vertex 62.1918 85.8521 7.5
+      vertex 62.391 85.8076 0
+      vertex 62.1918 85.8521 0
+    endloop
+  endfacet
+  facet normal -0.975944 0.21802 0
+    outer loop
+      vertex 66.1479 88.1918 0
+      vertex 66.1924 88.391 3
+      vertex 66.1924 88.391 0
+    endloop
+  endfacet
+  facet normal -0.975944 0.21802 0
+    outer loop
+      vertex 66.1924 88.391 3
+      vertex 66.1479 88.1918 0
+      vertex 66.1479 88.1918 3
+    endloop
+  endfacet
+  facet normal 0.156692 -0.987648 0
+    outer loop
+      vertex 62.391 92.1924 0
+      vertex 62.5927 92.2244 3
+      vertex 62.391 92.1924 3
+    endloop
+  endfacet
+  facet normal 0.156692 -0.987648 0
+    outer loop
+      vertex 62.5927 92.2244 3
+      vertex 62.391 92.1924 0
+      vertex 62.5927 92.2244 0
+    endloop
+  endfacet
+  facet normal -0.454058 0.890972 0
+    outer loop
+      vertex 64.5657 86.152 0
+      vertex 64.3838 86.0593 3
+      vertex 64.5657 86.152 3
+    endloop
+  endfacet
+  facet normal -0.454058 0.890972 0
+    outer loop
+      vertex 64.3838 86.0593 3
+      vertex 64.5657 86.152 0
+      vertex 64.3838 86.0593 0
+    endloop
+  endfacet
+  facet normal 0.999509 0.0313418 0
+    outer loop
+      vertex 59.7564 88.7959 3
+      vertex 59.75 89 0
+      vertex 59.75 89 3
+    endloop
+  endfacet
+  facet normal 0.999509 0.0313418 0
+    outer loop
+      vertex 59.75 89 0
+      vertex 59.7564 88.7959 3
+      vertex 59.7564 88.7959 0
+    endloop
+  endfacet
+  facet normal -0.397168 -0.917746 0
+    outer loop
+      vertex 64.1964 92.0218 0
+      vertex 64.3838 91.9407 3
+      vertex 64.1964 92.0218 3
+    endloop
+  endfacet
+  facet normal -0.397168 -0.917746 -0
+    outer loop
+      vertex 64.3838 91.9407 3
+      vertex 64.1964 92.0218 0
+      vertex 64.3838 91.9407 0
+    endloop
+  endfacet
+  facet normal 0.750024 0.661411 0
+    outer loop
+      vertex 60.6309 86.7752 3
+      vertex 60.4958 86.9284 0
+      vertex 60.4958 86.9284 3
+    endloop
+  endfacet
+  facet normal 0.750024 0.661411 0
+    outer loop
+      vertex 60.4958 86.9284 0
+      vertex 60.6309 86.7752 3
+      vertex 60.6309 86.7752 0
+    endloop
+  endfacet
+  facet normal -0.890972 0.454058 0
+    outer loop
+      vertex 65.848 87.4343 0
+      vertex 65.9407 87.6162 3
+      vertex 65.9407 87.6162 0
+    endloop
+  endfacet
+  facet normal -0.890972 0.454058 0
+    outer loop
+      vertex 65.9407 87.6162 3
+      vertex 65.848 87.4343 0
+      vertex 65.848 87.4343 3
+    endloop
+  endfacet
+  facet normal -0.860761 -0.50901 0
+    outer loop
+      vertex 65.848 90.5657 0
+      vertex 65.7441 90.7414 3
+      vertex 65.7441 90.7414 0
+    endloop
+  endfacet
+  facet normal -0.860761 -0.50901 0
+    outer loop
+      vertex 65.7441 90.7414 3
+      vertex 65.848 90.5657 0
+      vertex 65.848 90.5657 3
+    endloop
+  endfacet
+  facet normal 0.917746 -0.397168 0
+    outer loop
+      vertex 59.9782 90.1964 3
+      vertex 60.0593 90.3838 0
+      vertex 60.0593 90.3838 3
+    endloop
+  endfacet
+  facet normal 0.917746 -0.397168 0
+    outer loop
+      vertex 60.0593 90.3838 0
+      vertex 59.9782 90.1964 3
+      vertex 59.9782 90.1964 0
+    endloop
+  endfacet
+  facet normal 0.454058 -0.890972 0
+    outer loop
+      vertex 61.4343 91.848 0
+      vertex 61.6162 91.9407 3
+      vertex 61.4343 91.848 3
+    endloop
+  endfacet
+  facet normal 0.454058 -0.890972 0
+    outer loop
+      vertex 61.6162 91.9407 3
+      vertex 61.4343 91.848 0
+      vertex 61.6162 91.9407 0
+    endloop
+  endfacet
+  facet normal 0.612855 0.790196 -0
+    outer loop
+      vertex 61.0897 86.3707 0
+      vertex 60.9284 86.4958 3
+      vertex 61.0897 86.3707 3
+    endloop
+  endfacet
+  facet normal 0.612855 0.790196 0
+    outer loop
+      vertex 60.9284 86.4958 3
+      vertex 61.0897 86.3707 0
+      vertex 60.9284 86.4958 0
+    endloop
+  endfacet
+  facet normal 0.0940692 0.995566 -0
+    outer loop
+      vertex 62.7959 85.7564 0
+      vertex 62.5927 85.7756 7.5
+      vertex 62.7959 85.7564 7.5
+    endloop
+  endfacet
+  facet normal 0.0940692 0.995566 0
+    outer loop
+      vertex 62.5927 85.7756 7.5
+      vertex 62.7959 85.7564 0
+      vertex 62.5927 85.7756 0
+    endloop
+  endfacet
+  facet normal -0.995566 0.0940692 0
+    outer loop
+      vertex 66.2244 88.5927 0
+      vertex 66.2436 88.7959 3
+      vertex 66.2436 88.7959 0
+    endloop
+  endfacet
+  facet normal -0.995566 0.0940692 0
+    outer loop
+      vertex 66.2436 88.7959 3
+      vertex 66.2244 88.5927 0
+      vertex 66.2244 88.5927 3
+    endloop
+  endfacet
+  facet normal 0.790196 -0.612855 0
+    outer loop
+      vertex 60.3707 90.9103 3
+      vertex 60.4958 91.0716 0
+      vertex 60.4958 91.0716 3
+    endloop
+  endfacet
+  facet normal 0.790196 -0.612855 0
+    outer loop
+      vertex 60.4958 91.0716 0
+      vertex 60.3707 90.9103 3
+      vertex 60.3707 90.9103 0
+    endloop
+  endfacet
+  facet normal -0.393919 0.919145 0
+    outer loop
+      vertex 64.3838 86.0593 3
+      vertex 64.3838 86.0593 0
+      vertex 64.3775 86.0566 3
+    endloop
+  endfacet
+  facet normal -0.39728 0.917697 0
+    outer loop
+      vertex 64.3775 86.0566 3
+      vertex 64.1964 85.9782 7.5
+      vertex 64.3775 86.0566 7.5
+    endloop
+  endfacet
+  facet normal -0.397168 0.917746 -8.08048e-06
+    outer loop
+      vertex 64.1964 85.9782 0
+      vertex 64.3775 86.0566 3
+      vertex 64.3838 86.0593 0
+    endloop
+  endfacet
+  facet normal -0.39728 0.917697 0
+    outer loop
+      vertex 64.3775 86.0566 3
+      vertex 64.1964 85.9782 0
+      vertex 64.1964 85.9782 7.5
+    endloop
+  endfacet
+  facet normal -0.156692 0.987648 0
+    outer loop
+      vertex 63.609 85.8076 0
+      vertex 63.4073 85.7756 7.5
+      vertex 63.609 85.8076 7.5
+    endloop
+  endfacet
+  facet normal -0.156692 0.987648 0
+    outer loop
+      vertex 63.4073 85.7756 7.5
+      vertex 63.609 85.8076 0
+      vertex 63.4073 85.7756 0
+    endloop
+  endfacet
+  facet normal 0.0313418 -0.999509 0
+    outer loop
+      vertex 62.7959 92.2436 0
+      vertex 63 92.25 3
+      vertex 62.7959 92.2436 3
+    endloop
+  endfacet
+  facet normal 0.0313418 -0.999509 0
+    outer loop
+      vertex 63 92.25 3
+      vertex 62.7959 92.2436 0
+      vertex 63 92.25 0
+    endloop
+  endfacet
+  facet normal 0.975944 -0.21802 0
+    outer loop
+      vertex 59.8076 89.609 3
+      vertex 59.8521 89.8082 0
+      vertex 59.8521 89.8082 3
+    endloop
+  endfacet
+  facet normal 0.975944 -0.21802 0
+    outer loop
+      vertex 59.8521 89.8082 0
+      vertex 59.8076 89.609 3
+      vertex 59.8076 89.609 0
+    endloop
+  endfacet
+  facet normal 0.21802 -0.975944 0
+    outer loop
+      vertex 62.1918 92.1479 0
+      vertex 62.391 92.1924 3
+      vertex 62.1918 92.1479 3
+    endloop
+  endfacet
+  facet normal 0.21802 -0.975944 0
+    outer loop
+      vertex 62.391 92.1924 3
+      vertex 62.1918 92.1479 0
+      vertex 62.391 92.1924 0
+    endloop
+  endfacet
+  facet normal 0.790196 0.612855 0
+    outer loop
+      vertex 60.4958 86.9284 3
+      vertex 60.3707 87.0897 0
+      vertex 60.3707 87.0897 3
+    endloop
+  endfacet
+  facet normal 0.790196 0.612855 0
+    outer loop
+      vertex 60.3707 87.0897 0
+      vertex 60.4958 86.9284 3
+      vertex 60.4958 86.9284 0
+    endloop
+  endfacet
+  facet normal -0.960257 -0.279116 0
+    outer loop
+      vertex 66.1479 89.8082 0
+      vertex 66.0909 90.0043 3
+      vertex 66.0909 90.0043 0
+    endloop
+  endfacet
+  facet normal -0.960257 -0.279116 0
+    outer loop
+      vertex 66.0909 90.0043 3
+      vertex 66.1479 89.8082 0
+      vertex 66.1479 89.8082 3
+    endloop
+  endfacet
+  facet normal 0.960257 0.279116 0
+    outer loop
+      vertex 59.9091 87.9957 3
+      vertex 59.8521 88.1918 0
+      vertex 59.8521 88.1918 3
+    endloop
+  endfacet
+  facet normal 0.960257 0.279116 0
+    outer loop
+      vertex 59.8521 88.1918 0
+      vertex 59.9091 87.9957 3
+      vertex 59.9091 87.9957 0
+    endloop
+  endfacet
+  facet normal 0.987648 -0.156692 0
+    outer loop
+      vertex 59.7756 89.4073 3
+      vertex 59.8076 89.609 0
+      vertex 59.8076 89.609 3
+    endloop
+  endfacet
+  facet normal 0.987648 -0.156692 0
+    outer loop
+      vertex 59.8076 89.609 0
+      vertex 59.7756 89.4073 3
+      vertex 59.7756 89.4073 0
+    endloop
+  endfacet
+  facet normal -0.960257 0.279116 0
+    outer loop
+      vertex 66.0909 87.9957 0
+      vertex 66.1479 88.1918 3
+      vertex 66.1479 88.1918 0
+    endloop
+  endfacet
+  facet normal -0.960257 0.279116 0
+    outer loop
+      vertex 66.1479 88.1918 3
+      vertex 66.0909 87.9957 0
+      vertex 66.0909 87.9957 3
+    endloop
+  endfacet
+  facet normal 0.917746 0.397168 0
+    outer loop
+      vertex 60.0593 87.6162 3
+      vertex 59.9782 87.8036 0
+      vertex 59.9782 87.8036 3
+    endloop
+  endfacet
+  facet normal 0.917746 0.397168 0
+    outer loop
+      vertex 59.9782 87.8036 0
+      vertex 60.0593 87.6162 3
+      vertex 60.0593 87.6162 0
+    endloop
+  endfacet
+  facet normal 0.338477 -0.940975 0
+    outer loop
+      vertex 61.8036 92.0218 0
+      vertex 61.9957 92.0909 3
+      vertex 61.8036 92.0218 3
+    endloop
+  endfacet
+  facet normal 0.338477 -0.940975 0
+    outer loop
+      vertex 61.9957 92.0909 3
+      vertex 61.8036 92.0218 0
+      vertex 61.9957 92.0909 0
+    endloop
+  endfacet
+  facet normal 0.0313418 0.999509 -0
+    outer loop
+      vertex 63 85.75 0
+      vertex 62.7959 85.7564 7.5
+      vertex 63 85.75 7.5
+    endloop
+  endfacet
+  facet normal 0.0313418 0.999509 0
+    outer loop
+      vertex 62.7959 85.7564 7.5
+      vertex 63 85.75 0
+      vertex 62.7959 85.7564 0
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex 65.3691 91.2248 0
+      vertex 65.2248 91.3691 3
+      vertex 65.2248 91.3691 0
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex 65.2248 91.3691 3
+      vertex 65.3691 91.2248 0
+      vertex 65.3691 91.2248 3
+    endloop
+  endfacet
+  facet normal 0.337983 0.941152 0
+    outer loop
+      vertex 61.9957 85.9091 7.5
+      vertex 61.9233 85.9351 3
+      vertex 61.9233 85.9351 7.5
+    endloop
+  endfacet
+  facet normal 0.337983 0.941152 -0
+    outer loop
+      vertex 61.9957 85.9091 0
+      vertex 61.9233 85.9351 3
+      vertex 61.9957 85.9091 7.5
+    endloop
+  endfacet
+  facet normal 0.338477 0.940975 1.34542e-05
+    outer loop
+      vertex 61.8036 85.9782 0
+      vertex 61.9233 85.9351 3
+      vertex 61.9957 85.9091 0
+    endloop
+  endfacet
+  facet normal 0.338775 0.940867 0
+    outer loop
+      vertex 61.9233 85.9351 3
+      vertex 61.8036 85.9782 0
+      vertex 61.8036 85.9782 3
+    endloop
+  endfacet
+  facet normal -0.279116 -0.960257 0
+    outer loop
+      vertex 63.8082 92.1479 0
+      vertex 64.0043 92.0909 3
+      vertex 63.8082 92.1479 3
+    endloop
+  endfacet
+  facet normal -0.279116 -0.960257 -0
+    outer loop
+      vertex 64.0043 92.0909 3
+      vertex 63.8082 92.1479 0
+      vertex 64.0043 92.0909 0
+    endloop
+  endfacet
+  facet normal -0.940975 0.338477 0
+    outer loop
+      vertex 66.0218 87.8036 0
+      vertex 66.0909 87.9957 3
+      vertex 66.0909 87.9957 0
+    endloop
+  endfacet
+  facet normal -0.940975 0.338477 0
+    outer loop
+      vertex 66.0909 87.9957 3
+      vertex 66.0218 87.8036 0
+      vertex 66.0218 87.8036 3
+    endloop
+  endfacet
+  facet normal -0.338477 -0.940975 0
+    outer loop
+      vertex 64.0043 92.0909 0
+      vertex 64.1964 92.0218 3
+      vertex 64.0043 92.0909 3
+    endloop
+  endfacet
+  facet normal -0.338477 -0.940975 -0
+    outer loop
+      vertex 64.1964 92.0218 3
+      vertex 64.0043 92.0909 0
+      vertex 64.1964 92.0218 0
+    endloop
+  endfacet
+  facet normal -0.790196 -0.612855 0
+    outer loop
+      vertex 65.6293 90.9103 0
+      vertex 65.5042 91.0716 3
+      vertex 65.5042 91.0716 0
+    endloop
+  endfacet
+  facet normal -0.790196 -0.612855 0
+    outer loop
+      vertex 65.5042 91.0716 3
+      vertex 65.6293 90.9103 0
+      vertex 65.6293 90.9103 3
+    endloop
+  endfacet
+  facet normal -0.612855 -0.790196 0
+    outer loop
+      vertex 64.9103 91.6293 0
+      vertex 65.0716 91.5042 3
+      vertex 64.9103 91.6293 3
+    endloop
+  endfacet
+  facet normal -0.612855 -0.790196 -0
+    outer loop
+      vertex 65.0716 91.5042 3
+      vertex 64.9103 91.6293 0
+      vertex 65.0716 91.5042 0
+    endloop
+  endfacet
+  facet normal 0.987648 0.156692 0
+    outer loop
+      vertex 59.8076 88.391 3
+      vertex 59.7756 88.5927 0
+      vertex 59.7756 88.5927 3
+    endloop
+  endfacet
+  facet normal 0.987648 0.156692 0
+    outer loop
+      vertex 59.7756 88.5927 0
+      vertex 59.8076 88.391 3
+      vertex 59.8076 88.391 0
+    endloop
+  endfacet
+  facet normal -0.917746 0.397168 0
+    outer loop
+      vertex 65.9407 87.6162 0
+      vertex 66.0218 87.8036 3
+      vertex 66.0218 87.8036 0
+    endloop
+  endfacet
+  facet normal -0.917746 0.397168 0
+    outer loop
+      vertex 66.0218 87.8036 3
+      vertex 65.9407 87.6162 0
+      vertex 65.9407 87.6162 3
+    endloop
+  endfacet
+  facet normal -0.21802 -0.975944 0
+    outer loop
+      vertex 63.609 92.1924 0
+      vertex 63.8082 92.1479 3
+      vertex 63.609 92.1924 3
+    endloop
+  endfacet
+  facet normal -0.21802 -0.975944 -0
+    outer loop
+      vertex 63.8082 92.1479 3
+      vertex 63.609 92.1924 0
+      vertex 63.8082 92.1479 0
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 0
+    outer loop
+      vertex 60.6309 91.2248 3
+      vertex 60.7752 91.3691 0
+      vertex 60.7752 91.3691 3
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 0
+    outer loop
+      vertex 60.7752 91.3691 0
+      vertex 60.6309 91.2248 3
+      vertex 60.6309 91.2248 0
+    endloop
+  endfacet
+  facet normal 0.890972 0.454058 0
+    outer loop
+      vertex 60.152 87.4343 3
+      vertex 60.0593 87.6162 0
+      vertex 60.0593 87.6162 3
+    endloop
+  endfacet
+  facet normal 0.890972 0.454058 0
+    outer loop
+      vertex 60.0593 87.6162 0
+      vertex 60.152 87.4343 3
+      vertex 60.152 87.4343 0
+    endloop
+  endfacet
+  facet normal -0.0313418 0.999509 0
+    outer loop
+      vertex 63.2041 85.7564 0
+      vertex 63 85.75 7.5
+      vertex 63.2041 85.7564 7.5
+    endloop
+  endfacet
+  facet normal -0.0313418 0.999509 0
+    outer loop
+      vertex 63 85.75 7.5
+      vertex 63.2041 85.7564 0
+      vertex 63 85.75 0
+    endloop
+  endfacet
+  facet normal -0.0940692 -0.995566 0
+    outer loop
+      vertex 63.2041 92.2436 0
+      vertex 63.4073 92.2244 3
+      vertex 63.2041 92.2436 3
+    endloop
+  endfacet
+  facet normal -0.0940692 -0.995566 -0
+    outer loop
+      vertex 63.4073 92.2244 3
+      vertex 63.2041 92.2436 0
+      vertex 63.4073 92.2244 0
+    endloop
+  endfacet
+  facet normal 0.995566 0.0940692 0
+    outer loop
+      vertex 59.7756 88.5927 3
+      vertex 59.7564 88.7959 0
+      vertex 59.7564 88.7959 3
+    endloop
+  endfacet
+  facet normal 0.995566 0.0940692 0
+    outer loop
+      vertex 59.7564 88.7959 0
+      vertex 59.7756 88.5927 3
+      vertex 59.7756 88.5927 0
+    endloop
+  endfacet
+  facet normal 0.860761 -0.50901 0
+    outer loop
+      vertex 60.152 90.5657 3
+      vertex 60.2559 90.7414 0
+      vertex 60.2559 90.7414 3
+    endloop
+  endfacet
+  facet normal 0.860761 -0.50901 0
+    outer loop
+      vertex 60.2559 90.7414 0
+      vertex 60.152 90.5657 3
+      vertex 60.152 90.5657 0
+    endloop
+  endfacet
+  facet normal 0.562136 0.827045 -0
+    outer loop
+      vertex 61.2586 86.2559 0
+      vertex 61.0897 86.3707 3
+      vertex 61.2586 86.2559 3
+    endloop
+  endfacet
+  facet normal 0.562136 0.827045 0
+    outer loop
+      vertex 61.0897 86.3707 3
+      vertex 61.2586 86.2559 0
+      vertex 61.0897 86.3707 0
+    endloop
+  endfacet
+  facet normal 0.860761 0.50901 0
+    outer loop
+      vertex 60.2559 87.2586 3
+      vertex 60.152 87.4343 0
+      vertex 60.152 87.4343 3
+    endloop
+  endfacet
+  facet normal 0.860761 0.50901 0
+    outer loop
+      vertex 60.152 87.4343 0
+      vertex 60.2559 87.2586 3
+      vertex 60.2559 87.2586 0
+    endloop
+  endfacet
+  facet normal 0.940975 -0.338477 0
+    outer loop
+      vertex 59.9091 90.0043 3
+      vertex 59.9782 90.1964 0
+      vertex 59.9782 90.1964 3
+    endloop
+  endfacet
+  facet normal 0.940975 -0.338477 0
+    outer loop
+      vertex 59.9782 90.1964 0
+      vertex 59.9091 90.0043 3
+      vertex 59.9091 90.0043 0
+    endloop
+  endfacet
+  facet normal 0.661411 0.750024 -0
+    outer loop
+      vertex 60.9284 86.4958 0
+      vertex 60.7752 86.6309 3
+      vertex 60.9284 86.4958 3
+    endloop
+  endfacet
+  facet normal 0.661411 0.750024 0
+    outer loop
+      vertex 60.7752 86.6309 3
+      vertex 60.9284 86.4958 0
+      vertex 60.7752 86.6309 0
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 0
+    outer loop
+      vertex 60.7752 86.6309 3
+      vertex 60.6309 86.7752 0
+      vertex 60.6309 86.7752 3
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 0
+    outer loop
+      vertex 60.6309 86.7752 0
+      vertex 60.7752 86.6309 3
+      vertex 60.7752 86.6309 0
+    endloop
+  endfacet
+  facet normal 0.562136 -0.827045 0
+    outer loop
+      vertex 61.0897 91.6293 0
+      vertex 61.2586 91.7441 3
+      vertex 61.0897 91.6293 3
+    endloop
+  endfacet
+  facet normal 0.562136 -0.827045 0
+    outer loop
+      vertex 61.2586 91.7441 3
+      vertex 61.0897 91.6293 0
+      vertex 61.2586 91.7441 0
+    endloop
+  endfacet
+  facet normal -0.50901 0.860761 0
+    outer loop
+      vertex 64.7414 86.2559 0
+      vertex 64.5657 86.152 3
+      vertex 64.7414 86.2559 3
+    endloop
+  endfacet
+  facet normal -0.50901 0.860761 0
+    outer loop
+      vertex 64.5657 86.152 3
+      vertex 64.7414 86.2559 0
+      vertex 64.5657 86.152 0
+    endloop
+  endfacet
+  facet normal 0.960257 -0.279116 0
+    outer loop
+      vertex 59.8521 89.8082 3
+      vertex 59.9091 90.0043 0
+      vertex 59.9091 90.0043 3
+    endloop
+  endfacet
+  facet normal 0.960257 -0.279116 0
+    outer loop
+      vertex 59.9091 90.0043 0
+      vertex 59.8521 89.8082 3
+      vertex 59.8521 89.8082 0
+    endloop
+  endfacet
+  facet normal 0.750024 -0.661411 0
+    outer loop
+      vertex 60.4958 91.0716 3
+      vertex 60.6309 91.2248 0
+      vertex 60.6309 91.2248 3
+    endloop
+  endfacet
+  facet normal 0.750024 -0.661411 0
+    outer loop
+      vertex 60.6309 91.2248 0
+      vertex 60.4958 91.0716 3
+      vertex 60.4958 91.0716 0
+    endloop
+  endfacet
+  facet normal 0.612855 -0.790196 0
+    outer loop
+      vertex 60.9284 91.5042 0
+      vertex 61.0897 91.6293 3
+      vertex 60.9284 91.5042 3
+    endloop
+  endfacet
+  facet normal 0.612855 -0.790196 0
+    outer loop
+      vertex 61.0897 91.6293 3
+      vertex 60.9284 91.5042 0
+      vertex 61.0897 91.6293 0
+    endloop
+  endfacet
+  facet normal -0.562136 0.827045 0
+    outer loop
+      vertex 64.9103 86.3707 0
+      vertex 64.7414 86.2559 3
+      vertex 64.9103 86.3707 3
+    endloop
+  endfacet
+  facet normal -0.562136 0.827045 0
+    outer loop
+      vertex 64.7414 86.2559 3
+      vertex 64.9103 86.3707 0
+      vertex 64.7414 86.2559 0
+    endloop
+  endfacet
+  facet normal 0.940975 0.338477 0
+    outer loop
+      vertex 59.9782 87.8036 3
+      vertex 59.9091 87.9957 0
+      vertex 59.9091 87.9957 3
+    endloop
+  endfacet
+  facet normal 0.940975 0.338477 0
+    outer loop
+      vertex 59.9091 87.9957 0
+      vertex 59.9782 87.8036 3
+      vertex 59.9782 87.8036 0
+    endloop
+  endfacet
+  facet normal 0.890972 -0.454058 0
+    outer loop
+      vertex 60.0593 90.3838 3
+      vertex 60.152 90.5657 0
+      vertex 60.152 90.5657 3
+    endloop
+  endfacet
+  facet normal 0.890972 -0.454058 0
+    outer loop
+      vertex 60.152 90.5657 0
+      vertex 60.0593 90.3838 3
+      vertex 60.0593 90.3838 0
+    endloop
+  endfacet
+  facet normal -0.454036 -0.890983 0
+    outer loop
+      vertex 74.0449 48.5959 0
+      vertex 74.5767 48.3249 3
+      vertex 74.0449 48.5959 3
+    endloop
+  endfacet
+  facet normal -0.454036 -0.890983 -0
+    outer loop
+      vertex 74.5767 48.3249 3
+      vertex 74.0449 48.5959 0
+      vertex 74.5767 48.3249 0
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 0
+    outer loop
+      vertex 63.0748 46.5032 3
+      vertex 63.4968 46.9252 0
+      vertex 63.4968 46.9252 3
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 0
+    outer loop
+      vertex 63.4968 46.9252 0
+      vertex 63.0748 46.5032 3
+      vertex 63.0748 46.5032 0
+    endloop
+  endfacet
+  facet normal -0.995557 -0.0941607 0
+    outer loop
+      vertex 79.4813 40.5965 0
+      vertex 79.4251 41.1907 3
+      vertex 79.4251 41.1907 0
+    endloop
+  endfacet
+  facet normal -0.995557 -0.0941607 0
+    outer loop
+      vertex 79.4251 41.1907 3
+      vertex 79.4813 40.5965 0
+      vertex 79.4813 40.5965 3
+    endloop
+  endfacet
+  facet normal -0.999509 -0.0313341 0
+    outer loop
+      vertex 79.5 40 0
+      vertex 79.4813 40.5965 3
+      vertex 79.4813 40.5965 0
+    endloop
+  endfacet
+  facet normal -0.999509 -0.0313341 0
+    outer loop
+      vertex 79.4813 40.5965 3
+      vertex 79.5 40 0
+      vertex 79.5 40 3
+    endloop
+  endfacet
+  facet normal -0.454036 0.890983 0
+    outer loop
+      vertex 74.5767 31.6751 0
+      vertex 74.0449 31.4041 3
+      vertex 74.5767 31.6751 3
+    endloop
+  endfacet
+  facet normal -0.454036 0.890983 0
+    outer loop
+      vertex 74.0449 31.4041 3
+      vertex 74.5767 31.6751 0
+      vertex 74.0449 31.4041 0
+    endloop
+  endfacet
+  facet normal 0.562026 0.82712 -0
+    outer loop
+      vertex 64.9096 31.9789 0
+      vertex 64.416 32.3143 3
+      vertex 64.9096 31.9789 3
+    endloop
+  endfacet
+  facet normal 0.562026 0.82712 0
+    outer loop
+      vertex 64.416 32.3143 3
+      vertex 64.9096 31.9789 0
+      vertex 64.416 32.3143 0
+    endloop
+  endfacet
+  facet normal -0.860743 -0.50904 0
+    outer loop
+      vertex 78.3249 44.5767 0
+      vertex 78.0211 45.0904 3
+      vertex 78.0211 45.0904 0
+    endloop
+  endfacet
+  facet normal -0.860743 -0.50904 0
+    outer loop
+      vertex 78.0211 45.0904 3
+      vertex 78.3249 44.5767 0
+      vertex 78.3249 44.5767 3
+    endloop
+  endfacet
+  facet normal -0.82712 -0.562026 0
+    outer loop
+      vertex 78.0211 45.0904 0
+      vertex 77.6857 45.584 3
+      vertex 77.6857 45.584 0
+    endloop
+  endfacet
+  facet normal -0.82712 -0.562026 0
+    outer loop
+      vertex 77.6857 45.584 3
+      vertex 78.0211 45.0904 0
+      vertex 78.0211 45.0904 3
+    endloop
+  endfacet
+  facet normal -0.0941607 0.995557 0
+    outer loop
+      vertex 71.1907 30.5749 0
+      vertex 70.5965 30.5187 3
+      vertex 71.1907 30.5749 3
+    endloop
+  endfacet
+  facet normal -0.0941607 0.995557 0
+    outer loop
+      vertex 70.5965 30.5187 3
+      vertex 71.1907 30.5749 0
+      vertex 70.5965 30.5187 0
+    endloop
+  endfacet
+  facet normal 0.0941607 -0.995557 0
+    outer loop
+      vertex 68.8093 49.4251 0
+      vertex 69.4035 49.4813 3
+      vertex 68.8093 49.4251 3
+    endloop
+  endfacet
+  facet normal 0.0941607 -0.995557 0
+    outer loop
+      vertex 69.4035 49.4813 3
+      vertex 68.8093 49.4251 0
+      vertex 69.4035 49.4813 0
+    endloop
+  endfacet
+  facet normal 0.999509 0.0313341 0
+    outer loop
+      vertex 60.5187 39.4035 3
+      vertex 60.5 40 0
+      vertex 60.5 40 3
+    endloop
+  endfacet
+  facet normal 0.999509 0.0313341 0
+    outer loop
+      vertex 60.5 40 0
+      vertex 60.5187 39.4035 3
+      vertex 60.5187 39.4035 0
+    endloop
+  endfacet
+  facet normal -0.960294 -0.27899 0
+    outer loop
+      vertex 79.2015 42.3626 0
+      vertex 79.035 42.9357 3
+      vertex 79.035 42.9357 0
+    endloop
+  endfacet
+  facet normal -0.960294 -0.27899 0
+    outer loop
+      vertex 79.035 42.9357 3
+      vertex 79.2015 42.3626 0
+      vertex 79.2015 42.3626 3
+    endloop
+  endfacet
+  facet normal 0.0941607 0.995557 -0
+    outer loop
+      vertex 69.4035 30.5187 0
+      vertex 68.8093 30.5749 3
+      vertex 69.4035 30.5187 3
+    endloop
+  endfacet
+  facet normal 0.0941607 0.995557 0
+    outer loop
+      vertex 68.8093 30.5749 3
+      vertex 69.4035 30.5187 0
+      vertex 68.8093 30.5749 0
+    endloop
+  endfacet
+  facet normal -0.890983 -0.454036 0
+    outer loop
+      vertex 78.5959 44.0449 0
+      vertex 78.3249 44.5767 3
+      vertex 78.3249 44.5767 0
+    endloop
+  endfacet
+  facet normal -0.890983 -0.454036 0
+    outer loop
+      vertex 78.3249 44.5767 3
+      vertex 78.5959 44.0449 0
+      vertex 78.5959 44.0449 3
+    endloop
+  endfacet
+  facet normal 0.750112 0.661311 0
+    outer loop
+      vertex 63.0748 33.4968 3
+      vertex 62.6801 33.9445 0
+      vertex 62.6801 33.9445 3
+    endloop
+  endfacet
+  facet normal 0.750112 0.661311 0
+    outer loop
+      vertex 62.6801 33.9445 0
+      vertex 63.0748 33.4968 3
+      vertex 63.0748 33.4968 0
+    endloop
+  endfacet
+  facet normal 0.995557 -0.0941607 0
+    outer loop
+      vertex 60.5187 40.5965 3
+      vertex 60.5749 41.1907 0
+      vertex 60.5749 41.1907 3
+    endloop
+  endfacet
+  facet normal 0.995557 -0.0941607 0
+    outer loop
+      vertex 60.5749 41.1907 0
+      vertex 60.5187 40.5965 3
+      vertex 60.5187 40.5965 0
+    endloop
+  endfacet
+  facet normal -0.612977 -0.790101 0
+    outer loop
+      vertex 75.584 47.6857 0
+      vertex 76.0555 47.3199 3
+      vertex 75.584 47.6857 3
+    endloop
+  endfacet
+  facet normal -0.612977 -0.790101 -0
+    outer loop
+      vertex 76.0555 47.3199 3
+      vertex 75.584 47.6857 0
+      vertex 76.0555 47.3199 0
+    endloop
+  endfacet
+  facet normal 0.397132 -0.917761 0
+    outer loop
+      vertex 65.9551 48.5959 0
+      vertex 66.5028 48.8329 3
+      vertex 65.9551 48.5959 3
+    endloop
+  endfacet
+  facet normal 0.397132 -0.917761 0
+    outer loop
+      vertex 66.5028 48.8329 3
+      vertex 65.9551 48.5959 0
+      vertex 66.5028 48.8329 0
+    endloop
+  endfacet
+  facet normal 0.612977 0.790101 -0
+    outer loop
+      vertex 64.416 32.3143 0
+      vertex 63.9445 32.6801 3
+      vertex 64.416 32.3143 3
+    endloop
+  endfacet
+  facet normal 0.612977 0.790101 0
+    outer loop
+      vertex 63.9445 32.6801 3
+      vertex 64.416 32.3143 0
+      vertex 63.9445 32.6801 0
+    endloop
+  endfacet
+  facet normal -0.0313341 0.999509 0
+    outer loop
+      vertex 70.5965 30.5187 0
+      vertex 70 30.5 3
+      vertex 70.5965 30.5187 3
+    endloop
+  endfacet
+  facet normal -0.0313341 0.999509 0
+    outer loop
+      vertex 70 30.5 3
+      vertex 70.5965 30.5187 0
+      vertex 70 30.5 0
+    endloop
+  endfacet
+  facet normal -0.0941607 -0.995557 0
+    outer loop
+      vertex 70.5965 49.4813 0
+      vertex 71.1907 49.4251 3
+      vertex 70.5965 49.4813 3
+    endloop
+  endfacet
+  facet normal -0.0941607 -0.995557 -0
+    outer loop
+      vertex 71.1907 49.4251 3
+      vertex 70.5965 49.4813 0
+      vertex 71.1907 49.4251 0
+    endloop
+  endfacet
+  facet normal -0.33866 0.940909 0
+    outer loop
+      vertex 73.4972 31.1671 0
+      vertex 72.9357 30.965 3
+      vertex 73.4972 31.1671 3
+    endloop
+  endfacet
+  facet normal -0.33866 0.940909 0
+    outer loop
+      vertex 72.9357 30.965 3
+      vertex 73.4972 31.1671 0
+      vertex 72.9357 30.965 0
+    endloop
+  endfacet
+  facet normal -0.750112 0.661311 0
+    outer loop
+      vertex 76.9252 33.4968 0
+      vertex 77.3199 33.9445 3
+      vertex 77.3199 33.9445 0
+    endloop
+  endfacet
+  facet normal -0.750112 0.661311 0
+    outer loop
+      vertex 77.3199 33.9445 3
+      vertex 76.9252 33.4968 0
+      vertex 76.9252 33.4968 3
+    endloop
+  endfacet
+  facet normal 0.50904 0.860743 -0
+    outer loop
+      vertex 65.4233 31.6751 0
+      vertex 64.9096 31.9789 3
+      vertex 65.4233 31.6751 3
+    endloop
+  endfacet
+  facet normal 0.50904 0.860743 0
+    outer loop
+      vertex 64.9096 31.9789 3
+      vertex 65.4233 31.6751 0
+      vertex 64.9096 31.9789 0
+    endloop
+  endfacet
+  facet normal -0.82712 0.562026 0
+    outer loop
+      vertex 77.6857 34.416 0
+      vertex 78.0211 34.9096 3
+      vertex 78.0211 34.9096 0
+    endloop
+  endfacet
+  facet normal -0.82712 0.562026 0
+    outer loop
+      vertex 78.0211 34.9096 3
+      vertex 77.6857 34.416 0
+      vertex 77.6857 34.416 3
+    endloop
+  endfacet
+  facet normal -0.156513 0.987676 0
+    outer loop
+      vertex 71.7801 30.6683 0
+      vertex 71.1907 30.5749 3
+      vertex 71.7801 30.6683 3
+    endloop
+  endfacet
+  facet normal -0.156513 0.987676 0
+    outer loop
+      vertex 71.1907 30.5749 3
+      vertex 71.7801 30.6683 0
+      vertex 71.1907 30.5749 0
+    endloop
+  endfacet
+  facet normal -0.397132 -0.917761 0
+    outer loop
+      vertex 73.4972 48.8329 0
+      vertex 74.0449 48.5959 3
+      vertex 73.4972 48.8329 3
+    endloop
+  endfacet
+  facet normal -0.397132 -0.917761 -0
+    outer loop
+      vertex 74.0449 48.5959 3
+      vertex 73.4972 48.8329 0
+      vertex 74.0449 48.5959 0
+    endloop
+  endfacet
+  facet normal 0.82712 -0.562026 0
+    outer loop
+      vertex 61.9789 45.0904 3
+      vertex 62.3143 45.584 0
+      vertex 62.3143 45.584 3
+    endloop
+  endfacet
+  facet normal 0.82712 -0.562026 0
+    outer loop
+      vertex 62.3143 45.584 0
+      vertex 61.9789 45.0904 3
+      vertex 61.9789 45.0904 0
+    endloop
+  endfacet
+  facet normal -0.562026 0.82712 0
+    outer loop
+      vertex 75.584 32.3143 0
+      vertex 75.0904 31.9789 3
+      vertex 75.584 32.3143 3
+    endloop
+  endfacet
+  facet normal -0.562026 0.82712 0
+    outer loop
+      vertex 75.0904 31.9789 3
+      vertex 75.584 32.3143 0
+      vertex 75.0904 31.9789 0
+    endloop
+  endfacet
+  facet normal 0.0313341 -0.999509 0
+    outer loop
+      vertex 69.4035 49.4813 0
+      vertex 70 49.5 3
+      vertex 69.4035 49.4813 3
+    endloop
+  endfacet
+  facet normal 0.0313341 -0.999509 0
+    outer loop
+      vertex 70 49.5 3
+      vertex 69.4035 49.4813 0
+      vertex 70 49.5 0
+    endloop
+  endfacet
+  facet normal -0.50904 0.860743 0
+    outer loop
+      vertex 75.0904 31.9789 0
+      vertex 74.5767 31.6751 3
+      vertex 75.0904 31.9789 3
+    endloop
+  endfacet
+  facet normal -0.50904 0.860743 0
+    outer loop
+      vertex 74.5767 31.6751 3
+      vertex 75.0904 31.9789 0
+      vertex 74.5767 31.6751 0
+    endloop
+  endfacet
+  facet normal 0.454036 -0.890983 0
+    outer loop
+      vertex 65.4233 48.3249 0
+      vertex 65.9551 48.5959 3
+      vertex 65.4233 48.3249 3
+    endloop
+  endfacet
+  facet normal 0.454036 -0.890983 0
+    outer loop
+      vertex 65.9551 48.5959 3
+      vertex 65.4233 48.3249 0
+      vertex 65.9551 48.5959 0
+    endloop
+  endfacet
+  facet normal 0.995557 0.0941607 0
+    outer loop
+      vertex 60.5749 38.8093 3
+      vertex 60.5187 39.4035 0
+      vertex 60.5187 39.4035 3
+    endloop
+  endfacet
+  facet normal 0.995557 0.0941607 0
+    outer loop
+      vertex 60.5187 39.4035 0
+      vertex 60.5749 38.8093 3
+      vertex 60.5749 38.8093 0
+    endloop
+  endfacet
+  facet normal 0.987676 0.156513 0
+    outer loop
+      vertex 60.6683 38.2199 3
+      vertex 60.5749 38.8093 0
+      vertex 60.5749 38.8093 3
+    endloop
+  endfacet
+  facet normal 0.987676 0.156513 0
+    outer loop
+      vertex 60.5749 38.8093 0
+      vertex 60.6683 38.2199 3
+      vertex 60.6683 38.2199 0
+    endloop
+  endfacet
+  facet normal 0.612977 -0.790101 0
+    outer loop
+      vertex 63.9445 47.3199 0
+      vertex 64.416 47.6857 3
+      vertex 63.9445 47.3199 3
+    endloop
+  endfacet
+  facet normal 0.612977 -0.790101 0
+    outer loop
+      vertex 64.416 47.6857 3
+      vertex 63.9445 47.3199 0
+      vertex 64.416 47.6857 0
+    endloop
+  endfacet
+  facet normal -0.562026 -0.82712 0
+    outer loop
+      vertex 75.0904 48.0211 0
+      vertex 75.584 47.6857 3
+      vertex 75.0904 48.0211 3
+    endloop
+  endfacet
+  facet normal -0.562026 -0.82712 -0
+    outer loop
+      vertex 75.584 47.6857 3
+      vertex 75.0904 48.0211 0
+      vertex 75.584 47.6857 0
+    endloop
+  endfacet
+  facet normal 0.750112 -0.661311 0
+    outer loop
+      vertex 62.6801 46.0555 3
+      vertex 63.0748 46.5032 0
+      vertex 63.0748 46.5032 3
+    endloop
+  endfacet
+  facet normal 0.750112 -0.661311 0
+    outer loop
+      vertex 63.0748 46.5032 0
+      vertex 62.6801 46.0555 3
+      vertex 62.6801 46.0555 0
+    endloop
+  endfacet
+  facet normal -0.33866 -0.940909 0
+    outer loop
+      vertex 72.9357 49.035 0
+      vertex 73.4972 48.8329 3
+      vertex 72.9357 49.035 3
+    endloop
+  endfacet
+  facet normal -0.33866 -0.940909 -0
+    outer loop
+      vertex 73.4972 48.8329 3
+      vertex 72.9357 49.035 0
+      vertex 73.4972 48.8329 0
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 0
+    outer loop
+      vertex 76.5032 33.0748 0
+      vertex 76.9252 33.4968 3
+      vertex 76.9252 33.4968 0
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 0
+    outer loop
+      vertex 76.9252 33.4968 3
+      vertex 76.5032 33.0748 0
+      vertex 76.5032 33.0748 3
+    endloop
+  endfacet
+  facet normal 0.960294 0.27899 0
+    outer loop
+      vertex 60.965 37.0643 3
+      vertex 60.7985 37.6374 0
+      vertex 60.7985 37.6374 3
+    endloop
+  endfacet
+  facet normal 0.960294 0.27899 0
+    outer loop
+      vertex 60.7985 37.6374 0
+      vertex 60.965 37.0643 3
+      vertex 60.965 37.0643 0
+    endloop
+  endfacet
+  facet normal 0.960294 -0.27899 0
+    outer loop
+      vertex 60.7985 42.3626 3
+      vertex 60.965 42.9357 0
+      vertex 60.965 42.9357 3
+    endloop
+  endfacet
+  facet normal 0.960294 -0.27899 0
+    outer loop
+      vertex 60.965 42.9357 0
+      vertex 60.7985 42.3626 3
+      vertex 60.7985 42.3626 0
+    endloop
+  endfacet
+  facet normal -0.218137 0.975918 0
+    outer loop
+      vertex 72.3626 30.7985 0
+      vertex 71.7801 30.6683 3
+      vertex 72.3626 30.7985 3
+    endloop
+  endfacet
+  facet normal -0.218137 0.975918 0
+    outer loop
+      vertex 71.7801 30.6683 3
+      vertex 72.3626 30.7985 0
+      vertex 71.7801 30.6683 0
+    endloop
+  endfacet
+  facet normal 0.790101 0.612977 0
+    outer loop
+      vertex 62.6801 33.9445 3
+      vertex 62.3143 34.416 0
+      vertex 62.3143 34.416 3
+    endloop
+  endfacet
+  facet normal 0.790101 0.612977 0
+    outer loop
+      vertex 62.3143 34.416 0
+      vertex 62.6801 33.9445 3
+      vertex 62.6801 33.9445 0
+    endloop
+  endfacet
+  facet normal -0.960294 0.27899 0
+    outer loop
+      vertex 79.035 37.0643 0
+      vertex 79.2015 37.6374 3
+      vertex 79.2015 37.6374 0
+    endloop
+  endfacet
+  facet normal -0.960294 0.27899 0
+    outer loop
+      vertex 79.2015 37.6374 3
+      vertex 79.035 37.0643 0
+      vertex 79.035 37.0643 3
+    endloop
+  endfacet
+  facet normal -0.27899 0.960294 0
+    outer loop
+      vertex 72.9357 30.965 0
+      vertex 72.3626 30.7985 3
+      vertex 72.9357 30.965 3
+    endloop
+  endfacet
+  facet normal -0.27899 0.960294 0
+    outer loop
+      vertex 72.3626 30.7985 3
+      vertex 72.9357 30.965 0
+      vertex 72.3626 30.7985 0
+    endloop
+  endfacet
+  facet normal -0.860743 0.50904 0
+    outer loop
+      vertex 78.0211 34.9096 0
+      vertex 78.3249 35.4233 3
+      vertex 78.3249 35.4233 0
+    endloop
+  endfacet
+  facet normal -0.860743 0.50904 0
+    outer loop
+      vertex 78.3249 35.4233 3
+      vertex 78.0211 34.9096 0
+      vertex 78.0211 34.9096 3
+    endloop
+  endfacet
+  facet normal -0.917761 -0.397132 0
+    outer loop
+      vertex 78.8329 43.4972 0
+      vertex 78.5959 44.0449 3
+      vertex 78.5959 44.0449 0
+    endloop
+  endfacet
+  facet normal -0.917761 -0.397132 0
+    outer loop
+      vertex 78.5959 44.0449 3
+      vertex 78.8329 43.4972 0
+      vertex 78.8329 43.4972 3
+    endloop
+  endfacet
+  facet normal -0.999509 0.0313341 0
+    outer loop
+      vertex 79.4813 39.4035 0
+      vertex 79.5 40 3
+      vertex 79.5 40 0
+    endloop
+  endfacet
+  facet normal -0.999509 0.0313341 0
+    outer loop
+      vertex 79.5 40 3
+      vertex 79.4813 39.4035 0
+      vertex 79.4813 39.4035 3
+    endloop
+  endfacet
+  facet normal 0.33866 0.940909 -0
+    outer loop
+      vertex 67.0643 30.965 0
+      vertex 66.5028 31.1671 3
+      vertex 67.0643 30.965 3
+    endloop
+  endfacet
+  facet normal 0.33866 0.940909 0
+    outer loop
+      vertex 66.5028 31.1671 3
+      vertex 67.0643 30.965 0
+      vertex 66.5028 31.1671 0
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex 76.9252 46.5032 0
+      vertex 76.5032 46.9252 3
+      vertex 76.5032 46.9252 0
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex 76.5032 46.9252 3
+      vertex 76.9252 46.5032 0
+      vertex 76.9252 46.5032 3
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 0
+    outer loop
+      vertex 63.4968 33.0748 3
+      vertex 63.0748 33.4968 0
+      vertex 63.0748 33.4968 3
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 0
+    outer loop
+      vertex 63.0748 33.4968 0
+      vertex 63.4968 33.0748 3
+      vertex 63.4968 33.0748 0
+    endloop
+  endfacet
+  facet normal -0.987676 0.156513 0
+    outer loop
+      vertex 79.3317 38.2199 0
+      vertex 79.4251 38.8093 3
+      vertex 79.4251 38.8093 0
+    endloop
+  endfacet
+  facet normal -0.987676 0.156513 0
+    outer loop
+      vertex 79.4251 38.8093 3
+      vertex 79.3317 38.2199 0
+      vertex 79.3317 38.2199 3
+    endloop
+  endfacet
+  facet normal 0.33866 -0.940909 0
+    outer loop
+      vertex 66.5028 48.8329 0
+      vertex 67.0643 49.035 3
+      vertex 66.5028 48.8329 3
+    endloop
+  endfacet
+  facet normal 0.33866 -0.940909 0
+    outer loop
+      vertex 67.0643 49.035 3
+      vertex 66.5028 48.8329 0
+      vertex 67.0643 49.035 0
+    endloop
+  endfacet
+  facet normal -0.397132 0.917761 0
+    outer loop
+      vertex 74.0449 31.4041 0
+      vertex 73.4972 31.1671 3
+      vertex 74.0449 31.4041 3
+    endloop
+  endfacet
+  facet normal -0.397132 0.917761 0
+    outer loop
+      vertex 73.4972 31.1671 3
+      vertex 74.0449 31.4041 0
+      vertex 73.4972 31.1671 0
+    endloop
+  endfacet
+  facet normal -0.612977 0.790101 0
+    outer loop
+      vertex 76.0555 32.6801 0
+      vertex 75.584 32.3143 3
+      vertex 76.0555 32.6801 3
+    endloop
+  endfacet
+  facet normal -0.612977 0.790101 0
+    outer loop
+      vertex 75.584 32.3143 3
+      vertex 76.0555 32.6801 0
+      vertex 75.584 32.3143 0
+    endloop
+  endfacet
+  facet normal 0.50904 -0.860743 0
+    outer loop
+      vertex 64.9096 48.0211 0
+      vertex 65.4233 48.3249 3
+      vertex 64.9096 48.0211 3
+    endloop
+  endfacet
+  facet normal 0.50904 -0.860743 0
+    outer loop
+      vertex 65.4233 48.3249 3
+      vertex 64.9096 48.0211 0
+      vertex 65.4233 48.3249 0
+    endloop
+  endfacet
+  facet normal -0.790101 -0.612977 0
+    outer loop
+      vertex 77.6857 45.584 0
+      vertex 77.3199 46.0555 3
+      vertex 77.3199 46.0555 0
+    endloop
+  endfacet
+  facet normal -0.790101 -0.612977 0
+    outer loop
+      vertex 77.3199 46.0555 3
+      vertex 77.6857 45.584 0
+      vertex 77.6857 45.584 3
+    endloop
+  endfacet
+  facet normal -0.890983 0.454036 0
+    outer loop
+      vertex 78.3249 35.4233 0
+      vertex 78.5959 35.9551 3
+      vertex 78.5959 35.9551 0
+    endloop
+  endfacet
+  facet normal -0.890983 0.454036 0
+    outer loop
+      vertex 78.5959 35.9551 3
+      vertex 78.3249 35.4233 0
+      vertex 78.3249 35.4233 3
+    endloop
+  endfacet
+  facet normal -0.995557 0.0941607 0
+    outer loop
+      vertex 79.4251 38.8093 0
+      vertex 79.4813 39.4035 3
+      vertex 79.4813 39.4035 0
+    endloop
+  endfacet
+  facet normal -0.995557 0.0941607 0
+    outer loop
+      vertex 79.4813 39.4035 3
+      vertex 79.4251 38.8093 0
+      vertex 79.4251 38.8093 3
+    endloop
+  endfacet
+  facet normal -0.661311 -0.750112 0
+    outer loop
+      vertex 76.0555 47.3199 0
+      vertex 76.5032 46.9252 3
+      vertex 76.0555 47.3199 3
+    endloop
+  endfacet
+  facet normal -0.661311 -0.750112 -0
+    outer loop
+      vertex 76.5032 46.9252 3
+      vertex 76.0555 47.3199 0
+      vertex 76.5032 46.9252 0
+    endloop
+  endfacet
+  facet normal -0.790101 0.612977 0
+    outer loop
+      vertex 77.3199 33.9445 0
+      vertex 77.6857 34.416 3
+      vertex 77.6857 34.416 0
+    endloop
+  endfacet
+  facet normal -0.790101 0.612977 0
+    outer loop
+      vertex 77.6857 34.416 3
+      vertex 77.3199 33.9445 0
+      vertex 77.3199 33.9445 3
+    endloop
+  endfacet
+  facet normal 0.975918 0.218137 0
+    outer loop
+      vertex 60.7985 37.6374 3
+      vertex 60.6683 38.2199 0
+      vertex 60.6683 38.2199 3
+    endloop
+  endfacet
+  facet normal 0.975918 0.218137 0
+    outer loop
+      vertex 60.6683 38.2199 0
+      vertex 60.7985 37.6374 3
+      vertex 60.7985 37.6374 0
+    endloop
+  endfacet
+  facet normal 0.790101 -0.612977 0
+    outer loop
+      vertex 62.3143 45.584 3
+      vertex 62.6801 46.0555 0
+      vertex 62.6801 46.0555 3
+    endloop
+  endfacet
+  facet normal 0.790101 -0.612977 0
+    outer loop
+      vertex 62.6801 46.0555 0
+      vertex 62.3143 45.584 3
+      vertex 62.3143 45.584 0
+    endloop
+  endfacet
+  facet normal 0.27899 0.960294 -0
+    outer loop
+      vertex 67.6374 30.7985 0
+      vertex 67.0643 30.965 3
+      vertex 67.6374 30.7985 3
+    endloop
+  endfacet
+  facet normal 0.27899 0.960294 0
+    outer loop
+      vertex 67.0643 30.965 3
+      vertex 67.6374 30.7985 0
+      vertex 67.0643 30.965 0
+    endloop
+  endfacet
+  facet normal 0.562026 -0.82712 0
+    outer loop
+      vertex 64.416 47.6857 0
+      vertex 64.9096 48.0211 3
+      vertex 64.416 47.6857 3
+    endloop
+  endfacet
+  facet normal 0.562026 -0.82712 0
+    outer loop
+      vertex 64.9096 48.0211 3
+      vertex 64.416 47.6857 0
+      vertex 64.9096 48.0211 0
+    endloop
+  endfacet
+  facet normal -0.50904 -0.860743 0
+    outer loop
+      vertex 74.5767 48.3249 0
+      vertex 75.0904 48.0211 3
+      vertex 74.5767 48.3249 3
+    endloop
+  endfacet
+  facet normal -0.50904 -0.860743 -0
+    outer loop
+      vertex 75.0904 48.0211 3
+      vertex 74.5767 48.3249 0
+      vertex 75.0904 48.0211 0
+    endloop
+  endfacet
+  facet normal -0.940909 0.33866 0
+    outer loop
+      vertex 78.8329 36.5028 0
+      vertex 79.035 37.0643 3
+      vertex 79.035 37.0643 0
+    endloop
+  endfacet
+  facet normal -0.940909 0.33866 0
+    outer loop
+      vertex 79.035 37.0643 3
+      vertex 78.8329 36.5028 0
+      vertex 78.8329 36.5028 3
+    endloop
+  endfacet
+  facet normal -0.218137 -0.975918 0
+    outer loop
+      vertex 71.7801 49.3317 0
+      vertex 72.3626 49.2015 3
+      vertex 71.7801 49.3317 3
+    endloop
+  endfacet
+  facet normal -0.218137 -0.975918 -0
+    outer loop
+      vertex 72.3626 49.2015 3
+      vertex 71.7801 49.3317 0
+      vertex 72.3626 49.2015 0
+    endloop
+  endfacet
+  facet normal 0.397132 0.917761 -0
+    outer loop
+      vertex 66.5028 31.1671 0
+      vertex 65.9551 31.4041 3
+      vertex 66.5028 31.1671 3
+    endloop
+  endfacet
+  facet normal 0.397132 0.917761 0
+    outer loop
+      vertex 65.9551 31.4041 3
+      vertex 66.5028 31.1671 0
+      vertex 65.9551 31.4041 0
+    endloop
+  endfacet
+  facet normal 0.975918 -0.218137 0
+    outer loop
+      vertex 60.6683 41.7801 3
+      vertex 60.7985 42.3626 0
+      vertex 60.7985 42.3626 3
+    endloop
+  endfacet
+  facet normal 0.975918 -0.218137 0
+    outer loop
+      vertex 60.7985 42.3626 0
+      vertex 60.6683 41.7801 3
+      vertex 60.6683 41.7801 0
+    endloop
+  endfacet
+  facet normal 0.82712 0.562026 0
+    outer loop
+      vertex 62.3143 34.416 3
+      vertex 61.9789 34.9096 0
+      vertex 61.9789 34.9096 3
+    endloop
+  endfacet
+  facet normal 0.82712 0.562026 0
+    outer loop
+      vertex 61.9789 34.9096 0
+      vertex 62.3143 34.416 3
+      vertex 62.3143 34.416 0
+    endloop
+  endfacet
+  facet normal 0.218137 0.975918 -0
+    outer loop
+      vertex 68.2199 30.6683 0
+      vertex 67.6374 30.7985 3
+      vertex 68.2199 30.6683 3
+    endloop
+  endfacet
+  facet normal 0.218137 0.975918 0
+    outer loop
+      vertex 67.6374 30.7985 3
+      vertex 68.2199 30.6683 0
+      vertex 67.6374 30.7985 0
+    endloop
+  endfacet
+  facet normal -0.975918 0.218137 0
+    outer loop
+      vertex 79.2015 37.6374 0
+      vertex 79.3317 38.2199 3
+      vertex 79.3317 38.2199 0
+    endloop
+  endfacet
+  facet normal -0.975918 0.218137 0
+    outer loop
+      vertex 79.3317 38.2199 3
+      vertex 79.2015 37.6374 0
+      vertex 79.2015 37.6374 3
+    endloop
+  endfacet
+  facet normal -0.917761 0.397132 0
+    outer loop
+      vertex 78.5959 35.9551 0
+      vertex 78.8329 36.5028 3
+      vertex 78.8329 36.5028 0
+    endloop
+  endfacet
+  facet normal -0.917761 0.397132 0
+    outer loop
+      vertex 78.8329 36.5028 3
+      vertex 78.5959 35.9551 0
+      vertex 78.5959 35.9551 3
+    endloop
+  endfacet
+  facet normal 0.860743 -0.50904 0
+    outer loop
+      vertex 61.6751 44.5767 3
+      vertex 61.9789 45.0904 0
+      vertex 61.9789 45.0904 3
+    endloop
+  endfacet
+  facet normal 0.860743 -0.50904 0
+    outer loop
+      vertex 61.9789 45.0904 0
+      vertex 61.6751 44.5767 3
+      vertex 61.6751 44.5767 0
+    endloop
+  endfacet
+  facet normal -0.975918 -0.218137 0
+    outer loop
+      vertex 79.3317 41.7801 0
+      vertex 79.2015 42.3626 3
+      vertex 79.2015 42.3626 0
+    endloop
+  endfacet
+  facet normal -0.975918 -0.218137 0
+    outer loop
+      vertex 79.2015 42.3626 3
+      vertex 79.3317 41.7801 0
+      vertex 79.3317 41.7801 3
+    endloop
+  endfacet
+  facet normal 0.987676 -0.156513 0
+    outer loop
+      vertex 60.5749 41.1907 3
+      vertex 60.6683 41.7801 0
+      vertex 60.6683 41.7801 3
+    endloop
+  endfacet
+  facet normal 0.987676 -0.156513 0
+    outer loop
+      vertex 60.6683 41.7801 0
+      vertex 60.5749 41.1907 3
+      vertex 60.5749 41.1907 0
+    endloop
+  endfacet
+  facet normal -0.940909 -0.33866 0
+    outer loop
+      vertex 79.035 42.9357 0
+      vertex 78.8329 43.4972 3
+      vertex 78.8329 43.4972 0
+    endloop
+  endfacet
+  facet normal -0.940909 -0.33866 0
+    outer loop
+      vertex 78.8329 43.4972 3
+      vertex 79.035 42.9357 0
+      vertex 79.035 42.9357 3
+    endloop
+  endfacet
+  facet normal 0.940909 -0.33866 0
+    outer loop
+      vertex 60.965 42.9357 3
+      vertex 61.1671 43.4972 0
+      vertex 61.1671 43.4972 3
+    endloop
+  endfacet
+  facet normal 0.940909 -0.33866 0
+    outer loop
+      vertex 61.1671 43.4972 0
+      vertex 60.965 42.9357 3
+      vertex 60.965 42.9357 0
+    endloop
+  endfacet
+  facet normal -0.750112 -0.661311 0
+    outer loop
+      vertex 77.3199 46.0555 0
+      vertex 76.9252 46.5032 3
+      vertex 76.9252 46.5032 0
+    endloop
+  endfacet
+  facet normal -0.750112 -0.661311 0
+    outer loop
+      vertex 76.9252 46.5032 3
+      vertex 77.3199 46.0555 0
+      vertex 77.3199 46.0555 3
+    endloop
+  endfacet
+  facet normal -0.987676 -0.156513 0
+    outer loop
+      vertex 79.4251 41.1907 0
+      vertex 79.3317 41.7801 3
+      vertex 79.3317 41.7801 0
+    endloop
+  endfacet
+  facet normal -0.987676 -0.156513 0
+    outer loop
+      vertex 79.3317 41.7801 3
+      vertex 79.4251 41.1907 0
+      vertex 79.4251 41.1907 3
+    endloop
+  endfacet
+  facet normal 0.661311 -0.750112 0
+    outer loop
+      vertex 63.4968 46.9252 0
+      vertex 63.9445 47.3199 3
+      vertex 63.4968 46.9252 3
+    endloop
+  endfacet
+  facet normal 0.661311 -0.750112 0
+    outer loop
+      vertex 63.9445 47.3199 3
+      vertex 63.4968 46.9252 0
+      vertex 63.9445 47.3199 0
+    endloop
+  endfacet
+  facet normal 0.27899 -0.960294 0
+    outer loop
+      vertex 67.0643 49.035 0
+      vertex 67.6374 49.2015 3
+      vertex 67.0643 49.035 3
+    endloop
+  endfacet
+  facet normal 0.27899 -0.960294 0
+    outer loop
+      vertex 67.6374 49.2015 3
+      vertex 67.0643 49.035 0
+      vertex 67.6374 49.2015 0
+    endloop
+  endfacet
+  facet normal 0.917761 0.397132 0
+    outer loop
+      vertex 61.4041 35.9551 3
+      vertex 61.1671 36.5028 0
+      vertex 61.1671 36.5028 3
+    endloop
+  endfacet
+  facet normal 0.917761 0.397132 0
+    outer loop
+      vertex 61.1671 36.5028 0
+      vertex 61.4041 35.9551 3
+      vertex 61.4041 35.9551 0
+    endloop
+  endfacet
+  facet normal 0.218137 -0.975918 0
+    outer loop
+      vertex 67.6374 49.2015 0
+      vertex 68.2199 49.3317 3
+      vertex 67.6374 49.2015 3
+    endloop
+  endfacet
+  facet normal 0.218137 -0.975918 0
+    outer loop
+      vertex 68.2199 49.3317 3
+      vertex 67.6374 49.2015 0
+      vertex 68.2199 49.3317 0
+    endloop
+  endfacet
+  facet normal 0.999509 -0.0313341 0
+    outer loop
+      vertex 60.5 40 3
+      vertex 60.5187 40.5965 0
+      vertex 60.5187 40.5965 3
+    endloop
+  endfacet
+  facet normal 0.999509 -0.0313341 0
+    outer loop
+      vertex 60.5187 40.5965 0
+      vertex 60.5 40 3
+      vertex 60.5 40 0
+    endloop
+  endfacet
+  facet normal 0.156513 -0.987676 0
+    outer loop
+      vertex 68.2199 49.3317 0
+      vertex 68.8093 49.4251 3
+      vertex 68.2199 49.3317 3
+    endloop
+  endfacet
+  facet normal 0.156513 -0.987676 0
+    outer loop
+      vertex 68.8093 49.4251 3
+      vertex 68.2199 49.3317 0
+      vertex 68.8093 49.4251 0
+    endloop
+  endfacet
+  facet normal 0.940909 0.33866 0
+    outer loop
+      vertex 61.1671 36.5028 3
+      vertex 60.965 37.0643 0
+      vertex 60.965 37.0643 3
+    endloop
+  endfacet
+  facet normal 0.940909 0.33866 0
+    outer loop
+      vertex 60.965 37.0643 0
+      vertex 61.1671 36.5028 3
+      vertex 61.1671 36.5028 0
+    endloop
+  endfacet
+  facet normal 0.860743 0.50904 0
+    outer loop
+      vertex 61.9789 34.9096 3
+      vertex 61.6751 35.4233 0
+      vertex 61.6751 35.4233 3
+    endloop
+  endfacet
+  facet normal 0.860743 0.50904 0
+    outer loop
+      vertex 61.6751 35.4233 0
+      vertex 61.9789 34.9096 3
+      vertex 61.9789 34.9096 0
+    endloop
+  endfacet
+  facet normal -0.27899 -0.960294 0
+    outer loop
+      vertex 72.3626 49.2015 0
+      vertex 72.9357 49.035 3
+      vertex 72.3626 49.2015 3
+    endloop
+  endfacet
+  facet normal -0.27899 -0.960294 -0
+    outer loop
+      vertex 72.9357 49.035 3
+      vertex 72.3626 49.2015 0
+      vertex 72.9357 49.035 0
+    endloop
+  endfacet
+  facet normal -0.0313341 -0.999509 0
+    outer loop
+      vertex 70 49.5 0
+      vertex 70.5965 49.4813 3
+      vertex 70 49.5 3
+    endloop
+  endfacet
+  facet normal -0.0313341 -0.999509 -0
+    outer loop
+      vertex 70.5965 49.4813 3
+      vertex 70 49.5 0
+      vertex 70.5965 49.4813 0
+    endloop
+  endfacet
+  facet normal 0.661311 0.750112 -0
+    outer loop
+      vertex 63.9445 32.6801 0
+      vertex 63.4968 33.0748 3
+      vertex 63.9445 32.6801 3
+    endloop
+  endfacet
+  facet normal 0.661311 0.750112 0
+    outer loop
+      vertex 63.4968 33.0748 3
+      vertex 63.9445 32.6801 0
+      vertex 63.4968 33.0748 0
+    endloop
+  endfacet
+  facet normal 0.917761 -0.397132 0
+    outer loop
+      vertex 61.1671 43.4972 3
+      vertex 61.4041 44.0449 0
+      vertex 61.4041 44.0449 3
+    endloop
+  endfacet
+  facet normal 0.917761 -0.397132 0
+    outer loop
+      vertex 61.4041 44.0449 0
+      vertex 61.1671 43.4972 3
+      vertex 61.1671 43.4972 0
+    endloop
+  endfacet
+  facet normal -0.661311 0.750112 0
+    outer loop
+      vertex 76.5032 33.0748 0
+      vertex 76.0555 32.6801 3
+      vertex 76.5032 33.0748 3
+    endloop
+  endfacet
+  facet normal -0.661311 0.750112 0
+    outer loop
+      vertex 76.0555 32.6801 3
+      vertex 76.5032 33.0748 0
+      vertex 76.0555 32.6801 0
+    endloop
+  endfacet
+  facet normal 0.0313341 0.999509 -0
+    outer loop
+      vertex 70 30.5 0
+      vertex 69.4035 30.5187 3
+      vertex 70 30.5 3
+    endloop
+  endfacet
+  facet normal 0.0313341 0.999509 0
+    outer loop
+      vertex 69.4035 30.5187 3
+      vertex 70 30.5 0
+      vertex 69.4035 30.5187 0
+    endloop
+  endfacet
+  facet normal 0.156513 0.987676 -0
+    outer loop
+      vertex 68.8093 30.5749 0
+      vertex 68.2199 30.6683 3
+      vertex 68.8093 30.5749 3
+    endloop
+  endfacet
+  facet normal 0.156513 0.987676 0
+    outer loop
+      vertex 68.2199 30.6683 3
+      vertex 68.8093 30.5749 0
+      vertex 68.2199 30.6683 0
+    endloop
+  endfacet
+  facet normal 0.890983 -0.454036 0
+    outer loop
+      vertex 61.4041 44.0449 3
+      vertex 61.6751 44.5767 0
+      vertex 61.6751 44.5767 3
+    endloop
+  endfacet
+  facet normal 0.890983 -0.454036 0
+    outer loop
+      vertex 61.6751 44.5767 0
+      vertex 61.4041 44.0449 3
+      vertex 61.4041 44.0449 0
+    endloop
+  endfacet
+  facet normal 0.890983 0.454036 0
+    outer loop
+      vertex 61.6751 35.4233 3
+      vertex 61.4041 35.9551 0
+      vertex 61.4041 35.9551 3
+    endloop
+  endfacet
+  facet normal 0.890983 0.454036 0
+    outer loop
+      vertex 61.4041 35.9551 0
+      vertex 61.6751 35.4233 3
+      vertex 61.6751 35.4233 0
+    endloop
+  endfacet
+  facet normal 0.454036 0.890983 -0
+    outer loop
+      vertex 65.9551 31.4041 0
+      vertex 65.4233 31.6751 3
+      vertex 65.9551 31.4041 3
+    endloop
+  endfacet
+  facet normal 0.454036 0.890983 0
+    outer loop
+      vertex 65.4233 31.6751 3
+      vertex 65.9551 31.4041 0
+      vertex 65.4233 31.6751 0
+    endloop
+  endfacet
+  facet normal -0.156513 -0.987676 0
+    outer loop
+      vertex 71.1907 49.4251 0
+      vertex 71.7801 49.3317 3
+      vertex 71.1907 49.4251 3
+    endloop
+  endfacet
+  facet normal -0.156513 -0.987676 -0
+    outer loop
+      vertex 71.7801 49.3317 3
+      vertex 71.1907 49.4251 0
+      vertex 71.7801 49.3317 0
+    endloop
+  endfacet
+  facet normal -0.995566 -0.0940692 0
+    outer loop
+      vertex 80.2436 51.2041 0
+      vertex 80.2244 51.4073 3
+      vertex 80.2244 51.4073 0
+    endloop
+  endfacet
+  facet normal -0.995566 -0.0940692 0
+    outer loop
+      vertex 80.2244 51.4073 3
+      vertex 80.2436 51.2041 0
+      vertex 80.2436 51.2041 3
+    endloop
+  endfacet
+  facet normal -0.999509 -0.0313418 0
+    outer loop
+      vertex 80.25 51 0
+      vertex 80.2436 51.2041 3
+      vertex 80.2436 51.2041 0
+    endloop
+  endfacet
+  facet normal -0.999509 -0.0313418 0
+    outer loop
+      vertex 80.2436 51.2041 3
+      vertex 80.25 51 0
+      vertex 80.25 51 3
+    endloop
+  endfacet
+  facet normal -0.987648 -0.156692 0
+    outer loop
+      vertex 80.2244 51.4073 0
+      vertex 80.1924 51.609 3
+      vertex 80.1924 51.609 0
+    endloop
+  endfacet
+  facet normal -0.987648 -0.156692 0
+    outer loop
+      vertex 80.1924 51.609 3
+      vertex 80.2244 51.4073 0
+      vertex 80.2244 51.4073 3
+    endloop
+  endfacet
+  facet normal -0.975944 -0.21802 0
+    outer loop
+      vertex 80.1924 51.609 0
+      vertex 80.1479 51.8082 3
+      vertex 80.1479 51.8082 0
+    endloop
+  endfacet
+  facet normal -0.975944 -0.21802 0
+    outer loop
+      vertex 80.1479 51.8082 3
+      vertex 80.1924 51.609 0
+      vertex 80.1924 51.609 3
+    endloop
+  endfacet
+  facet normal -0.661411 -0.750024 0
+    outer loop
+      vertex 79.0716 53.5042 0
+      vertex 79.2248 53.3691 3
+      vertex 79.0716 53.5042 3
+    endloop
+  endfacet
+  facet normal -0.661411 -0.750024 -0
+    outer loop
+      vertex 79.2248 53.3691 3
+      vertex 79.0716 53.5042 0
+      vertex 79.2248 53.3691 0
+    endloop
+  endfacet
+  facet normal 0.860761 -0.50901 0
+    outer loop
+      vertex 74.152 52.5657 3
+      vertex 74.2559 52.7414 0
+      vertex 74.2559 52.7414 3
+    endloop
+  endfacet
+  facet normal 0.860761 -0.50901 0
+    outer loop
+      vertex 74.2559 52.7414 0
+      vertex 74.152 52.5657 3
+      vertex 74.152 52.5657 0
+    endloop
+  endfacet
+  facet normal 0.338477 0.940975 -0
+    outer loop
+      vertex 75.9957 47.9091 0
+      vertex 75.8036 47.9782 3
+      vertex 75.9957 47.9091 3
+    endloop
+  endfacet
+  facet normal 0.338477 0.940975 0
+    outer loop
+      vertex 75.8036 47.9782 3
+      vertex 75.9957 47.9091 0
+      vertex 75.8036 47.9782 0
+    endloop
+  endfacet
+  facet normal -0.50901 0.860761 0
+    outer loop
+      vertex 78.7414 48.2559 0
+      vertex 78.5657 48.152 3
+      vertex 78.7414 48.2559 3
+    endloop
+  endfacet
+  facet normal -0.50901 0.860761 0
+    outer loop
+      vertex 78.5657 48.152 3
+      vertex 78.7414 48.2559 0
+      vertex 78.5657 48.152 0
+    endloop
+  endfacet
+  facet normal -0.995566 0.0940692 0
+    outer loop
+      vertex 80.2244 50.5927 0
+      vertex 80.2436 50.7959 3
+      vertex 80.2436 50.7959 0
+    endloop
+  endfacet
+  facet normal -0.995566 0.0940692 0
+    outer loop
+      vertex 80.2436 50.7959 3
+      vertex 80.2244 50.5927 0
+      vertex 80.2244 50.5927 3
+    endloop
+  endfacet
+  facet normal -0.612855 -0.790196 0
+    outer loop
+      vertex 78.9103 53.6293 0
+      vertex 79.0716 53.5042 3
+      vertex 78.9103 53.6293 3
+    endloop
+  endfacet
+  facet normal -0.612855 -0.790196 -0
+    outer loop
+      vertex 79.0716 53.5042 3
+      vertex 78.9103 53.6293 0
+      vertex 79.0716 53.5042 0
+    endloop
+  endfacet
+  facet normal -0.790196 -0.612855 0
+    outer loop
+      vertex 79.6293 52.9103 0
+      vertex 79.5042 53.0716 3
+      vertex 79.5042 53.0716 0
+    endloop
+  endfacet
+  facet normal -0.790196 -0.612855 0
+    outer loop
+      vertex 79.5042 53.0716 3
+      vertex 79.6293 52.9103 0
+      vertex 79.6293 52.9103 3
+    endloop
+  endfacet
+  facet normal 0.279116 -0.960257 0
+    outer loop
+      vertex 75.9957 54.0909 0
+      vertex 76.1918 54.1479 7.5
+      vertex 75.9957 54.0909 7.5
+    endloop
+  endfacet
+  facet normal 0.279116 -0.960257 0
+    outer loop
+      vertex 76.1918 54.1479 7.5
+      vertex 75.9957 54.0909 0
+      vertex 76.1918 54.1479 0
+    endloop
+  endfacet
+  facet normal 0.999509 0.0313418 0
+    outer loop
+      vertex 73.7564 50.7959 3
+      vertex 73.75 51 0
+      vertex 73.75 51 3
+    endloop
+  endfacet
+  facet normal 0.999509 0.0313418 0
+    outer loop
+      vertex 73.75 51 0
+      vertex 73.7564 50.7959 3
+      vertex 73.7564 50.7959 0
+    endloop
+  endfacet
+  facet normal 0.995566 0.0940692 0
+    outer loop
+      vertex 73.7756 50.5927 3
+      vertex 73.7564 50.7959 0
+      vertex 73.7564 50.7959 3
+    endloop
+  endfacet
+  facet normal 0.995566 0.0940692 0
+    outer loop
+      vertex 73.7564 50.7959 0
+      vertex 73.7756 50.5927 3
+      vertex 73.7756 50.5927 0
+    endloop
+  endfacet
+  facet normal -0.562136 -0.827045 0
+    outer loop
+      vertex 78.7414 53.7441 0
+      vertex 78.9103 53.6293 3
+      vertex 78.7414 53.7441 3
+    endloop
+  endfacet
+  facet normal -0.562136 -0.827045 -0
+    outer loop
+      vertex 78.9103 53.6293 3
+      vertex 78.7414 53.7441 0
+      vertex 78.9103 53.6293 0
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 0
+    outer loop
+      vertex 74.6309 53.2248 3
+      vertex 74.7752 53.3691 0
+      vertex 74.7752 53.3691 3
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 0
+    outer loop
+      vertex 74.7752 53.3691 0
+      vertex 74.6309 53.2248 3
+      vertex 74.6309 53.2248 0
+    endloop
+  endfacet
+  facet normal -0.827045 0.562136 0
+    outer loop
+      vertex 79.6293 49.0897 0
+      vertex 79.7441 49.2586 3
+      vertex 79.7441 49.2586 0
+    endloop
+  endfacet
+  facet normal -0.827045 0.562136 0
+    outer loop
+      vertex 79.7441 49.2586 3
+      vertex 79.6293 49.0897 0
+      vertex 79.6293 49.0897 3
+    endloop
+  endfacet
+  facet normal -0.0940692 0.995566 0
+    outer loop
+      vertex 77.4073 47.7756 0
+      vertex 77.2041 47.7564 3
+      vertex 77.4073 47.7756 3
+    endloop
+  endfacet
+  facet normal -0.0940692 0.995566 0
+    outer loop
+      vertex 77.2041 47.7564 3
+      vertex 77.4073 47.7756 0
+      vertex 77.2041 47.7564 0
+    endloop
+  endfacet
+  facet normal -0.940975 -0.338477 0
+    outer loop
+      vertex 80.0909 52.0043 0
+      vertex 80.0218 52.1964 3
+      vertex 80.0218 52.1964 0
+    endloop
+  endfacet
+  facet normal -0.940975 -0.338477 0
+    outer loop
+      vertex 80.0218 52.1964 3
+      vertex 80.0909 52.0043 0
+      vertex 80.0909 52.0043 3
+    endloop
+  endfacet
+  facet normal -0.279116 -0.960257 0
+    outer loop
+      vertex 77.8082 54.1479 0
+      vertex 78.0043 54.0909 7.5
+      vertex 77.8082 54.1479 7.5
+    endloop
+  endfacet
+  facet normal -0.279116 -0.960257 -0
+    outer loop
+      vertex 78.0043 54.0909 7.5
+      vertex 77.8082 54.1479 0
+      vertex 78.0043 54.0909 0
+    endloop
+  endfacet
+  facet normal 0.393919 -0.919145 0
+    outer loop
+      vertex 75.6162 53.9407 3
+      vertex 75.6162 53.9407 0
+      vertex 75.6225 53.9434 3
+    endloop
+  endfacet
+  facet normal 0.39728 -0.917697 0
+    outer loop
+      vertex 75.6225 53.9434 3
+      vertex 75.8036 54.0218 7.5
+      vertex 75.6225 53.9434 7.5
+    endloop
+  endfacet
+  facet normal 0.397168 -0.917746 -8.08048e-06
+    outer loop
+      vertex 75.8036 54.0218 0
+      vertex 75.6225 53.9434 3
+      vertex 75.6162 53.9407 0
+    endloop
+  endfacet
+  facet normal 0.39728 -0.917697 0
+    outer loop
+      vertex 75.6225 53.9434 3
+      vertex 75.8036 54.0218 0
+      vertex 75.8036 54.0218 7.5
+    endloop
+  endfacet
+  facet normal -0.890972 -0.454058 0
+    outer loop
+      vertex 79.9407 52.3838 0
+      vertex 79.848 52.5657 3
+      vertex 79.848 52.5657 0
+    endloop
+  endfacet
+  facet normal -0.890972 -0.454058 0
+    outer loop
+      vertex 79.848 52.5657 3
+      vertex 79.9407 52.3838 0
+      vertex 79.9407 52.3838 3
+    endloop
+  endfacet
+  facet normal 0.890972 -0.454058 0
+    outer loop
+      vertex 74.0593 52.3838 3
+      vertex 74.152 52.5657 0
+      vertex 74.152 52.5657 3
+    endloop
+  endfacet
+  facet normal 0.890972 -0.454058 0
+    outer loop
+      vertex 74.152 52.5657 0
+      vertex 74.0593 52.3838 3
+      vertex 74.0593 52.3838 0
+    endloop
+  endfacet
+  facet normal -0.0940692 -0.995566 0
+    outer loop
+      vertex 77.2041 54.2436 0
+      vertex 77.4073 54.2244 7.5
+      vertex 77.2041 54.2436 7.5
+    endloop
+  endfacet
+  facet normal -0.0940692 -0.995566 -0
+    outer loop
+      vertex 77.4073 54.2244 7.5
+      vertex 77.2041 54.2436 0
+      vertex 77.4073 54.2244 0
+    endloop
+  endfacet
+  facet normal 0.21802 -0.975944 0
+    outer loop
+      vertex 76.1918 54.1479 0
+      vertex 76.391 54.1924 7.5
+      vertex 76.1918 54.1479 7.5
+    endloop
+  endfacet
+  facet normal 0.21802 -0.975944 0
+    outer loop
+      vertex 76.391 54.1924 7.5
+      vertex 76.1918 54.1479 0
+      vertex 76.391 54.1924 0
+    endloop
+  endfacet
+  facet normal -0.454058 0.890972 0
+    outer loop
+      vertex 78.5657 48.152 0
+      vertex 78.3838 48.0593 3
+      vertex 78.5657 48.152 3
+    endloop
+  endfacet
+  facet normal -0.454058 0.890972 0
+    outer loop
+      vertex 78.3838 48.0593 3
+      vertex 78.5657 48.152 0
+      vertex 78.3838 48.0593 0
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex 79.3691 53.2248 0
+      vertex 79.2248 53.3691 3
+      vertex 79.2248 53.3691 0
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex 79.2248 53.3691 3
+      vertex 79.3691 53.2248 0
+      vertex 79.3691 53.2248 3
+    endloop
+  endfacet
+  facet normal 0.987648 -0.156692 0
+    outer loop
+      vertex 73.7756 51.4073 3
+      vertex 73.8076 51.609 0
+      vertex 73.8076 51.609 3
+    endloop
+  endfacet
+  facet normal 0.987648 -0.156692 0
+    outer loop
+      vertex 73.8076 51.609 0
+      vertex 73.7756 51.4073 3
+      vertex 73.7756 51.4073 0
+    endloop
+  endfacet
+  facet normal 0.750024 -0.661411 0
+    outer loop
+      vertex 74.4958 53.0716 3
+      vertex 74.6309 53.2248 0
+      vertex 74.6309 53.2248 3
+    endloop
+  endfacet
+  facet normal 0.750024 -0.661411 0
+    outer loop
+      vertex 74.6309 53.2248 0
+      vertex 74.4958 53.0716 3
+      vertex 74.4958 53.0716 0
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 0
+    outer loop
+      vertex 74.7752 48.6309 3
+      vertex 74.6309 48.7752 0
+      vertex 74.6309 48.7752 3
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 0
+    outer loop
+      vertex 74.6309 48.7752 0
+      vertex 74.7752 48.6309 3
+      vertex 74.7752 48.6309 0
+    endloop
+  endfacet
+  facet normal 0.790196 -0.612855 0
+    outer loop
+      vertex 74.3707 52.9103 3
+      vertex 74.4958 53.0716 0
+      vertex 74.4958 53.0716 3
+    endloop
+  endfacet
+  facet normal 0.790196 -0.612855 0
+    outer loop
+      vertex 74.4958 53.0716 0
+      vertex 74.3707 52.9103 3
+      vertex 74.3707 52.9103 0
+    endloop
+  endfacet
+  facet normal -0.337983 -0.941152 0
+    outer loop
+      vertex 78.0043 54.0909 7.5
+      vertex 78.0767 54.0649 3
+      vertex 78.0767 54.0649 7.5
+    endloop
+  endfacet
+  facet normal -0.337983 -0.941152 0
+    outer loop
+      vertex 78.0043 54.0909 0
+      vertex 78.0767 54.0649 3
+      vertex 78.0043 54.0909 7.5
+    endloop
+  endfacet
+  facet normal -0.338477 -0.940975 1.34542e-05
+    outer loop
+      vertex 78.1964 54.0218 0
+      vertex 78.0767 54.0649 3
+      vertex 78.0043 54.0909 0
+    endloop
+  endfacet
+  facet normal -0.338775 -0.940867 0
+    outer loop
+      vertex 78.0767 54.0649 3
+      vertex 78.1964 54.0218 0
+      vertex 78.1964 54.0218 3
+    endloop
+  endfacet
+  facet normal -0.960257 0.279116 0
+    outer loop
+      vertex 80.0909 49.9957 0
+      vertex 80.1479 50.1918 3
+      vertex 80.1479 50.1918 0
+    endloop
+  endfacet
+  facet normal -0.960257 0.279116 0
+    outer loop
+      vertex 80.1479 50.1918 3
+      vertex 80.0909 49.9957 0
+      vertex 80.0909 49.9957 3
+    endloop
+  endfacet
+  facet normal 0.21802 0.975944 -0
+    outer loop
+      vertex 76.391 47.8076 0
+      vertex 76.1918 47.8521 3
+      vertex 76.391 47.8076 3
+    endloop
+  endfacet
+  facet normal 0.21802 0.975944 0
+    outer loop
+      vertex 76.1918 47.8521 3
+      vertex 76.391 47.8076 0
+      vertex 76.1918 47.8521 0
+    endloop
+  endfacet
+  facet normal -0.890972 0.454058 0
+    outer loop
+      vertex 79.848 49.4343 0
+      vertex 79.9407 49.6162 3
+      vertex 79.9407 49.6162 0
+    endloop
+  endfacet
+  facet normal -0.890972 0.454058 0
+    outer loop
+      vertex 79.9407 49.6162 3
+      vertex 79.848 49.4343 0
+      vertex 79.848 49.4343 3
+    endloop
+  endfacet
+  facet normal -0.917746 -0.397168 0
+    outer loop
+      vertex 80.0218 52.1964 0
+      vertex 79.9407 52.3838 3
+      vertex 79.9407 52.3838 0
+    endloop
+  endfacet
+  facet normal -0.917746 -0.397168 0
+    outer loop
+      vertex 79.9407 52.3838 3
+      vertex 80.0218 52.1964 0
+      vertex 80.0218 52.1964 3
+    endloop
+  endfacet
+  facet normal -0.940975 0.338477 0
+    outer loop
+      vertex 80.0218 49.8036 0
+      vertex 80.0909 49.9957 3
+      vertex 80.0909 49.9957 0
+    endloop
+  endfacet
+  facet normal -0.940975 0.338477 0
+    outer loop
+      vertex 80.0909 49.9957 3
+      vertex 80.0218 49.8036 0
+      vertex 80.0218 49.8036 3
+    endloop
+  endfacet
+  facet normal 0.860761 0.50901 0
+    outer loop
+      vertex 74.2559 49.2586 3
+      vertex 74.152 49.4343 0
+      vertex 74.152 49.4343 3
+    endloop
+  endfacet
+  facet normal 0.860761 0.50901 0
+    outer loop
+      vertex 74.152 49.4343 0
+      vertex 74.2559 49.2586 3
+      vertex 74.2559 49.2586 0
+    endloop
+  endfacet
+  facet normal 0.790196 0.612855 0
+    outer loop
+      vertex 74.4958 48.9284 3
+      vertex 74.3707 49.0897 0
+      vertex 74.3707 49.0897 3
+    endloop
+  endfacet
+  facet normal 0.790196 0.612855 0
+    outer loop
+      vertex 74.3707 49.0897 0
+      vertex 74.4958 48.9284 3
+      vertex 74.4958 48.9284 0
+    endloop
+  endfacet
+  facet normal -0.397168 -0.917746 0
+    outer loop
+      vertex 78.1964 54.0218 0
+      vertex 78.3838 53.9407 3
+      vertex 78.1964 54.0218 3
+    endloop
+  endfacet
+  facet normal -0.397168 -0.917746 -0
+    outer loop
+      vertex 78.3838 53.9407 3
+      vertex 78.1964 54.0218 0
+      vertex 78.3838 53.9407 0
+    endloop
+  endfacet
+  facet normal -0.999509 0.0313418 0
+    outer loop
+      vertex 80.2436 50.7959 0
+      vertex 80.25 51 3
+      vertex 80.25 51 0
+    endloop
+  endfacet
+  facet normal -0.999509 0.0313418 0
+    outer loop
+      vertex 80.25 51 3
+      vertex 80.2436 50.7959 0
+      vertex 80.2436 50.7959 3
+    endloop
+  endfacet
+  facet normal -0.960257 -0.279116 0
+    outer loop
+      vertex 80.1479 51.8082 0
+      vertex 80.0909 52.0043 3
+      vertex 80.0909 52.0043 0
+    endloop
+  endfacet
+  facet normal -0.960257 -0.279116 0
+    outer loop
+      vertex 80.0909 52.0043 3
+      vertex 80.1479 51.8082 0
+      vertex 80.1479 51.8082 3
+    endloop
+  endfacet
+  facet normal -0.860761 -0.50901 0
+    outer loop
+      vertex 79.848 52.5657 0
+      vertex 79.7441 52.7414 3
+      vertex 79.7441 52.7414 0
+    endloop
+  endfacet
+  facet normal -0.860761 -0.50901 0
+    outer loop
+      vertex 79.7441 52.7414 3
+      vertex 79.848 52.5657 0
+      vertex 79.848 52.5657 3
+    endloop
+  endfacet
+  facet normal -0.50901 -0.860761 0
+    outer loop
+      vertex 78.5657 53.848 0
+      vertex 78.7414 53.7441 3
+      vertex 78.5657 53.848 3
+    endloop
+  endfacet
+  facet normal -0.50901 -0.860761 -0
+    outer loop
+      vertex 78.7414 53.7441 3
+      vertex 78.5657 53.848 0
+      vertex 78.7414 53.7441 0
+    endloop
+  endfacet
+  facet normal -0.454058 -0.890972 0
+    outer loop
+      vertex 78.3838 53.9407 0
+      vertex 78.5657 53.848 3
+      vertex 78.3838 53.9407 3
+    endloop
+  endfacet
+  facet normal -0.454058 -0.890972 -0
+    outer loop
+      vertex 78.5657 53.848 3
+      vertex 78.3838 53.9407 0
+      vertex 78.5657 53.848 0
+    endloop
+  endfacet
+  facet normal -0.156692 -0.987648 0
+    outer loop
+      vertex 77.4073 54.2244 0
+      vertex 77.609 54.1924 7.5
+      vertex 77.4073 54.2244 7.5
+    endloop
+  endfacet
+  facet normal -0.156692 -0.987648 -0
+    outer loop
+      vertex 77.609 54.1924 7.5
+      vertex 77.4073 54.2244 0
+      vertex 77.609 54.1924 0
+    endloop
+  endfacet
+  facet normal -0.338477 0.940975 0
+    outer loop
+      vertex 78.1964 47.9782 0
+      vertex 78.0043 47.9091 3
+      vertex 78.1964 47.9782 3
+    endloop
+  endfacet
+  facet normal -0.338477 0.940975 0
+    outer loop
+      vertex 78.0043 47.9091 3
+      vertex 78.1964 47.9782 0
+      vertex 78.0043 47.9091 0
+    endloop
+  endfacet
+  facet normal 0.0313418 0.999509 -0
+    outer loop
+      vertex 77 47.75 0
+      vertex 76.7959 47.7564 3
+      vertex 77 47.75 3
+    endloop
+  endfacet
+  facet normal 0.0313418 0.999509 0
+    outer loop
+      vertex 76.7959 47.7564 3
+      vertex 77 47.75 0
+      vertex 76.7959 47.7564 0
+    endloop
+  endfacet
+  facet normal 0.975944 -0.21802 0
+    outer loop
+      vertex 73.8076 51.609 3
+      vertex 73.8521 51.8082 0
+      vertex 73.8521 51.8082 3
+    endloop
+  endfacet
+  facet normal 0.975944 -0.21802 0
+    outer loop
+      vertex 73.8521 51.8082 0
+      vertex 73.8076 51.609 3
+      vertex 73.8076 51.609 0
+    endloop
+  endfacet
+  facet normal 0.987648 0.156692 0
+    outer loop
+      vertex 73.8076 50.391 3
+      vertex 73.7756 50.5927 0
+      vertex 73.7756 50.5927 3
+    endloop
+  endfacet
+  facet normal 0.987648 0.156692 0
+    outer loop
+      vertex 73.7756 50.5927 0
+      vertex 73.8076 50.391 3
+      vertex 73.8076 50.391 0
+    endloop
+  endfacet
+  facet normal 0.0940692 -0.995566 0
+    outer loop
+      vertex 76.5927 54.2244 0
+      vertex 76.7959 54.2436 7.5
+      vertex 76.5927 54.2244 7.5
+    endloop
+  endfacet
+  facet normal 0.0940692 -0.995566 0
+    outer loop
+      vertex 76.7959 54.2436 7.5
+      vertex 76.5927 54.2244 0
+      vertex 76.7959 54.2436 0
+    endloop
+  endfacet
+  facet normal -0.827045 -0.562136 0
+    outer loop
+      vertex 79.7441 52.7414 0
+      vertex 79.6293 52.9103 3
+      vertex 79.6293 52.9103 0
+    endloop
+  endfacet
+  facet normal -0.827045 -0.562136 0
+    outer loop
+      vertex 79.6293 52.9103 3
+      vertex 79.7441 52.7414 0
+      vertex 79.7441 52.7414 3
+    endloop
+  endfacet
+  facet normal 0.827045 0.562136 0
+    outer loop
+      vertex 74.3707 49.0897 3
+      vertex 74.2559 49.2586 0
+      vertex 74.2559 49.2586 3
+    endloop
+  endfacet
+  facet normal 0.827045 0.562136 0
+    outer loop
+      vertex 74.2559 49.2586 0
+      vertex 74.3707 49.0897 3
+      vertex 74.3707 49.0897 0
+    endloop
+  endfacet
+  facet normal -0.21802 0.975944 0
+    outer loop
+      vertex 77.8082 47.8521 0
+      vertex 77.609 47.8076 3
+      vertex 77.8082 47.8521 3
+    endloop
+  endfacet
+  facet normal -0.21802 0.975944 0
+    outer loop
+      vertex 77.609 47.8076 3
+      vertex 77.8082 47.8521 0
+      vertex 77.609 47.8076 0
+    endloop
+  endfacet
+  facet normal -0.975944 0.21802 0
+    outer loop
+      vertex 80.1479 50.1918 0
+      vertex 80.1924 50.391 3
+      vertex 80.1924 50.391 0
+    endloop
+  endfacet
+  facet normal -0.975944 0.21802 0
+    outer loop
+      vertex 80.1924 50.391 3
+      vertex 80.1479 50.1918 0
+      vertex 80.1479 50.1918 3
+    endloop
+  endfacet
+  facet normal -0.0313418 0.999509 0
+    outer loop
+      vertex 77.2041 47.7564 0
+      vertex 77 47.75 3
+      vertex 77.2041 47.7564 3
+    endloop
+  endfacet
+  facet normal -0.0313418 0.999509 0
+    outer loop
+      vertex 77 47.75 3
+      vertex 77.2041 47.7564 0
+      vertex 77 47.75 0
+    endloop
+  endfacet
+  facet normal -0.661411 0.750024 0
+    outer loop
+      vertex 79.2248 48.6309 0
+      vertex 79.0716 48.4958 3
+      vertex 79.2248 48.6309 3
+    endloop
+  endfacet
+  facet normal -0.661411 0.750024 0
+    outer loop
+      vertex 79.0716 48.4958 3
+      vertex 79.2248 48.6309 0
+      vertex 79.0716 48.4958 0
+    endloop
+  endfacet
+  facet normal -0.156692 0.987648 0
+    outer loop
+      vertex 77.609 47.8076 0
+      vertex 77.4073 47.7756 3
+      vertex 77.609 47.8076 3
+    endloop
+  endfacet
+  facet normal -0.156692 0.987648 0
+    outer loop
+      vertex 77.4073 47.7756 3
+      vertex 77.609 47.8076 0
+      vertex 77.4073 47.7756 0
+    endloop
+  endfacet
+  facet normal 0.960257 -0.279116 0
+    outer loop
+      vertex 73.8521 51.8082 3
+      vertex 73.9091 52.0043 0
+      vertex 73.9091 52.0043 3
+    endloop
+  endfacet
+  facet normal 0.960257 -0.279116 0
+    outer loop
+      vertex 73.9091 52.0043 0
+      vertex 73.8521 51.8082 3
+      vertex 73.8521 51.8082 0
+    endloop
+  endfacet
+  facet normal -0.397168 0.917746 0
+    outer loop
+      vertex 78.3838 48.0593 0
+      vertex 78.1964 47.9782 3
+      vertex 78.3838 48.0593 3
+    endloop
+  endfacet
+  facet normal -0.397168 0.917746 0
+    outer loop
+      vertex 78.1964 47.9782 3
+      vertex 78.3838 48.0593 0
+      vertex 78.1964 47.9782 0
+    endloop
+  endfacet
+  facet normal 0.562136 -0.827045 0
+    outer loop
+      vertex 75.0897 53.6293 0
+      vertex 75.2586 53.7441 3
+      vertex 75.0897 53.6293 3
+    endloop
+  endfacet
+  facet normal 0.562136 -0.827045 0
+    outer loop
+      vertex 75.2586 53.7441 3
+      vertex 75.0897 53.6293 0
+      vertex 75.2586 53.7441 0
+    endloop
+  endfacet
+  facet normal 0.661411 0.750024 -0
+    outer loop
+      vertex 74.9284 48.4958 0
+      vertex 74.7752 48.6309 3
+      vertex 74.9284 48.4958 3
+    endloop
+  endfacet
+  facet normal 0.661411 0.750024 0
+    outer loop
+      vertex 74.7752 48.6309 3
+      vertex 74.9284 48.4958 0
+      vertex 74.7752 48.6309 0
+    endloop
+  endfacet
+  facet normal -0.279116 0.960257 0
+    outer loop
+      vertex 78.0043 47.9091 0
+      vertex 77.8082 47.8521 3
+      vertex 78.0043 47.9091 3
+    endloop
+  endfacet
+  facet normal -0.279116 0.960257 0
+    outer loop
+      vertex 77.8082 47.8521 3
+      vertex 78.0043 47.9091 0
+      vertex 77.8082 47.8521 0
+    endloop
+  endfacet
+  facet normal 0.661411 -0.750024 0
+    outer loop
+      vertex 74.7752 53.3691 0
+      vertex 74.9284 53.5042 3
+      vertex 74.7752 53.3691 3
+    endloop
+  endfacet
+  facet normal 0.661411 -0.750024 0
+    outer loop
+      vertex 74.9284 53.5042 3
+      vertex 74.7752 53.3691 0
+      vertex 74.9284 53.5042 0
+    endloop
+  endfacet
+  facet normal -0.917746 0.397168 0
+    outer loop
+      vertex 79.9407 49.6162 0
+      vertex 80.0218 49.8036 3
+      vertex 80.0218 49.8036 0
+    endloop
+  endfacet
+  facet normal -0.917746 0.397168 0
+    outer loop
+      vertex 80.0218 49.8036 3
+      vertex 79.9407 49.6162 0
+      vertex 79.9407 49.6162 3
+    endloop
+  endfacet
+  facet normal 0.156692 -0.987648 0
+    outer loop
+      vertex 76.391 54.1924 0
+      vertex 76.5927 54.2244 7.5
+      vertex 76.391 54.1924 7.5
+    endloop
+  endfacet
+  facet normal 0.156692 -0.987648 0
+    outer loop
+      vertex 76.5927 54.2244 7.5
+      vertex 76.391 54.1924 0
+      vertex 76.5927 54.2244 0
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 0
+    outer loop
+      vertex 79.2248 48.6309 0
+      vertex 79.3691 48.7752 3
+      vertex 79.3691 48.7752 0
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 0
+    outer loop
+      vertex 79.3691 48.7752 3
+      vertex 79.2248 48.6309 0
+      vertex 79.2248 48.6309 3
+    endloop
+  endfacet
+  facet normal -0.790196 0.612855 0
+    outer loop
+      vertex 79.5042 48.9284 0
+      vertex 79.6293 49.0897 3
+      vertex 79.6293 49.0897 0
+    endloop
+  endfacet
+  facet normal -0.790196 0.612855 0
+    outer loop
+      vertex 79.6293 49.0897 3
+      vertex 79.5042 48.9284 0
+      vertex 79.5042 48.9284 3
+    endloop
+  endfacet
+  facet normal 0.975944 0.21802 0
+    outer loop
+      vertex 73.8521 50.1918 3
+      vertex 73.8076 50.391 0
+      vertex 73.8076 50.391 3
+    endloop
+  endfacet
+  facet normal 0.975944 0.21802 0
+    outer loop
+      vertex 73.8076 50.391 0
+      vertex 73.8521 50.1918 3
+      vertex 73.8521 50.1918 0
+    endloop
+  endfacet
+  facet normal 0.999509 -0.0313418 0
+    outer loop
+      vertex 73.75 51 3
+      vertex 73.7564 51.2041 0
+      vertex 73.7564 51.2041 3
+    endloop
+  endfacet
+  facet normal 0.999509 -0.0313418 0
+    outer loop
+      vertex 73.7564 51.2041 0
+      vertex 73.75 51 3
+      vertex 73.75 51 0
+    endloop
+  endfacet
+  facet normal -0.987648 0.156692 0
+    outer loop
+      vertex 80.1924 50.391 0
+      vertex 80.2244 50.5927 3
+      vertex 80.2244 50.5927 0
+    endloop
+  endfacet
+  facet normal -0.987648 0.156692 0
+    outer loop
+      vertex 80.2244 50.5927 3
+      vertex 80.1924 50.391 0
+      vertex 80.1924 50.391 3
+    endloop
+  endfacet
+  facet normal 0.995566 -0.0940692 0
+    outer loop
+      vertex 73.7564 51.2041 3
+      vertex 73.7756 51.4073 0
+      vertex 73.7756 51.4073 3
+    endloop
+  endfacet
+  facet normal 0.995566 -0.0940692 0
+    outer loop
+      vertex 73.7756 51.4073 0
+      vertex 73.7564 51.2041 3
+      vertex 73.7564 51.2041 0
+    endloop
+  endfacet
+  facet normal -0.750024 0.661411 0
+    outer loop
+      vertex 79.3691 48.7752 0
+      vertex 79.5042 48.9284 3
+      vertex 79.5042 48.9284 0
+    endloop
+  endfacet
+  facet normal -0.750024 0.661411 0
+    outer loop
+      vertex 79.5042 48.9284 3
+      vertex 79.3691 48.7752 0
+      vertex 79.3691 48.7752 3
+    endloop
+  endfacet
+  facet normal -0.860761 0.50901 0
+    outer loop
+      vertex 79.7441 49.2586 0
+      vertex 79.848 49.4343 3
+      vertex 79.848 49.4343 0
+    endloop
+  endfacet
+  facet normal -0.860761 0.50901 0
+    outer loop
+      vertex 79.848 49.4343 3
+      vertex 79.7441 49.2586 0
+      vertex 79.7441 49.2586 3
+    endloop
+  endfacet
+  facet normal -0.612855 0.790196 0
+    outer loop
+      vertex 79.0716 48.4958 0
+      vertex 78.9103 48.3707 3
+      vertex 79.0716 48.4958 3
+    endloop
+  endfacet
+  facet normal -0.612855 0.790196 0
+    outer loop
+      vertex 78.9103 48.3707 3
+      vertex 79.0716 48.4958 0
+      vertex 78.9103 48.3707 0
+    endloop
+  endfacet
+  facet normal 0.827045 -0.562136 0
+    outer loop
+      vertex 74.2559 52.7414 3
+      vertex 74.3707 52.9103 0
+      vertex 74.3707 52.9103 3
+    endloop
+  endfacet
+  facet normal 0.827045 -0.562136 0
+    outer loop
+      vertex 74.3707 52.9103 0
+      vertex 74.2559 52.7414 3
+      vertex 74.2559 52.7414 0
+    endloop
+  endfacet
+  facet normal 0.338477 -0.940975 0
+    outer loop
+      vertex 75.8036 54.0218 0
+      vertex 75.9957 54.0909 7.5
+      vertex 75.8036 54.0218 7.5
+    endloop
+  endfacet
+  facet normal 0.338477 -0.940975 0
+    outer loop
+      vertex 75.9957 54.0909 7.5
+      vertex 75.8036 54.0218 0
+      vertex 75.9957 54.0909 0
+    endloop
+  endfacet
+  facet normal 0.917746 -0.397168 0
+    outer loop
+      vertex 73.9782 52.1964 3
+      vertex 74.0593 52.3838 0
+      vertex 74.0593 52.3838 3
+    endloop
+  endfacet
+  facet normal 0.917746 -0.397168 0
+    outer loop
+      vertex 74.0593 52.3838 0
+      vertex 73.9782 52.1964 3
+      vertex 73.9782 52.1964 0
+    endloop
+  endfacet
+  facet normal 0.562136 0.827045 -0
+    outer loop
+      vertex 75.2586 48.2559 0
+      vertex 75.0897 48.3707 3
+      vertex 75.2586 48.2559 3
+    endloop
+  endfacet
+  facet normal 0.562136 0.827045 0
+    outer loop
+      vertex 75.0897 48.3707 3
+      vertex 75.2586 48.2559 0
+      vertex 75.0897 48.3707 0
+    endloop
+  endfacet
+  facet normal 0.917746 0.397168 0
+    outer loop
+      vertex 74.0593 49.6162 3
+      vertex 73.9782 49.8036 0
+      vertex 73.9782 49.8036 3
+    endloop
+  endfacet
+  facet normal 0.917746 0.397168 0
+    outer loop
+      vertex 73.9782 49.8036 0
+      vertex 74.0593 49.6162 3
+      vertex 74.0593 49.6162 0
+    endloop
+  endfacet
+  facet normal 0.612855 -0.790196 0
+    outer loop
+      vertex 74.9284 53.5042 0
+      vertex 75.0897 53.6293 3
+      vertex 74.9284 53.5042 3
+    endloop
+  endfacet
+  facet normal 0.612855 -0.790196 0
+    outer loop
+      vertex 75.0897 53.6293 3
+      vertex 74.9284 53.5042 0
+      vertex 75.0897 53.6293 0
+    endloop
+  endfacet
+  facet normal -0.21802 -0.975944 0
+    outer loop
+      vertex 77.609 54.1924 0
+      vertex 77.8082 54.1479 7.5
+      vertex 77.609 54.1924 7.5
+    endloop
+  endfacet
+  facet normal -0.21802 -0.975944 -0
+    outer loop
+      vertex 77.8082 54.1479 7.5
+      vertex 77.609 54.1924 0
+      vertex 77.8082 54.1479 0
+    endloop
+  endfacet
+  facet normal 0.50901 0.860761 -0
+    outer loop
+      vertex 75.4343 48.152 0
+      vertex 75.2586 48.2559 3
+      vertex 75.4343 48.152 3
+    endloop
+  endfacet
+  facet normal 0.50901 0.860761 0
+    outer loop
+      vertex 75.2586 48.2559 3
+      vertex 75.4343 48.152 0
+      vertex 75.2586 48.2559 0
+    endloop
+  endfacet
+  facet normal 0.454058 0.890972 -0
+    outer loop
+      vertex 75.6162 48.0593 0
+      vertex 75.4343 48.152 3
+      vertex 75.6162 48.0593 3
+    endloop
+  endfacet
+  facet normal 0.454058 0.890972 0
+    outer loop
+      vertex 75.4343 48.152 3
+      vertex 75.6162 48.0593 0
+      vertex 75.4343 48.152 0
+    endloop
+  endfacet
+  facet normal 0.397168 0.917746 -0
+    outer loop
+      vertex 75.8036 47.9782 0
+      vertex 75.6162 48.0593 3
+      vertex 75.8036 47.9782 3
+    endloop
+  endfacet
+  facet normal 0.397168 0.917746 0
+    outer loop
+      vertex 75.6162 48.0593 3
+      vertex 75.8036 47.9782 0
+      vertex 75.6162 48.0593 0
+    endloop
+  endfacet
+  facet normal 0.750024 0.661411 0
+    outer loop
+      vertex 74.6309 48.7752 3
+      vertex 74.4958 48.9284 0
+      vertex 74.4958 48.9284 3
+    endloop
+  endfacet
+  facet normal 0.750024 0.661411 0
+    outer loop
+      vertex 74.4958 48.9284 0
+      vertex 74.6309 48.7752 3
+      vertex 74.6309 48.7752 0
+    endloop
+  endfacet
+  facet normal -0.0313418 -0.999509 0
+    outer loop
+      vertex 77 54.25 0
+      vertex 77.2041 54.2436 7.5
+      vertex 77 54.25 7.5
+    endloop
+  endfacet
+  facet normal -0.0313418 -0.999509 -0
+    outer loop
+      vertex 77.2041 54.2436 7.5
+      vertex 77 54.25 0
+      vertex 77.2041 54.2436 0
+    endloop
+  endfacet
+  facet normal 0.0313418 -0.999509 0
+    outer loop
+      vertex 76.7959 54.2436 0
+      vertex 77 54.25 7.5
+      vertex 76.7959 54.2436 7.5
+    endloop
+  endfacet
+  facet normal 0.0313418 -0.999509 0
+    outer loop
+      vertex 77 54.25 7.5
+      vertex 76.7959 54.2436 0
+      vertex 77 54.25 0
+    endloop
+  endfacet
+  facet normal 0.0940692 0.995566 -0
+    outer loop
+      vertex 76.7959 47.7564 0
+      vertex 76.5927 47.7756 3
+      vertex 76.7959 47.7564 3
+    endloop
+  endfacet
+  facet normal 0.0940692 0.995566 0
+    outer loop
+      vertex 76.5927 47.7756 3
+      vertex 76.7959 47.7564 0
+      vertex 76.5927 47.7756 0
+    endloop
+  endfacet
+  facet normal 0.156692 0.987648 -0
+    outer loop
+      vertex 76.5927 47.7756 0
+      vertex 76.391 47.8076 3
+      vertex 76.5927 47.7756 3
+    endloop
+  endfacet
+  facet normal 0.156692 0.987648 0
+    outer loop
+      vertex 76.391 47.8076 3
+      vertex 76.5927 47.7756 0
+      vertex 76.391 47.8076 0
+    endloop
+  endfacet
+  facet normal 0.279116 0.960257 -0
+    outer loop
+      vertex 76.1918 47.8521 0
+      vertex 75.9957 47.9091 3
+      vertex 76.1918 47.8521 3
+    endloop
+  endfacet
+  facet normal 0.279116 0.960257 0
+    outer loop
+      vertex 75.9957 47.9091 3
+      vertex 76.1918 47.8521 0
+      vertex 75.9957 47.9091 0
+    endloop
+  endfacet
+  facet normal 0.940975 -0.338477 0
+    outer loop
+      vertex 73.9091 52.0043 3
+      vertex 73.9782 52.1964 0
+      vertex 73.9782 52.1964 3
+    endloop
+  endfacet
+  facet normal 0.940975 -0.338477 0
+    outer loop
+      vertex 73.9782 52.1964 0
+      vertex 73.9091 52.0043 3
+      vertex 73.9091 52.0043 0
+    endloop
+  endfacet
+  facet normal 0.50901 -0.860761 0
+    outer loop
+      vertex 75.2586 53.7441 0
+      vertex 75.4343 53.848 3
+      vertex 75.2586 53.7441 3
+    endloop
+  endfacet
+  facet normal 0.50901 -0.860761 0
+    outer loop
+      vertex 75.4343 53.848 3
+      vertex 75.2586 53.7441 0
+      vertex 75.4343 53.848 0
+    endloop
+  endfacet
+  facet normal -0.750024 -0.661411 0
+    outer loop
+      vertex 79.5042 53.0716 0
+      vertex 79.3691 53.2248 3
+      vertex 79.3691 53.2248 0
+    endloop
+  endfacet
+  facet normal -0.750024 -0.661411 0
+    outer loop
+      vertex 79.3691 53.2248 3
+      vertex 79.5042 53.0716 0
+      vertex 79.5042 53.0716 3
+    endloop
+  endfacet
+  facet normal 0.890972 0.454058 0
+    outer loop
+      vertex 74.152 49.4343 3
+      vertex 74.0593 49.6162 0
+      vertex 74.0593 49.6162 3
+    endloop
+  endfacet
+  facet normal 0.890972 0.454058 0
+    outer loop
+      vertex 74.0593 49.6162 0
+      vertex 74.152 49.4343 3
+      vertex 74.152 49.4343 0
+    endloop
+  endfacet
+  facet normal -0.562136 0.827045 0
+    outer loop
+      vertex 78.9103 48.3707 0
+      vertex 78.7414 48.2559 3
+      vertex 78.9103 48.3707 3
+    endloop
+  endfacet
+  facet normal -0.562136 0.827045 0
+    outer loop
+      vertex 78.7414 48.2559 3
+      vertex 78.9103 48.3707 0
+      vertex 78.7414 48.2559 0
+    endloop
+  endfacet
+  facet normal 0.454058 -0.890972 0
+    outer loop
+      vertex 75.4343 53.848 0
+      vertex 75.6162 53.9407 3
+      vertex 75.4343 53.848 3
+    endloop
+  endfacet
+  facet normal 0.454058 -0.890972 0
+    outer loop
+      vertex 75.6162 53.9407 3
+      vertex 75.4343 53.848 0
+      vertex 75.6162 53.9407 0
+    endloop
+  endfacet
+  facet normal 0.960257 0.279116 0
+    outer loop
+      vertex 73.9091 49.9957 3
+      vertex 73.8521 50.1918 0
+      vertex 73.8521 50.1918 3
+    endloop
+  endfacet
+  facet normal 0.960257 0.279116 0
+    outer loop
+      vertex 73.8521 50.1918 0
+      vertex 73.9091 49.9957 3
+      vertex 73.9091 49.9957 0
+    endloop
+  endfacet
+  facet normal 0.940975 0.338477 0
+    outer loop
+      vertex 73.9782 49.8036 3
+      vertex 73.9091 49.9957 0
+      vertex 73.9091 49.9957 3
+    endloop
+  endfacet
+  facet normal 0.940975 0.338477 0
+    outer loop
+      vertex 73.9091 49.9957 0
+      vertex 73.9782 49.8036 3
+      vertex 73.9782 49.8036 0
+    endloop
+  endfacet
+  facet normal 0.612855 0.790196 -0
+    outer loop
+      vertex 75.0897 48.3707 0
+      vertex 74.9284 48.4958 3
+      vertex 75.0897 48.3707 3
+    endloop
+  endfacet
+  facet normal 0.612855 0.790196 0
+    outer loop
+      vertex 74.9284 48.4958 3
+      vertex 75.0897 48.3707 0
+      vertex 74.9284 48.4958 0
+    endloop
+  endfacet
+  facet normal 0.951076 0.308956 0
+    outer loop
+      vertex 75.5878 83.5398 7.5
+      vertex 75.5393 83.6891 0
+      vertex 75.5393 83.6891 7.5
+    endloop
+  endfacet
+  facet normal 0.951076 0.308956 0
+    outer loop
+      vertex 75.5393 83.6891 0
+      vertex 75.5878 83.5398 7.5
+      vertex 75.5878 83.5398 0
+    endloop
+  endfacet
+  facet normal -0.982305 -0.187288 0
+    outer loop
+      vertex 77.9901 84.1567 0
+      vertex 77.9607 84.3109 7.5
+      vertex 77.9607 84.3109 0
+    endloop
+  endfacet
+  facet normal -0.982305 -0.187288 0
+    outer loop
+      vertex 77.9607 84.3109 7.5
+      vertex 77.9901 84.1567 0
+      vertex 77.9901 84.1567 7.5
+    endloop
+  endfacet
+  facet normal -0.99801 -0.0630523 0
+    outer loop
+      vertex 78 84 0
+      vertex 77.9901 84.1567 7.5
+      vertex 77.9901 84.1567 0
+    endloop
+  endfacet
+  facet normal -0.99801 -0.0630523 0
+    outer loop
+      vertex 77.9901 84.1567 7.5
+      vertex 78 84 0
+      vertex 78 84 7.5
+    endloop
+  endfacet
+  facet normal 0.982305 -0.187288 0
+    outer loop
+      vertex 75.5099 84.1567 7.5
+      vertex 75.5393 84.3109 0
+      vertex 75.5393 84.3109 7.5
+    endloop
+  endfacet
+  facet normal 0.982305 -0.187288 0
+    outer loop
+      vertex 75.5393 84.3109 0
+      vertex 75.5099 84.1567 7.5
+      vertex 75.5099 84.1567 0
+    endloop
+  endfacet
+  facet normal 0.248973 -0.96851 0
+    outer loop
+      vertex 76.3637 85.1888 0
+      vertex 76.5158 85.2279 7.5
+      vertex 76.3637 85.1888 7.5
+    endloop
+  endfacet
+  facet normal 0.248973 -0.96851 0
+    outer loop
+      vertex 76.5158 85.2279 7.5
+      vertex 76.3637 85.1888 0
+      vertex 76.5158 85.2279 0
+    endloop
+  endfacet
+  facet normal -0.68445 -0.72906 0
+    outer loop
+      vertex 77.5468 84.9631 0
+      vertex 77.6612 84.8557 7.5
+      vertex 77.5468 84.9631 7.5
+    endloop
+  endfacet
+  facet normal -0.68445 -0.72906 -0
+    outer loop
+      vertex 77.6612 84.8557 7.5
+      vertex 77.5468 84.9631 0
+      vertex 77.6612 84.8557 0
+    endloop
+  endfacet
+  facet normal -0.248973 0.96851 0
+    outer loop
+      vertex 77.1363 82.8112 0
+      vertex 76.9842 82.7721 7.5
+      vertex 77.1363 82.8112 7.5
+    endloop
+  endfacet
+  facet normal -0.248973 0.96851 0
+    outer loop
+      vertex 76.9842 82.7721 7.5
+      vertex 77.1363 82.8112 0
+      vertex 76.9842 82.7721 0
+    endloop
+  endfacet
+  facet normal 0.904876 0.425674 0
+    outer loop
+      vertex 75.6546 83.3978 7.5
+      vertex 75.5878 83.5398 0
+      vertex 75.5878 83.5398 7.5
+    endloop
+  endfacet
+  facet normal 0.904876 0.425674 0
+    outer loop
+      vertex 75.5878 83.5398 0
+      vertex 75.6546 83.3978 7.5
+      vertex 75.6546 83.3978 0
+    endloop
+  endfacet
+  facet normal 0.951076 -0.308956 0
+    outer loop
+      vertex 75.5393 84.3109 7.5
+      vertex 75.5878 84.4602 0
+      vertex 75.5878 84.4602 7.5
+    endloop
+  endfacet
+  facet normal 0.951076 -0.308956 0
+    outer loop
+      vertex 75.5878 84.4602 0
+      vertex 75.5393 84.3109 7.5
+      vertex 75.5393 84.3109 0
+    endloop
+  endfacet
+  facet normal -0.124897 0.99217 0
+    outer loop
+      vertex 76.9842 82.7721 0
+      vertex 76.8285 82.7525 7.5
+      vertex 76.9842 82.7721 7.5
+    endloop
+  endfacet
+  facet normal -0.124897 0.99217 0
+    outer loop
+      vertex 76.8285 82.7525 7.5
+      vertex 76.9842 82.7721 0
+      vertex 76.8285 82.7525 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 76.8285 82.7525 0
+      vertex 76.6715 82.7525 7.5
+      vertex 76.8285 82.7525 7.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 76.6715 82.7525 7.5
+      vertex 76.8285 82.7525 0
+      vertex 76.6715 82.7525 0
+    endloop
+  endfacet
+  facet normal -0.982305 0.187288 0
+    outer loop
+      vertex 77.9607 83.6891 0
+      vertex 77.9901 83.8433 7.5
+      vertex 77.9901 83.8433 0
+    endloop
+  endfacet
+  facet normal -0.982305 0.187288 0
+    outer loop
+      vertex 77.9901 83.8433 7.5
+      vertex 77.9607 83.6891 0
+      vertex 77.9607 83.6891 7.5
+    endloop
+  endfacet
+  facet normal 0.587907 -0.808929 0
+    outer loop
+      vertex 75.9532 84.9631 0
+      vertex 76.0802 85.0554 7.5
+      vertex 75.9532 84.9631 7.5
+    endloop
+  endfacet
+  facet normal 0.587907 -0.808929 0
+    outer loop
+      vertex 76.0802 85.0554 7.5
+      vertex 75.9532 84.9631 0
+      vertex 76.0802 85.0554 0
+    endloop
+  endfacet
+  facet normal -0.951076 0.308956 0
+    outer loop
+      vertex 77.9122 83.5398 0
+      vertex 77.9607 83.6891 7.5
+      vertex 77.9607 83.6891 0
+    endloop
+  endfacet
+  facet normal -0.951076 0.308956 0
+    outer loop
+      vertex 77.9607 83.6891 7.5
+      vertex 77.9122 83.5398 0
+      vertex 77.9122 83.5398 7.5
+    endloop
+  endfacet
+  facet normal 0.99801 0.0630523 0
+    outer loop
+      vertex 75.5099 83.8433 7.5
+      vertex 75.5 84 0
+      vertex 75.5 84 7.5
+    endloop
+  endfacet
+  facet normal 0.99801 0.0630523 0
+    outer loop
+      vertex 75.5 84 0
+      vertex 75.5099 83.8433 7.5
+      vertex 75.5099 83.8433 0
+    endloop
+  endfacet
+  facet normal 0.368312 -0.929702 0
+    outer loop
+      vertex 76.2178 85.131 0
+      vertex 76.3637 85.1888 7.5
+      vertex 76.2178 85.131 7.5
+    endloop
+  endfacet
+  facet normal 0.368312 -0.929702 0
+    outer loop
+      vertex 76.3637 85.1888 7.5
+      vertex 76.2178 85.131 0
+      vertex 76.3637 85.1888 0
+    endloop
+  endfacet
+  facet normal -0.124897 -0.99217 0
+    outer loop
+      vertex 76.8285 85.2475 0
+      vertex 76.9842 85.2279 7.5
+      vertex 76.8285 85.2475 7.5
+    endloop
+  endfacet
+  facet normal -0.124897 -0.99217 -0
+    outer loop
+      vertex 76.9842 85.2279 7.5
+      vertex 76.8285 85.2475 0
+      vertex 76.9842 85.2279 0
+    endloop
+  endfacet
+  facet normal -0.481527 0.876431 0
+    outer loop
+      vertex 77.4198 82.9446 0
+      vertex 77.2822 82.869 7.5
+      vertex 77.4198 82.9446 7.5
+    endloop
+  endfacet
+  facet normal -0.481527 0.876431 0
+    outer loop
+      vertex 77.2822 82.869 7.5
+      vertex 77.4198 82.9446 0
+      vertex 77.2822 82.869 0
+    endloop
+  endfacet
+  facet normal -0.904876 0.425674 0
+    outer loop
+      vertex 77.8454 83.3978 0
+      vertex 77.9122 83.5398 7.5
+      vertex 77.9122 83.5398 0
+    endloop
+  endfacet
+  facet normal -0.904876 0.425674 0
+    outer loop
+      vertex 77.9122 83.5398 7.5
+      vertex 77.8454 83.3978 0
+      vertex 77.8454 83.3978 7.5
+    endloop
+  endfacet
+  facet normal -0.368312 0.929702 0
+    outer loop
+      vertex 77.2822 82.869 0
+      vertex 77.1363 82.8112 7.5
+      vertex 77.2822 82.869 7.5
+    endloop
+  endfacet
+  facet normal -0.368312 0.929702 0
+    outer loop
+      vertex 77.1363 82.8112 7.5
+      vertex 77.2822 82.869 0
+      vertex 77.1363 82.8112 0
+    endloop
+  endfacet
+  facet normal 0.904876 -0.425674 0
+    outer loop
+      vertex 75.5878 84.4602 7.5
+      vertex 75.6546 84.6022 0
+      vertex 75.6546 84.6022 7.5
+    endloop
+  endfacet
+  facet normal 0.904876 -0.425674 0
+    outer loop
+      vertex 75.6546 84.6022 0
+      vertex 75.5878 84.4602 7.5
+      vertex 75.5878 84.4602 0
+    endloop
+  endfacet
+  facet normal -0.904876 -0.425674 0
+    outer loop
+      vertex 77.9122 84.4602 0
+      vertex 77.8454 84.6022 7.5
+      vertex 77.8454 84.6022 0
+    endloop
+  endfacet
+  facet normal -0.904876 -0.425674 0
+    outer loop
+      vertex 77.8454 84.6022 7.5
+      vertex 77.9122 84.4602 0
+      vertex 77.9122 84.4602 7.5
+    endloop
+  endfacet
+  facet normal 0.99801 -0.0630523 0
+    outer loop
+      vertex 75.5 84 7.5
+      vertex 75.5099 84.1567 0
+      vertex 75.5099 84.1567 7.5
+    endloop
+  endfacet
+  facet normal 0.99801 -0.0630523 0
+    outer loop
+      vertex 75.5099 84.1567 0
+      vertex 75.5 84 7.5
+      vertex 75.5 84 0
+    endloop
+  endfacet
+  facet normal -0.844291 -0.535886 0
+    outer loop
+      vertex 77.8454 84.6022 0
+      vertex 77.7613 84.7347 7.5
+      vertex 77.7613 84.7347 0
+    endloop
+  endfacet
+  facet normal -0.844291 -0.535886 0
+    outer loop
+      vertex 77.7613 84.7347 7.5
+      vertex 77.8454 84.6022 0
+      vertex 77.8454 84.6022 7.5
+    endloop
+  endfacet
+  facet normal 0.68445 0.72906 -0
+    outer loop
+      vertex 75.9532 83.0369 0
+      vertex 75.8388 83.1443 7.5
+      vertex 75.9532 83.0369 7.5
+    endloop
+  endfacet
+  facet normal 0.68445 0.72906 0
+    outer loop
+      vertex 75.8388 83.1443 7.5
+      vertex 75.9532 83.0369 0
+      vertex 75.8388 83.1443 0
+    endloop
+  endfacet
+  facet normal 0.844291 0.535886 0
+    outer loop
+      vertex 75.7387 83.2653 7.5
+      vertex 75.6546 83.3978 0
+      vertex 75.6546 83.3978 7.5
+    endloop
+  endfacet
+  facet normal 0.844291 0.535886 0
+    outer loop
+      vertex 75.6546 83.3978 0
+      vertex 75.7387 83.2653 7.5
+      vertex 75.7387 83.2653 0
+    endloop
+  endfacet
+  facet normal 0.481527 0.876431 -0
+    outer loop
+      vertex 76.2178 82.869 0
+      vertex 76.0802 82.9446 7.5
+      vertex 76.2178 82.869 7.5
+    endloop
+  endfacet
+  facet normal 0.481527 0.876431 0
+    outer loop
+      vertex 76.0802 82.9446 7.5
+      vertex 76.2178 82.869 0
+      vertex 76.0802 82.9446 0
+    endloop
+  endfacet
+  facet normal -0.587907 -0.808929 0
+    outer loop
+      vertex 77.4198 85.0554 0
+      vertex 77.5468 84.9631 7.5
+      vertex 77.4198 85.0554 7.5
+    endloop
+  endfacet
+  facet normal -0.587907 -0.808929 -0
+    outer loop
+      vertex 77.5468 84.9631 7.5
+      vertex 77.4198 85.0554 0
+      vertex 77.5468 84.9631 0
+    endloop
+  endfacet
+  facet normal -0.99801 0.0630523 0
+    outer loop
+      vertex 77.9901 83.8433 0
+      vertex 78 84 7.5
+      vertex 78 84 0
+    endloop
+  endfacet
+  facet normal -0.99801 0.0630523 0
+    outer loop
+      vertex 78 84 7.5
+      vertex 77.9901 83.8433 0
+      vertex 77.9901 83.8433 7.5
+    endloop
+  endfacet
+  facet normal 0.248973 0.96851 -0
+    outer loop
+      vertex 76.5158 82.7721 0
+      vertex 76.3637 82.8112 7.5
+      vertex 76.5158 82.7721 7.5
+    endloop
+  endfacet
+  facet normal 0.248973 0.96851 0
+    outer loop
+      vertex 76.3637 82.8112 7.5
+      vertex 76.5158 82.7721 0
+      vertex 76.3637 82.8112 0
+    endloop
+  endfacet
+  facet normal 0.481527 -0.876431 0
+    outer loop
+      vertex 76.0802 85.0554 0
+      vertex 76.2178 85.131 7.5
+      vertex 76.0802 85.0554 7.5
+    endloop
+  endfacet
+  facet normal 0.481527 -0.876431 0
+    outer loop
+      vertex 76.2178 85.131 7.5
+      vertex 76.0802 85.0554 0
+      vertex 76.2178 85.131 0
+    endloop
+  endfacet
+  facet normal -0.587907 0.808929 0
+    outer loop
+      vertex 77.5468 83.0369 0
+      vertex 77.4198 82.9446 7.5
+      vertex 77.5468 83.0369 7.5
+    endloop
+  endfacet
+  facet normal -0.587907 0.808929 0
+    outer loop
+      vertex 77.4198 82.9446 7.5
+      vertex 77.5468 83.0369 0
+      vertex 77.4198 82.9446 0
+    endloop
+  endfacet
+  facet normal 0.844291 -0.535886 0
+    outer loop
+      vertex 75.6546 84.6022 7.5
+      vertex 75.7387 84.7347 0
+      vertex 75.7387 84.7347 7.5
+    endloop
+  endfacet
+  facet normal 0.844291 -0.535886 0
+    outer loop
+      vertex 75.7387 84.7347 0
+      vertex 75.6546 84.6022 7.5
+      vertex 75.6546 84.6022 0
+    endloop
+  endfacet
+  facet normal -0.248973 -0.96851 0
+    outer loop
+      vertex 76.9842 85.2279 0
+      vertex 77.1363 85.1888 7.5
+      vertex 76.9842 85.2279 7.5
+    endloop
+  endfacet
+  facet normal -0.248973 -0.96851 -0
+    outer loop
+      vertex 77.1363 85.1888 7.5
+      vertex 76.9842 85.2279 0
+      vertex 77.1363 85.1888 0
+    endloop
+  endfacet
+  facet normal 0.770513 0.637424 0
+    outer loop
+      vertex 75.8388 83.1443 7.5
+      vertex 75.7387 83.2653 0
+      vertex 75.7387 83.2653 7.5
+    endloop
+  endfacet
+  facet normal 0.770513 0.637424 0
+    outer loop
+      vertex 75.7387 83.2653 0
+      vertex 75.8388 83.1443 7.5
+      vertex 75.8388 83.1443 0
+    endloop
+  endfacet
+  facet normal -0.368312 -0.929702 0
+    outer loop
+      vertex 77.1363 85.1888 0
+      vertex 77.2822 85.131 7.5
+      vertex 77.1363 85.1888 7.5
+    endloop
+  endfacet
+  facet normal -0.368312 -0.929702 -0
+    outer loop
+      vertex 77.2822 85.131 7.5
+      vertex 77.1363 85.1888 0
+      vertex 77.2822 85.131 0
+    endloop
+  endfacet
+  facet normal 0.982305 0.187288 0
+    outer loop
+      vertex 75.5393 83.6891 7.5
+      vertex 75.5099 83.8433 0
+      vertex 75.5099 83.8433 7.5
+    endloop
+  endfacet
+  facet normal 0.982305 0.187288 0
+    outer loop
+      vertex 75.5099 83.8433 0
+      vertex 75.5393 83.6891 7.5
+      vertex 75.5393 83.6891 0
+    endloop
+  endfacet
+  facet normal -0.481527 -0.876431 0
+    outer loop
+      vertex 77.2822 85.131 0
+      vertex 77.4198 85.0554 7.5
+      vertex 77.2822 85.131 7.5
+    endloop
+  endfacet
+  facet normal -0.481527 -0.876431 -0
+    outer loop
+      vertex 77.4198 85.0554 7.5
+      vertex 77.2822 85.131 0
+      vertex 77.4198 85.0554 0
+    endloop
+  endfacet
+  facet normal 0.124897 0.99217 -0
+    outer loop
+      vertex 76.6715 82.7525 0
+      vertex 76.5158 82.7721 7.5
+      vertex 76.6715 82.7525 7.5
+    endloop
+  endfacet
+  facet normal 0.124897 0.99217 0
+    outer loop
+      vertex 76.5158 82.7721 7.5
+      vertex 76.6715 82.7525 0
+      vertex 76.5158 82.7721 0
+    endloop
+  endfacet
+  facet normal -0.844291 0.535886 0
+    outer loop
+      vertex 77.7613 83.2653 0
+      vertex 77.8454 83.3978 7.5
+      vertex 77.8454 83.3978 0
+    endloop
+  endfacet
+  facet normal -0.844291 0.535886 0
+    outer loop
+      vertex 77.8454 83.3978 7.5
+      vertex 77.7613 83.2653 0
+      vertex 77.7613 83.2653 7.5
+    endloop
+  endfacet
+  facet normal -0.770513 -0.637424 0
+    outer loop
+      vertex 77.7613 84.7347 0
+      vertex 77.6612 84.8557 7.5
+      vertex 77.6612 84.8557 0
+    endloop
+  endfacet
+  facet normal -0.770513 -0.637424 0
+    outer loop
+      vertex 77.6612 84.8557 7.5
+      vertex 77.7613 84.7347 0
+      vertex 77.7613 84.7347 7.5
+    endloop
+  endfacet
+  facet normal -0.951076 -0.308956 0
+    outer loop
+      vertex 77.9607 84.3109 0
+      vertex 77.9122 84.4602 7.5
+      vertex 77.9122 84.4602 0
+    endloop
+  endfacet
+  facet normal -0.951076 -0.308956 0
+    outer loop
+      vertex 77.9122 84.4602 7.5
+      vertex 77.9607 84.3109 0
+      vertex 77.9607 84.3109 7.5
+    endloop
+  endfacet
+  facet normal 0.68445 -0.72906 0
+    outer loop
+      vertex 75.8388 84.8557 0
+      vertex 75.9532 84.9631 7.5
+      vertex 75.8388 84.8557 7.5
+    endloop
+  endfacet
+  facet normal 0.68445 -0.72906 0
+    outer loop
+      vertex 75.9532 84.9631 7.5
+      vertex 75.8388 84.8557 0
+      vertex 75.9532 84.9631 0
+    endloop
+  endfacet
+  facet normal 0.770513 -0.637424 0
+    outer loop
+      vertex 75.7387 84.7347 7.5
+      vertex 75.8388 84.8557 0
+      vertex 75.8388 84.8557 7.5
+    endloop
+  endfacet
+  facet normal 0.770513 -0.637424 0
+    outer loop
+      vertex 75.8388 84.8557 0
+      vertex 75.7387 84.7347 7.5
+      vertex 75.7387 84.7347 0
+    endloop
+  endfacet
+  facet normal 0.587907 0.808929 -0
+    outer loop
+      vertex 76.0802 82.9446 0
+      vertex 75.9532 83.0369 7.5
+      vertex 76.0802 82.9446 7.5
+    endloop
+  endfacet
+  facet normal 0.587907 0.808929 0
+    outer loop
+      vertex 75.9532 83.0369 7.5
+      vertex 76.0802 82.9446 0
+      vertex 75.9532 83.0369 0
+    endloop
+  endfacet
+  facet normal 0.124897 -0.99217 0
+    outer loop
+      vertex 76.5158 85.2279 0
+      vertex 76.6715 85.2475 7.5
+      vertex 76.5158 85.2279 7.5
+    endloop
+  endfacet
+  facet normal 0.124897 -0.99217 0
+    outer loop
+      vertex 76.6715 85.2475 7.5
+      vertex 76.5158 85.2279 0
+      vertex 76.6715 85.2475 0
+    endloop
+  endfacet
+  facet normal -0.68445 0.72906 0
+    outer loop
+      vertex 77.6612 83.1443 0
+      vertex 77.5468 83.0369 7.5
+      vertex 77.6612 83.1443 7.5
+    endloop
+  endfacet
+  facet normal -0.68445 0.72906 0
+    outer loop
+      vertex 77.5468 83.0369 7.5
+      vertex 77.6612 83.1443 0
+      vertex 77.5468 83.0369 0
+    endloop
+  endfacet
+  facet normal -0.770513 0.637424 0
+    outer loop
+      vertex 77.6612 83.1443 0
+      vertex 77.7613 83.2653 7.5
+      vertex 77.7613 83.2653 0
+    endloop
+  endfacet
+  facet normal -0.770513 0.637424 0
+    outer loop
+      vertex 77.7613 83.2653 7.5
+      vertex 77.6612 83.1443 0
+      vertex 77.6612 83.1443 7.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 76.6715 85.2475 0
+      vertex 76.8285 85.2475 7.5
+      vertex 76.6715 85.2475 7.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 76.8285 85.2475 7.5
+      vertex 76.6715 85.2475 0
+      vertex 76.8285 85.2475 0
+    endloop
+  endfacet
+  facet normal 0.368312 0.929702 -0
+    outer loop
+      vertex 76.3637 82.8112 0
+      vertex 76.2178 82.869 7.5
+      vertex 76.3637 82.8112 7.5
+    endloop
+  endfacet
+  facet normal 0.368312 0.929702 0
+    outer loop
+      vertex 76.2178 82.869 7.5
+      vertex 76.3637 82.8112 0
+      vertex 76.2178 82.869 0
+    endloop
+  endfacet
+  facet normal 0.951076 0.308956 0
+    outer loop
+      vertex 75.5878 55.5398 7.5
+      vertex 75.5393 55.6891 0
+      vertex 75.5393 55.6891 7.5
+    endloop
+  endfacet
+  facet normal 0.951076 0.308956 0
+    outer loop
+      vertex 75.5393 55.6891 0
+      vertex 75.5878 55.5398 7.5
+      vertex 75.5878 55.5398 0
+    endloop
+  endfacet
+  facet normal -0.982305 -0.187288 0
+    outer loop
+      vertex 77.9901 56.1567 0
+      vertex 77.9607 56.3109 7.5
+      vertex 77.9607 56.3109 0
+    endloop
+  endfacet
+  facet normal -0.982305 -0.187288 0
+    outer loop
+      vertex 77.9607 56.3109 7.5
+      vertex 77.9901 56.1567 0
+      vertex 77.9901 56.1567 7.5
+    endloop
+  endfacet
+  facet normal -0.99801 -0.0630523 0
+    outer loop
+      vertex 78 56 0
+      vertex 77.9901 56.1567 7.5
+      vertex 77.9901 56.1567 0
+    endloop
+  endfacet
+  facet normal -0.99801 -0.0630523 0
+    outer loop
+      vertex 77.9901 56.1567 7.5
+      vertex 78 56 0
+      vertex 78 56 7.5
+    endloop
+  endfacet
+  facet normal 0.982305 -0.187288 0
+    outer loop
+      vertex 75.5099 56.1567 7.5
+      vertex 75.5393 56.3109 0
+      vertex 75.5393 56.3109 7.5
+    endloop
+  endfacet
+  facet normal 0.982305 -0.187288 0
+    outer loop
+      vertex 75.5393 56.3109 0
+      vertex 75.5099 56.1567 7.5
+      vertex 75.5099 56.1567 0
+    endloop
+  endfacet
+  facet normal 0.248973 -0.96851 0
+    outer loop
+      vertex 76.3637 57.1888 0
+      vertex 76.5158 57.2279 7.5
+      vertex 76.3637 57.1888 7.5
+    endloop
+  endfacet
+  facet normal 0.248973 -0.96851 0
+    outer loop
+      vertex 76.5158 57.2279 7.5
+      vertex 76.3637 57.1888 0
+      vertex 76.5158 57.2279 0
+    endloop
+  endfacet
+  facet normal -0.68445 -0.72906 0
+    outer loop
+      vertex 77.5468 56.9631 0
+      vertex 77.6612 56.8557 7.5
+      vertex 77.5468 56.9631 7.5
+    endloop
+  endfacet
+  facet normal -0.68445 -0.72906 -0
+    outer loop
+      vertex 77.6612 56.8557 7.5
+      vertex 77.5468 56.9631 0
+      vertex 77.6612 56.8557 0
+    endloop
+  endfacet
+  facet normal -0.248973 0.96851 0
+    outer loop
+      vertex 77.1363 54.8112 0
+      vertex 76.9842 54.7721 7.5
+      vertex 77.1363 54.8112 7.5
+    endloop
+  endfacet
+  facet normal -0.248973 0.96851 0
+    outer loop
+      vertex 76.9842 54.7721 7.5
+      vertex 77.1363 54.8112 0
+      vertex 76.9842 54.7721 0
+    endloop
+  endfacet
+  facet normal 0.904876 0.425674 0
+    outer loop
+      vertex 75.6546 55.3978 7.5
+      vertex 75.5878 55.5398 0
+      vertex 75.5878 55.5398 7.5
+    endloop
+  endfacet
+  facet normal 0.904876 0.425674 0
+    outer loop
+      vertex 75.5878 55.5398 0
+      vertex 75.6546 55.3978 7.5
+      vertex 75.6546 55.3978 0
+    endloop
+  endfacet
+  facet normal 0.951076 -0.308956 0
+    outer loop
+      vertex 75.5393 56.3109 7.5
+      vertex 75.5878 56.4602 0
+      vertex 75.5878 56.4602 7.5
+    endloop
+  endfacet
+  facet normal 0.951076 -0.308956 0
+    outer loop
+      vertex 75.5878 56.4602 0
+      vertex 75.5393 56.3109 7.5
+      vertex 75.5393 56.3109 0
+    endloop
+  endfacet
+  facet normal -0.124897 0.99217 0
+    outer loop
+      vertex 76.9842 54.7721 0
+      vertex 76.8285 54.7525 7.5
+      vertex 76.9842 54.7721 7.5
+    endloop
+  endfacet
+  facet normal -0.124897 0.99217 0
+    outer loop
+      vertex 76.8285 54.7525 7.5
+      vertex 76.9842 54.7721 0
+      vertex 76.8285 54.7525 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 76.8285 54.7525 0
+      vertex 76.6715 54.7525 7.5
+      vertex 76.8285 54.7525 7.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 76.6715 54.7525 7.5
+      vertex 76.8285 54.7525 0
+      vertex 76.6715 54.7525 0
+    endloop
+  endfacet
+  facet normal -0.982305 0.187288 0
+    outer loop
+      vertex 77.9607 55.6891 0
+      vertex 77.9901 55.8433 7.5
+      vertex 77.9901 55.8433 0
+    endloop
+  endfacet
+  facet normal -0.982305 0.187288 0
+    outer loop
+      vertex 77.9901 55.8433 7.5
+      vertex 77.9607 55.6891 0
+      vertex 77.9607 55.6891 7.5
+    endloop
+  endfacet
+  facet normal 0.587907 -0.808929 0
+    outer loop
+      vertex 75.9532 56.9631 0
+      vertex 76.0802 57.0554 7.5
+      vertex 75.9532 56.9631 7.5
+    endloop
+  endfacet
+  facet normal 0.587907 -0.808929 0
+    outer loop
+      vertex 76.0802 57.0554 7.5
+      vertex 75.9532 56.9631 0
+      vertex 76.0802 57.0554 0
+    endloop
+  endfacet
+  facet normal -0.951076 0.308956 0
+    outer loop
+      vertex 77.9122 55.5398 0
+      vertex 77.9607 55.6891 7.5
+      vertex 77.9607 55.6891 0
+    endloop
+  endfacet
+  facet normal -0.951076 0.308956 0
+    outer loop
+      vertex 77.9607 55.6891 7.5
+      vertex 77.9122 55.5398 0
+      vertex 77.9122 55.5398 7.5
+    endloop
+  endfacet
+  facet normal 0.99801 0.0630523 0
+    outer loop
+      vertex 75.5099 55.8433 7.5
+      vertex 75.5 56 0
+      vertex 75.5 56 7.5
+    endloop
+  endfacet
+  facet normal 0.99801 0.0630523 0
+    outer loop
+      vertex 75.5 56 0
+      vertex 75.5099 55.8433 7.5
+      vertex 75.5099 55.8433 0
+    endloop
+  endfacet
+  facet normal 0.368312 -0.929702 0
+    outer loop
+      vertex 76.2178 57.131 0
+      vertex 76.3637 57.1888 7.5
+      vertex 76.2178 57.131 7.5
+    endloop
+  endfacet
+  facet normal 0.368312 -0.929702 0
+    outer loop
+      vertex 76.3637 57.1888 7.5
+      vertex 76.2178 57.131 0
+      vertex 76.3637 57.1888 0
+    endloop
+  endfacet
+  facet normal -0.124897 -0.99217 0
+    outer loop
+      vertex 76.8285 57.2475 0
+      vertex 76.9842 57.2279 7.5
+      vertex 76.8285 57.2475 7.5
+    endloop
+  endfacet
+  facet normal -0.124897 -0.99217 -0
+    outer loop
+      vertex 76.9842 57.2279 7.5
+      vertex 76.8285 57.2475 0
+      vertex 76.9842 57.2279 0
+    endloop
+  endfacet
+  facet normal -0.481527 0.876431 0
+    outer loop
+      vertex 77.4198 54.9446 0
+      vertex 77.2822 54.869 7.5
+      vertex 77.4198 54.9446 7.5
+    endloop
+  endfacet
+  facet normal -0.481527 0.876431 0
+    outer loop
+      vertex 77.2822 54.869 7.5
+      vertex 77.4198 54.9446 0
+      vertex 77.2822 54.869 0
+    endloop
+  endfacet
+  facet normal -0.904876 0.425674 0
+    outer loop
+      vertex 77.8454 55.3978 0
+      vertex 77.9122 55.5398 7.5
+      vertex 77.9122 55.5398 0
+    endloop
+  endfacet
+  facet normal -0.904876 0.425674 0
+    outer loop
+      vertex 77.9122 55.5398 7.5
+      vertex 77.8454 55.3978 0
+      vertex 77.8454 55.3978 7.5
+    endloop
+  endfacet
+  facet normal -0.368312 0.929702 0
+    outer loop
+      vertex 77.2822 54.869 0
+      vertex 77.1363 54.8112 7.5
+      vertex 77.2822 54.869 7.5
+    endloop
+  endfacet
+  facet normal -0.368312 0.929702 0
+    outer loop
+      vertex 77.1363 54.8112 7.5
+      vertex 77.2822 54.869 0
+      vertex 77.1363 54.8112 0
+    endloop
+  endfacet
+  facet normal 0.904876 -0.425674 0
+    outer loop
+      vertex 75.5878 56.4602 7.5
+      vertex 75.6546 56.6022 0
+      vertex 75.6546 56.6022 7.5
+    endloop
+  endfacet
+  facet normal 0.904876 -0.425674 0
+    outer loop
+      vertex 75.6546 56.6022 0
+      vertex 75.5878 56.4602 7.5
+      vertex 75.5878 56.4602 0
+    endloop
+  endfacet
+  facet normal -0.904876 -0.425674 0
+    outer loop
+      vertex 77.9122 56.4602 0
+      vertex 77.8454 56.6022 7.5
+      vertex 77.8454 56.6022 0
+    endloop
+  endfacet
+  facet normal -0.904876 -0.425674 0
+    outer loop
+      vertex 77.8454 56.6022 7.5
+      vertex 77.9122 56.4602 0
+      vertex 77.9122 56.4602 7.5
+    endloop
+  endfacet
+  facet normal 0.99801 -0.0630523 0
+    outer loop
+      vertex 75.5 56 7.5
+      vertex 75.5099 56.1567 0
+      vertex 75.5099 56.1567 7.5
+    endloop
+  endfacet
+  facet normal 0.99801 -0.0630523 0
+    outer loop
+      vertex 75.5099 56.1567 0
+      vertex 75.5 56 7.5
+      vertex 75.5 56 0
+    endloop
+  endfacet
+  facet normal -0.844291 -0.535886 0
+    outer loop
+      vertex 77.8454 56.6022 0
+      vertex 77.7613 56.7347 7.5
+      vertex 77.7613 56.7347 0
+    endloop
+  endfacet
+  facet normal -0.844291 -0.535886 0
+    outer loop
+      vertex 77.7613 56.7347 7.5
+      vertex 77.8454 56.6022 0
+      vertex 77.8454 56.6022 7.5
+    endloop
+  endfacet
+  facet normal 0.68445 0.72906 -0
+    outer loop
+      vertex 75.9532 55.0369 0
+      vertex 75.8388 55.1443 7.5
+      vertex 75.9532 55.0369 7.5
+    endloop
+  endfacet
+  facet normal 0.68445 0.72906 0
+    outer loop
+      vertex 75.8388 55.1443 7.5
+      vertex 75.9532 55.0369 0
+      vertex 75.8388 55.1443 0
+    endloop
+  endfacet
+  facet normal 0.844291 0.535886 0
+    outer loop
+      vertex 75.7387 55.2653 7.5
+      vertex 75.6546 55.3978 0
+      vertex 75.6546 55.3978 7.5
+    endloop
+  endfacet
+  facet normal 0.844291 0.535886 0
+    outer loop
+      vertex 75.6546 55.3978 0
+      vertex 75.7387 55.2653 7.5
+      vertex 75.7387 55.2653 0
+    endloop
+  endfacet
+  facet normal 0.481527 0.876431 -0
+    outer loop
+      vertex 76.2178 54.869 0
+      vertex 76.0802 54.9446 7.5
+      vertex 76.2178 54.869 7.5
+    endloop
+  endfacet
+  facet normal 0.481527 0.876431 0
+    outer loop
+      vertex 76.0802 54.9446 7.5
+      vertex 76.2178 54.869 0
+      vertex 76.0802 54.9446 0
+    endloop
+  endfacet
+  facet normal -0.587907 -0.808929 0
+    outer loop
+      vertex 77.4198 57.0554 0
+      vertex 77.5468 56.9631 7.5
+      vertex 77.4198 57.0554 7.5
+    endloop
+  endfacet
+  facet normal -0.587907 -0.808929 -0
+    outer loop
+      vertex 77.5468 56.9631 7.5
+      vertex 77.4198 57.0554 0
+      vertex 77.5468 56.9631 0
+    endloop
+  endfacet
+  facet normal -0.99801 0.0630523 0
+    outer loop
+      vertex 77.9901 55.8433 0
+      vertex 78 56 7.5
+      vertex 78 56 0
+    endloop
+  endfacet
+  facet normal -0.99801 0.0630523 0
+    outer loop
+      vertex 78 56 7.5
+      vertex 77.9901 55.8433 0
+      vertex 77.9901 55.8433 7.5
+    endloop
+  endfacet
+  facet normal 0.481527 -0.876431 0
+    outer loop
+      vertex 76.0802 57.0554 0
+      vertex 76.2178 57.131 7.5
+      vertex 76.0802 57.0554 7.5
+    endloop
+  endfacet
+  facet normal 0.481527 -0.876431 0
+    outer loop
+      vertex 76.2178 57.131 7.5
+      vertex 76.0802 57.0554 0
+      vertex 76.2178 57.131 0
+    endloop
+  endfacet
+  facet normal -0.587907 0.808929 0
+    outer loop
+      vertex 77.5468 55.0369 0
+      vertex 77.4198 54.9446 7.5
+      vertex 77.5468 55.0369 7.5
+    endloop
+  endfacet
+  facet normal -0.587907 0.808929 0
+    outer loop
+      vertex 77.4198 54.9446 7.5
+      vertex 77.5468 55.0369 0
+      vertex 77.4198 54.9446 0
+    endloop
+  endfacet
+  facet normal 0.844291 -0.535886 0
+    outer loop
+      vertex 75.6546 56.6022 7.5
+      vertex 75.7387 56.7347 0
+      vertex 75.7387 56.7347 7.5
+    endloop
+  endfacet
+  facet normal 0.844291 -0.535886 0
+    outer loop
+      vertex 75.7387 56.7347 0
+      vertex 75.6546 56.6022 7.5
+      vertex 75.6546 56.6022 0
+    endloop
+  endfacet
+  facet normal -0.248973 -0.96851 0
+    outer loop
+      vertex 76.9842 57.2279 0
+      vertex 77.1363 57.1888 7.5
+      vertex 76.9842 57.2279 7.5
+    endloop
+  endfacet
+  facet normal -0.248973 -0.96851 -0
+    outer loop
+      vertex 77.1363 57.1888 7.5
+      vertex 76.9842 57.2279 0
+      vertex 77.1363 57.1888 0
+    endloop
+  endfacet
+  facet normal 0.770513 0.637424 0
+    outer loop
+      vertex 75.8388 55.1443 7.5
+      vertex 75.7387 55.2653 0
+      vertex 75.7387 55.2653 7.5
+    endloop
+  endfacet
+  facet normal 0.770513 0.637424 0
+    outer loop
+      vertex 75.7387 55.2653 0
+      vertex 75.8388 55.1443 7.5
+      vertex 75.8388 55.1443 0
+    endloop
+  endfacet
+  facet normal -0.368312 -0.929702 0
+    outer loop
+      vertex 77.1363 57.1888 0
+      vertex 77.2822 57.131 7.5
+      vertex 77.1363 57.1888 7.5
+    endloop
+  endfacet
+  facet normal -0.368312 -0.929702 -0
+    outer loop
+      vertex 77.2822 57.131 7.5
+      vertex 77.1363 57.1888 0
+      vertex 77.2822 57.131 0
+    endloop
+  endfacet
+  facet normal 0.982305 0.187288 0
+    outer loop
+      vertex 75.5393 55.6891 7.5
+      vertex 75.5099 55.8433 0
+      vertex 75.5099 55.8433 7.5
+    endloop
+  endfacet
+  facet normal 0.982305 0.187288 0
+    outer loop
+      vertex 75.5099 55.8433 0
+      vertex 75.5393 55.6891 7.5
+      vertex 75.5393 55.6891 0
+    endloop
+  endfacet
+  facet normal -0.481527 -0.876431 0
+    outer loop
+      vertex 77.2822 57.131 0
+      vertex 77.4198 57.0554 7.5
+      vertex 77.2822 57.131 7.5
+    endloop
+  endfacet
+  facet normal -0.481527 -0.876431 -0
+    outer loop
+      vertex 77.4198 57.0554 7.5
+      vertex 77.2822 57.131 0
+      vertex 77.4198 57.0554 0
+    endloop
+  endfacet
+  facet normal 0.124897 0.99217 -0
+    outer loop
+      vertex 76.6715 54.7525 0
+      vertex 76.5158 54.7721 7.5
+      vertex 76.6715 54.7525 7.5
+    endloop
+  endfacet
+  facet normal 0.124897 0.99217 0
+    outer loop
+      vertex 76.5158 54.7721 7.5
+      vertex 76.6715 54.7525 0
+      vertex 76.5158 54.7721 0
+    endloop
+  endfacet
+  facet normal -0.844291 0.535886 0
+    outer loop
+      vertex 77.7613 55.2653 0
+      vertex 77.8454 55.3978 7.5
+      vertex 77.8454 55.3978 0
+    endloop
+  endfacet
+  facet normal -0.844291 0.535886 0
+    outer loop
+      vertex 77.8454 55.3978 7.5
+      vertex 77.7613 55.2653 0
+      vertex 77.7613 55.2653 7.5
+    endloop
+  endfacet
+  facet normal -0.770513 -0.637424 0
+    outer loop
+      vertex 77.7613 56.7347 0
+      vertex 77.6612 56.8557 7.5
+      vertex 77.6612 56.8557 0
+    endloop
+  endfacet
+  facet normal -0.770513 -0.637424 0
+    outer loop
+      vertex 77.6612 56.8557 7.5
+      vertex 77.7613 56.7347 0
+      vertex 77.7613 56.7347 7.5
+    endloop
+  endfacet
+  facet normal -0.951076 -0.308956 0
+    outer loop
+      vertex 77.9607 56.3109 0
+      vertex 77.9122 56.4602 7.5
+      vertex 77.9122 56.4602 0
+    endloop
+  endfacet
+  facet normal -0.951076 -0.308956 0
+    outer loop
+      vertex 77.9122 56.4602 7.5
+      vertex 77.9607 56.3109 0
+      vertex 77.9607 56.3109 7.5
+    endloop
+  endfacet
+  facet normal 0.68445 -0.72906 0
+    outer loop
+      vertex 75.8388 56.8557 0
+      vertex 75.9532 56.9631 7.5
+      vertex 75.8388 56.8557 7.5
+    endloop
+  endfacet
+  facet normal 0.68445 -0.72906 0
+    outer loop
+      vertex 75.9532 56.9631 7.5
+      vertex 75.8388 56.8557 0
+      vertex 75.9532 56.9631 0
+    endloop
+  endfacet
+  facet normal 0.770513 -0.637424 0
+    outer loop
+      vertex 75.7387 56.7347 7.5
+      vertex 75.8388 56.8557 0
+      vertex 75.8388 56.8557 7.5
+    endloop
+  endfacet
+  facet normal 0.770513 -0.637424 0
+    outer loop
+      vertex 75.8388 56.8557 0
+      vertex 75.7387 56.7347 7.5
+      vertex 75.7387 56.7347 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 76.6715 57.2475 0
+      vertex 76.8285 57.2475 7.5
+      vertex 76.6715 57.2475 7.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 76.8285 57.2475 7.5
+      vertex 76.6715 57.2475 0
+      vertex 76.8285 57.2475 0
+    endloop
+  endfacet
+  facet normal 0.587907 0.808929 -0
+    outer loop
+      vertex 76.0802 54.9446 0
+      vertex 75.9532 55.0369 7.5
+      vertex 76.0802 54.9446 7.5
+    endloop
+  endfacet
+  facet normal 0.587907 0.808929 0
+    outer loop
+      vertex 75.9532 55.0369 7.5
+      vertex 76.0802 54.9446 0
+      vertex 75.9532 55.0369 0
+    endloop
+  endfacet
+  facet normal 0.124897 -0.99217 0
+    outer loop
+      vertex 76.5158 57.2279 0
+      vertex 76.6715 57.2475 7.5
+      vertex 76.5158 57.2279 7.5
+    endloop
+  endfacet
+  facet normal 0.124897 -0.99217 0
+    outer loop
+      vertex 76.6715 57.2475 7.5
+      vertex 76.5158 57.2279 0
+      vertex 76.6715 57.2475 0
+    endloop
+  endfacet
+  facet normal -0.68445 0.72906 0
+    outer loop
+      vertex 77.6612 55.1443 0
+      vertex 77.5468 55.0369 7.5
+      vertex 77.6612 55.1443 7.5
+    endloop
+  endfacet
+  facet normal -0.68445 0.72906 0
+    outer loop
+      vertex 77.5468 55.0369 7.5
+      vertex 77.6612 55.1443 0
+      vertex 77.5468 55.0369 0
+    endloop
+  endfacet
+  facet normal -0.770513 0.637424 0
+    outer loop
+      vertex 77.6612 55.1443 0
+      vertex 77.7613 55.2653 7.5
+      vertex 77.7613 55.2653 0
+    endloop
+  endfacet
+  facet normal -0.770513 0.637424 0
+    outer loop
+      vertex 77.7613 55.2653 7.5
+      vertex 77.6612 55.1443 0
+      vertex 77.6612 55.1443 7.5
+    endloop
+  endfacet
+  facet normal 0.248973 0.96851 -0
+    outer loop
+      vertex 76.5158 54.7721 0
+      vertex 76.3637 54.8112 7.5
+      vertex 76.5158 54.7721 7.5
+    endloop
+  endfacet
+  facet normal 0.248973 0.96851 0
+    outer loop
+      vertex 76.3637 54.8112 7.5
+      vertex 76.5158 54.7721 0
+      vertex 76.3637 54.8112 0
+    endloop
+  endfacet
+  facet normal 0.368312 0.929702 -0
+    outer loop
+      vertex 76.3637 54.8112 0
+      vertex 76.2178 54.869 7.5
+      vertex 76.3637 54.8112 7.5
+    endloop
+  endfacet
+  facet normal 0.368312 0.929702 0
+    outer loop
+      vertex 76.2178 54.869 7.5
+      vertex 76.3637 54.8112 0
+      vertex 76.2178 54.869 0
+    endloop
+  endfacet
+  facet normal -0.982305 -0.187288 0
+    outer loop
+      vertex 64.4901 84.1567 0
+      vertex 64.4607 84.3109 7.5
+      vertex 64.4607 84.3109 0
+    endloop
+  endfacet
+  facet normal -0.982305 -0.187288 0
+    outer loop
+      vertex 64.4607 84.3109 7.5
+      vertex 64.4901 84.1567 0
+      vertex 64.4901 84.1567 7.5
+    endloop
+  endfacet
+  facet normal -0.99801 -0.0630523 0
+    outer loop
+      vertex 64.5 84 0
+      vertex 64.4901 84.1567 7.5
+      vertex 64.4901 84.1567 0
+    endloop
+  endfacet
+  facet normal -0.99801 -0.0630523 0
+    outer loop
+      vertex 64.4901 84.1567 7.5
+      vertex 64.5 84 0
+      vertex 64.5 84 7.5
+    endloop
+  endfacet
+  facet normal 0.951076 -0.308956 0
+    outer loop
+      vertex 62.0393 84.3109 7.5
+      vertex 62.0878 84.4602 0
+      vertex 62.0878 84.4602 7.5
+    endloop
+  endfacet
+  facet normal 0.951076 -0.308956 0
+    outer loop
+      vertex 62.0878 84.4602 0
+      vertex 62.0393 84.3109 7.5
+      vertex 62.0393 84.3109 0
+    endloop
+  endfacet
+  facet normal -0.951076 0.308956 0
+    outer loop
+      vertex 64.4122 83.5398 0
+      vertex 64.4607 83.6891 7.5
+      vertex 64.4607 83.6891 0
+    endloop
+  endfacet
+  facet normal -0.951076 0.308956 0
+    outer loop
+      vertex 64.4607 83.6891 7.5
+      vertex 64.4122 83.5398 0
+      vertex 64.4122 83.5398 7.5
+    endloop
+  endfacet
+  facet normal -0.904876 -0.425674 0
+    outer loop
+      vertex 64.4122 84.4602 0
+      vertex 64.3454 84.6022 7.5
+      vertex 64.3454 84.6022 0
+    endloop
+  endfacet
+  facet normal -0.904876 -0.425674 0
+    outer loop
+      vertex 64.3454 84.6022 7.5
+      vertex 64.4122 84.4602 0
+      vertex 64.4122 84.4602 7.5
+    endloop
+  endfacet
+  facet normal -0.68445 -0.72906 0
+    outer loop
+      vertex 64.0468 84.9631 0
+      vertex 64.1612 84.8557 7.5
+      vertex 64.0468 84.9631 7.5
+    endloop
+  endfacet
+  facet normal -0.68445 -0.72906 -0
+    outer loop
+      vertex 64.1612 84.8557 7.5
+      vertex 64.0468 84.9631 0
+      vertex 64.1612 84.8557 0
+    endloop
+  endfacet
+  facet normal -0.368312 0.929702 0
+    outer loop
+      vertex 63.7822 82.869 0
+      vertex 63.6363 82.8112 7.5
+      vertex 63.7822 82.869 7.5
+    endloop
+  endfacet
+  facet normal -0.368312 0.929702 0
+    outer loop
+      vertex 63.6363 82.8112 7.5
+      vertex 63.7822 82.869 0
+      vertex 63.6363 82.8112 0
+    endloop
+  endfacet
+  facet normal -0.124897 0.99217 0
+    outer loop
+      vertex 63.4842 82.7721 0
+      vertex 63.3285 82.7525 7.5
+      vertex 63.4842 82.7721 7.5
+    endloop
+  endfacet
+  facet normal -0.124897 0.99217 0
+    outer loop
+      vertex 63.3285 82.7525 7.5
+      vertex 63.4842 82.7721 0
+      vertex 63.3285 82.7525 0
+    endloop
+  endfacet
+  facet normal -0.99801 0.0630523 0
+    outer loop
+      vertex 64.4901 83.8433 0
+      vertex 64.5 84 7.5
+      vertex 64.5 84 0
+    endloop
+  endfacet
+  facet normal -0.99801 0.0630523 0
+    outer loop
+      vertex 64.5 84 7.5
+      vertex 64.4901 83.8433 0
+      vertex 64.4901 83.8433 7.5
+    endloop
+  endfacet
+  facet normal -0.844291 -0.535886 0
+    outer loop
+      vertex 64.3454 84.6022 0
+      vertex 64.2613 84.7347 7.5
+      vertex 64.2613 84.7347 0
+    endloop
+  endfacet
+  facet normal -0.844291 -0.535886 0
+    outer loop
+      vertex 64.2613 84.7347 7.5
+      vertex 64.3454 84.6022 0
+      vertex 64.3454 84.6022 7.5
+    endloop
+  endfacet
+  facet normal 0.68445 0.72906 -0
+    outer loop
+      vertex 62.4532 83.0369 0
+      vertex 62.3388 83.1443 7.5
+      vertex 62.4532 83.0369 7.5
+    endloop
+  endfacet
+  facet normal 0.68445 0.72906 0
+    outer loop
+      vertex 62.3388 83.1443 7.5
+      vertex 62.4532 83.0369 0
+      vertex 62.3388 83.1443 0
+    endloop
+  endfacet
+  facet normal -0.368312 -0.929702 0
+    outer loop
+      vertex 63.6363 85.1888 0
+      vertex 63.7822 85.131 7.5
+      vertex 63.6363 85.1888 7.5
+    endloop
+  endfacet
+  facet normal -0.368312 -0.929702 -0
+    outer loop
+      vertex 63.7822 85.131 7.5
+      vertex 63.6363 85.1888 0
+      vertex 63.7822 85.131 0
+    endloop
+  endfacet
+  facet normal -0.68445 0.72906 0
+    outer loop
+      vertex 64.1612 83.1443 0
+      vertex 64.0468 83.0369 7.5
+      vertex 64.1612 83.1443 7.5
+    endloop
+  endfacet
+  facet normal -0.68445 0.72906 0
+    outer loop
+      vertex 64.0468 83.0369 7.5
+      vertex 64.1612 83.1443 0
+      vertex 64.0468 83.0369 0
+    endloop
+  endfacet
+  facet normal -0.481527 -0.876431 0
+    outer loop
+      vertex 63.7822 85.131 0
+      vertex 63.9198 85.0554 7.5
+      vertex 63.7822 85.131 7.5
+    endloop
+  endfacet
+  facet normal -0.481527 -0.876431 -0
+    outer loop
+      vertex 63.9198 85.0554 7.5
+      vertex 63.7822 85.131 0
+      vertex 63.9198 85.0554 0
+    endloop
+  endfacet
+  facet normal 0.481527 -0.876431 0
+    outer loop
+      vertex 62.5802 85.0554 0
+      vertex 62.7178 85.131 7.5
+      vertex 62.5802 85.0554 7.5
+    endloop
+  endfacet
+  facet normal 0.481527 -0.876431 0
+    outer loop
+      vertex 62.7178 85.131 7.5
+      vertex 62.5802 85.0554 0
+      vertex 62.7178 85.131 0
+    endloop
+  endfacet
+  facet normal 0.587907 0.808929 -0
+    outer loop
+      vertex 62.5802 82.9446 0
+      vertex 62.4532 83.0369 7.5
+      vertex 62.5802 82.9446 7.5
+    endloop
+  endfacet
+  facet normal 0.587907 0.808929 0
+    outer loop
+      vertex 62.4532 83.0369 7.5
+      vertex 62.5802 82.9446 0
+      vertex 62.4532 83.0369 0
+    endloop
+  endfacet
+  facet normal -0.982305 0.187288 0
+    outer loop
+      vertex 64.4607 83.6891 0
+      vertex 64.4901 83.8433 7.5
+      vertex 64.4901 83.8433 0
+    endloop
+  endfacet
+  facet normal -0.982305 0.187288 0
+    outer loop
+      vertex 64.4901 83.8433 7.5
+      vertex 64.4607 83.6891 0
+      vertex 64.4607 83.6891 7.5
+    endloop
+  endfacet
+  facet normal 0.68445 -0.72906 0
+    outer loop
+      vertex 62.3388 84.8557 0
+      vertex 62.4532 84.9631 7.5
+      vertex 62.3388 84.8557 7.5
+    endloop
+  endfacet
+  facet normal 0.68445 -0.72906 0
+    outer loop
+      vertex 62.4532 84.9631 7.5
+      vertex 62.3388 84.8557 0
+      vertex 62.4532 84.9631 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 63.3285 82.7525 0
+      vertex 63.1715 82.7525 7.5
+      vertex 63.3285 82.7525 7.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 63.1715 82.7525 7.5
+      vertex 63.3285 82.7525 0
+      vertex 63.1715 82.7525 0
+    endloop
+  endfacet
+  facet normal 0.124897 0.99217 -0
+    outer loop
+      vertex 63.1715 82.7525 0
+      vertex 63.0158 82.7721 7.5
+      vertex 63.1715 82.7525 7.5
+    endloop
+  endfacet
+  facet normal 0.124897 0.99217 0
+    outer loop
+      vertex 63.0158 82.7721 7.5
+      vertex 63.1715 82.7525 0
+      vertex 63.0158 82.7721 0
+    endloop
+  endfacet
+  facet normal 0.587907 -0.808929 0
+    outer loop
+      vertex 62.4532 84.9631 0
+      vertex 62.5802 85.0554 7.5
+      vertex 62.4532 84.9631 7.5
+    endloop
+  endfacet
+  facet normal 0.587907 -0.808929 0
+    outer loop
+      vertex 62.5802 85.0554 7.5
+      vertex 62.4532 84.9631 0
+      vertex 62.5802 85.0554 0
+    endloop
+  endfacet
+  facet normal -0.770513 0.637424 0
+    outer loop
+      vertex 64.1612 83.1443 0
+      vertex 64.2613 83.2653 7.5
+      vertex 64.2613 83.2653 0
+    endloop
+  endfacet
+  facet normal -0.770513 0.637424 0
+    outer loop
+      vertex 64.2613 83.2653 7.5
+      vertex 64.1612 83.1443 0
+      vertex 64.1612 83.1443 7.5
+    endloop
+  endfacet
+  facet normal 0.368312 -0.929702 0
+    outer loop
+      vertex 62.7178 85.131 0
+      vertex 62.8637 85.1888 7.5
+      vertex 62.7178 85.131 7.5
+    endloop
+  endfacet
+  facet normal 0.368312 -0.929702 0
+    outer loop
+      vertex 62.8637 85.1888 7.5
+      vertex 62.7178 85.131 0
+      vertex 62.8637 85.1888 0
+    endloop
+  endfacet
+  facet normal 0.248973 -0.96851 0
+    outer loop
+      vertex 62.8637 85.1888 0
+      vertex 63.0158 85.2279 7.5
+      vertex 62.8637 85.1888 7.5
+    endloop
+  endfacet
+  facet normal 0.248973 -0.96851 0
+    outer loop
+      vertex 63.0158 85.2279 7.5
+      vertex 62.8637 85.1888 0
+      vertex 63.0158 85.2279 0
+    endloop
+  endfacet
+  facet normal -0.124897 -0.99217 0
+    outer loop
+      vertex 63.3285 85.2475 0
+      vertex 63.4842 85.2279 7.5
+      vertex 63.3285 85.2475 7.5
+    endloop
+  endfacet
+  facet normal -0.124897 -0.99217 -0
+    outer loop
+      vertex 63.4842 85.2279 7.5
+      vertex 63.3285 85.2475 0
+      vertex 63.4842 85.2279 0
+    endloop
+  endfacet
+  facet normal -0.904876 0.425674 0
+    outer loop
+      vertex 64.3454 83.3978 0
+      vertex 64.4122 83.5398 7.5
+      vertex 64.4122 83.5398 0
+    endloop
+  endfacet
+  facet normal -0.904876 0.425674 0
+    outer loop
+      vertex 64.4122 83.5398 7.5
+      vertex 64.3454 83.3978 0
+      vertex 64.3454 83.3978 7.5
+    endloop
+  endfacet
+  facet normal -0.587907 -0.808929 0
+    outer loop
+      vertex 63.9198 85.0554 0
+      vertex 64.0468 84.9631 7.5
+      vertex 63.9198 85.0554 7.5
+    endloop
+  endfacet
+  facet normal -0.587907 -0.808929 -0
+    outer loop
+      vertex 64.0468 84.9631 7.5
+      vertex 63.9198 85.0554 0
+      vertex 64.0468 84.9631 0
+    endloop
+  endfacet
+  facet normal -0.481527 0.876431 0
+    outer loop
+      vertex 63.9198 82.9446 0
+      vertex 63.7822 82.869 7.5
+      vertex 63.9198 82.9446 7.5
+    endloop
+  endfacet
+  facet normal -0.481527 0.876431 0
+    outer loop
+      vertex 63.7822 82.869 7.5
+      vertex 63.9198 82.9446 0
+      vertex 63.7822 82.869 0
+    endloop
+  endfacet
+  facet normal 0.982305 0.187288 0
+    outer loop
+      vertex 62.0393 83.6891 7.5
+      vertex 62.0099 83.8433 0
+      vertex 62.0099 83.8433 7.5
+    endloop
+  endfacet
+  facet normal 0.982305 0.187288 0
+    outer loop
+      vertex 62.0099 83.8433 0
+      vertex 62.0393 83.6891 7.5
+      vertex 62.0393 83.6891 0
+    endloop
+  endfacet
+  facet normal -0.248973 0.96851 0
+    outer loop
+      vertex 63.6363 82.8112 0
+      vertex 63.4842 82.7721 7.5
+      vertex 63.6363 82.8112 7.5
+    endloop
+  endfacet
+  facet normal -0.248973 0.96851 0
+    outer loop
+      vertex 63.4842 82.7721 7.5
+      vertex 63.6363 82.8112 0
+      vertex 63.4842 82.7721 0
+    endloop
+  endfacet
+  facet normal 0.124897 -0.99217 0
+    outer loop
+      vertex 63.0158 85.2279 0
+      vertex 63.1715 85.2475 7.5
+      vertex 63.0158 85.2279 7.5
+    endloop
+  endfacet
+  facet normal 0.124897 -0.99217 0
+    outer loop
+      vertex 63.1715 85.2475 7.5
+      vertex 63.0158 85.2279 0
+      vertex 63.1715 85.2475 0
+    endloop
+  endfacet
+  facet normal 0.481527 0.876431 -0
+    outer loop
+      vertex 62.7178 82.869 0
+      vertex 62.5802 82.9446 7.5
+      vertex 62.7178 82.869 7.5
+    endloop
+  endfacet
+  facet normal 0.481527 0.876431 0
+    outer loop
+      vertex 62.5802 82.9446 7.5
+      vertex 62.7178 82.869 0
+      vertex 62.5802 82.9446 0
+    endloop
+  endfacet
+  facet normal 0.904876 0.425674 0
+    outer loop
+      vertex 62.1546 83.3978 7.5
+      vertex 62.0878 83.5398 0
+      vertex 62.0878 83.5398 7.5
+    endloop
+  endfacet
+  facet normal 0.904876 0.425674 0
+    outer loop
+      vertex 62.0878 83.5398 0
+      vertex 62.1546 83.3978 7.5
+      vertex 62.1546 83.3978 0
+    endloop
+  endfacet
+  facet normal -0.844291 0.535886 0
+    outer loop
+      vertex 64.2613 83.2653 0
+      vertex 64.3454 83.3978 7.5
+      vertex 64.3454 83.3978 0
+    endloop
+  endfacet
+  facet normal -0.844291 0.535886 0
+    outer loop
+      vertex 64.3454 83.3978 7.5
+      vertex 64.2613 83.2653 0
+      vertex 64.2613 83.2653 7.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 63.1715 85.2475 0
+      vertex 63.3285 85.2475 7.5
+      vertex 63.1715 85.2475 7.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 63.3285 85.2475 7.5
+      vertex 63.1715 85.2475 0
+      vertex 63.3285 85.2475 0
+    endloop
+  endfacet
+  facet normal -0.248973 -0.96851 0
+    outer loop
+      vertex 63.4842 85.2279 0
+      vertex 63.6363 85.1888 7.5
+      vertex 63.4842 85.2279 7.5
+    endloop
+  endfacet
+  facet normal -0.248973 -0.96851 -0
+    outer loop
+      vertex 63.6363 85.1888 7.5
+      vertex 63.4842 85.2279 0
+      vertex 63.6363 85.1888 0
+    endloop
+  endfacet
+  facet normal 0.951076 0.308956 0
+    outer loop
+      vertex 62.0878 83.5398 7.5
+      vertex 62.0393 83.6891 0
+      vertex 62.0393 83.6891 7.5
+    endloop
+  endfacet
+  facet normal 0.951076 0.308956 0
+    outer loop
+      vertex 62.0393 83.6891 0
+      vertex 62.0878 83.5398 7.5
+      vertex 62.0878 83.5398 0
+    endloop
+  endfacet
+  facet normal -0.770513 -0.637424 0
+    outer loop
+      vertex 64.2613 84.7347 0
+      vertex 64.1612 84.8557 7.5
+      vertex 64.1612 84.8557 0
+    endloop
+  endfacet
+  facet normal -0.770513 -0.637424 0
+    outer loop
+      vertex 64.1612 84.8557 7.5
+      vertex 64.2613 84.7347 0
+      vertex 64.2613 84.7347 7.5
+    endloop
+  endfacet
+  facet normal -0.587907 0.808929 0
+    outer loop
+      vertex 64.0468 83.0369 0
+      vertex 63.9198 82.9446 7.5
+      vertex 64.0468 83.0369 7.5
+    endloop
+  endfacet
+  facet normal -0.587907 0.808929 0
+    outer loop
+      vertex 63.9198 82.9446 7.5
+      vertex 64.0468 83.0369 0
+      vertex 63.9198 82.9446 0
+    endloop
+  endfacet
+  facet normal -0.951076 -0.308956 0
+    outer loop
+      vertex 64.4607 84.3109 0
+      vertex 64.4122 84.4602 7.5
+      vertex 64.4122 84.4602 0
+    endloop
+  endfacet
+  facet normal -0.951076 -0.308956 0
+    outer loop
+      vertex 64.4122 84.4602 7.5
+      vertex 64.4607 84.3109 0
+      vertex 64.4607 84.3109 7.5
+    endloop
+  endfacet
+  facet normal 0.248973 0.96851 -0
+    outer loop
+      vertex 63.0158 82.7721 0
+      vertex 62.8637 82.8112 7.5
+      vertex 63.0158 82.7721 7.5
+    endloop
+  endfacet
+  facet normal 0.248973 0.96851 0
+    outer loop
+      vertex 62.8637 82.8112 7.5
+      vertex 63.0158 82.7721 0
+      vertex 62.8637 82.8112 0
+    endloop
+  endfacet
+  facet normal 0.99801 0.0630523 0
+    outer loop
+      vertex 62.0099 83.8433 7.5
+      vertex 62 84 0
+      vertex 62 84 7.5
+    endloop
+  endfacet
+  facet normal 0.99801 0.0630523 0
+    outer loop
+      vertex 62 84 0
+      vertex 62.0099 83.8433 7.5
+      vertex 62.0099 83.8433 0
+    endloop
+  endfacet
+  facet normal 0.844291 -0.535886 0
+    outer loop
+      vertex 62.1546 84.6022 7.5
+      vertex 62.2387 84.7347 0
+      vertex 62.2387 84.7347 7.5
+    endloop
+  endfacet
+  facet normal 0.844291 -0.535886 0
+    outer loop
+      vertex 62.2387 84.7347 0
+      vertex 62.1546 84.6022 7.5
+      vertex 62.1546 84.6022 0
+    endloop
+  endfacet
+  facet normal 0.770513 -0.637424 0
+    outer loop
+      vertex 62.2387 84.7347 7.5
+      vertex 62.3388 84.8557 0
+      vertex 62.3388 84.8557 7.5
+    endloop
+  endfacet
+  facet normal 0.770513 -0.637424 0
+    outer loop
+      vertex 62.3388 84.8557 0
+      vertex 62.2387 84.7347 7.5
+      vertex 62.2387 84.7347 0
+    endloop
+  endfacet
+  facet normal 0.904876 -0.425674 0
+    outer loop
+      vertex 62.0878 84.4602 7.5
+      vertex 62.1546 84.6022 0
+      vertex 62.1546 84.6022 7.5
+    endloop
+  endfacet
+  facet normal 0.904876 -0.425674 0
+    outer loop
+      vertex 62.1546 84.6022 0
+      vertex 62.0878 84.4602 7.5
+      vertex 62.0878 84.4602 0
+    endloop
+  endfacet
+  facet normal 0.368312 0.929702 -0
+    outer loop
+      vertex 62.8637 82.8112 0
+      vertex 62.7178 82.869 7.5
+      vertex 62.8637 82.8112 7.5
+    endloop
+  endfacet
+  facet normal 0.368312 0.929702 0
+    outer loop
+      vertex 62.7178 82.869 7.5
+      vertex 62.8637 82.8112 0
+      vertex 62.7178 82.869 0
+    endloop
+  endfacet
+  facet normal 0.99801 -0.0630523 0
+    outer loop
+      vertex 62 84 7.5
+      vertex 62.0099 84.1567 0
+      vertex 62.0099 84.1567 7.5
+    endloop
+  endfacet
+  facet normal 0.99801 -0.0630523 0
+    outer loop
+      vertex 62.0099 84.1567 0
+      vertex 62 84 7.5
+      vertex 62 84 0
+    endloop
+  endfacet
+  facet normal 0.982305 -0.187288 0
+    outer loop
+      vertex 62.0099 84.1567 7.5
+      vertex 62.0393 84.3109 0
+      vertex 62.0393 84.3109 7.5
+    endloop
+  endfacet
+  facet normal 0.982305 -0.187288 0
+    outer loop
+      vertex 62.0393 84.3109 0
+      vertex 62.0099 84.1567 7.5
+      vertex 62.0099 84.1567 0
+    endloop
+  endfacet
+  facet normal 0.770513 0.637424 0
+    outer loop
+      vertex 62.3388 83.1443 7.5
+      vertex 62.2387 83.2653 0
+      vertex 62.2387 83.2653 7.5
+    endloop
+  endfacet
+  facet normal 0.770513 0.637424 0
+    outer loop
+      vertex 62.2387 83.2653 0
+      vertex 62.3388 83.1443 7.5
+      vertex 62.3388 83.1443 0
+    endloop
+  endfacet
+  facet normal 0.844291 0.535886 0
+    outer loop
+      vertex 62.2387 83.2653 7.5
+      vertex 62.1546 83.3978 0
+      vertex 62.1546 83.3978 7.5
+    endloop
+  endfacet
+  facet normal 0.844291 0.535886 0
+    outer loop
+      vertex 62.1546 83.3978 0
+      vertex 62.2387 83.2653 7.5
+      vertex 62.2387 83.2653 0
+    endloop
+  endfacet
+  facet normal -0.982305 -0.187288 0
+    outer loop
+      vertex 64.4901 56.1567 0
+      vertex 64.4607 56.3109 7.5
+      vertex 64.4607 56.3109 0
+    endloop
+  endfacet
+  facet normal -0.982305 -0.187288 0
+    outer loop
+      vertex 64.4607 56.3109 7.5
+      vertex 64.4901 56.1567 0
+      vertex 64.4901 56.1567 7.5
+    endloop
+  endfacet
+  facet normal -0.99801 -0.0630523 0
+    outer loop
+      vertex 64.5 56 0
+      vertex 64.4901 56.1567 7.5
+      vertex 64.4901 56.1567 0
+    endloop
+  endfacet
+  facet normal -0.99801 -0.0630523 0
+    outer loop
+      vertex 64.4901 56.1567 7.5
+      vertex 64.5 56 0
+      vertex 64.5 56 7.5
+    endloop
+  endfacet
+  facet normal 0.951076 -0.308956 0
+    outer loop
+      vertex 62.0393 56.3109 7.5
+      vertex 62.0878 56.4602 0
+      vertex 62.0878 56.4602 7.5
+    endloop
+  endfacet
+  facet normal 0.951076 -0.308956 0
+    outer loop
+      vertex 62.0878 56.4602 0
+      vertex 62.0393 56.3109 7.5
+      vertex 62.0393 56.3109 0
+    endloop
+  endfacet
+  facet normal -0.951076 0.308956 0
+    outer loop
+      vertex 64.4122 55.5398 0
+      vertex 64.4607 55.6891 7.5
+      vertex 64.4607 55.6891 0
+    endloop
+  endfacet
+  facet normal -0.951076 0.308956 0
+    outer loop
+      vertex 64.4607 55.6891 7.5
+      vertex 64.4122 55.5398 0
+      vertex 64.4122 55.5398 7.5
+    endloop
+  endfacet
+  facet normal -0.904876 -0.425674 0
+    outer loop
+      vertex 64.4122 56.4602 0
+      vertex 64.3454 56.6022 7.5
+      vertex 64.3454 56.6022 0
+    endloop
+  endfacet
+  facet normal -0.904876 -0.425674 0
+    outer loop
+      vertex 64.3454 56.6022 7.5
+      vertex 64.4122 56.4602 0
+      vertex 64.4122 56.4602 7.5
+    endloop
+  endfacet
+  facet normal -0.68445 -0.72906 0
+    outer loop
+      vertex 64.0468 56.9631 0
+      vertex 64.1612 56.8557 7.5
+      vertex 64.0468 56.9631 7.5
+    endloop
+  endfacet
+  facet normal -0.68445 -0.72906 -0
+    outer loop
+      vertex 64.1612 56.8557 7.5
+      vertex 64.0468 56.9631 0
+      vertex 64.1612 56.8557 0
+    endloop
+  endfacet
+  facet normal -0.951076 -0.308956 0
+    outer loop
+      vertex 64.4607 56.3109 0
+      vertex 64.4122 56.4602 7.5
+      vertex 64.4122 56.4602 0
+    endloop
+  endfacet
+  facet normal -0.951076 -0.308956 0
+    outer loop
+      vertex 64.4122 56.4602 7.5
+      vertex 64.4607 56.3109 0
+      vertex 64.4607 56.3109 7.5
+    endloop
+  endfacet
+  facet normal -0.368312 0.929702 0
+    outer loop
+      vertex 63.7822 54.869 0
+      vertex 63.6363 54.8112 7.5
+      vertex 63.7822 54.869 7.5
+    endloop
+  endfacet
+  facet normal -0.368312 0.929702 0
+    outer loop
+      vertex 63.6363 54.8112 7.5
+      vertex 63.7822 54.869 0
+      vertex 63.6363 54.8112 0
+    endloop
+  endfacet
+  facet normal -0.124897 0.99217 0
+    outer loop
+      vertex 63.4842 54.7721 0
+      vertex 63.3285 54.7525 7.5
+      vertex 63.4842 54.7721 7.5
+    endloop
+  endfacet
+  facet normal -0.124897 0.99217 0
+    outer loop
+      vertex 63.3285 54.7525 7.5
+      vertex 63.4842 54.7721 0
+      vertex 63.3285 54.7525 0
+    endloop
+  endfacet
+  facet normal -0.99801 0.0630523 0
+    outer loop
+      vertex 64.4901 55.8433 0
+      vertex 64.5 56 7.5
+      vertex 64.5 56 0
+    endloop
+  endfacet
+  facet normal -0.99801 0.0630523 0
+    outer loop
+      vertex 64.5 56 7.5
+      vertex 64.4901 55.8433 0
+      vertex 64.4901 55.8433 7.5
+    endloop
+  endfacet
+  facet normal -0.844291 -0.535886 0
+    outer loop
+      vertex 64.3454 56.6022 0
+      vertex 64.2613 56.7347 7.5
+      vertex 64.2613 56.7347 0
+    endloop
+  endfacet
+  facet normal -0.844291 -0.535886 0
+    outer loop
+      vertex 64.2613 56.7347 7.5
+      vertex 64.3454 56.6022 0
+      vertex 64.3454 56.6022 7.5
+    endloop
+  endfacet
+  facet normal 0.68445 0.72906 -0
+    outer loop
+      vertex 62.4532 55.0369 0
+      vertex 62.3388 55.1443 7.5
+      vertex 62.4532 55.0369 7.5
+    endloop
+  endfacet
+  facet normal 0.68445 0.72906 0
+    outer loop
+      vertex 62.3388 55.1443 7.5
+      vertex 62.4532 55.0369 0
+      vertex 62.3388 55.1443 0
+    endloop
+  endfacet
+  facet normal -0.368312 -0.929702 0
+    outer loop
+      vertex 63.6363 57.1888 0
+      vertex 63.7822 57.131 7.5
+      vertex 63.6363 57.1888 7.5
+    endloop
+  endfacet
+  facet normal -0.368312 -0.929702 -0
+    outer loop
+      vertex 63.7822 57.131 7.5
+      vertex 63.6363 57.1888 0
+      vertex 63.7822 57.131 0
+    endloop
+  endfacet
+  facet normal -0.68445 0.72906 0
+    outer loop
+      vertex 64.1612 55.1443 0
+      vertex 64.0468 55.0369 7.5
+      vertex 64.1612 55.1443 7.5
+    endloop
+  endfacet
+  facet normal -0.68445 0.72906 0
+    outer loop
+      vertex 64.0468 55.0369 7.5
+      vertex 64.1612 55.1443 0
+      vertex 64.0468 55.0369 0
+    endloop
+  endfacet
+  facet normal -0.481527 -0.876431 0
+    outer loop
+      vertex 63.7822 57.131 0
+      vertex 63.9198 57.0554 7.5
+      vertex 63.7822 57.131 7.5
+    endloop
+  endfacet
+  facet normal -0.481527 -0.876431 -0
+    outer loop
+      vertex 63.9198 57.0554 7.5
+      vertex 63.7822 57.131 0
+      vertex 63.9198 57.0554 0
+    endloop
+  endfacet
+  facet normal 0.481527 -0.876431 0
+    outer loop
+      vertex 62.5802 57.0554 0
+      vertex 62.7178 57.131 7.5
+      vertex 62.5802 57.0554 7.5
+    endloop
+  endfacet
+  facet normal 0.481527 -0.876431 0
+    outer loop
+      vertex 62.7178 57.131 7.5
+      vertex 62.5802 57.0554 0
+      vertex 62.7178 57.131 0
+    endloop
+  endfacet
+  facet normal 0.587907 0.808929 -0
+    outer loop
+      vertex 62.5802 54.9446 0
+      vertex 62.4532 55.0369 7.5
+      vertex 62.5802 54.9446 7.5
+    endloop
+  endfacet
+  facet normal 0.587907 0.808929 0
+    outer loop
+      vertex 62.4532 55.0369 7.5
+      vertex 62.5802 54.9446 0
+      vertex 62.4532 55.0369 0
+    endloop
+  endfacet
+  facet normal -0.982305 0.187288 0
+    outer loop
+      vertex 64.4607 55.6891 0
+      vertex 64.4901 55.8433 7.5
+      vertex 64.4901 55.8433 0
+    endloop
+  endfacet
+  facet normal -0.982305 0.187288 0
+    outer loop
+      vertex 64.4901 55.8433 7.5
+      vertex 64.4607 55.6891 0
+      vertex 64.4607 55.6891 7.5
+    endloop
+  endfacet
+  facet normal 0.68445 -0.72906 0
+    outer loop
+      vertex 62.3388 56.8557 0
+      vertex 62.4532 56.9631 7.5
+      vertex 62.3388 56.8557 7.5
+    endloop
+  endfacet
+  facet normal 0.68445 -0.72906 0
+    outer loop
+      vertex 62.4532 56.9631 7.5
+      vertex 62.3388 56.8557 0
+      vertex 62.4532 56.9631 0
+    endloop
+  endfacet
+  facet normal 0.124897 0.99217 -0
+    outer loop
+      vertex 63.1715 54.7525 0
+      vertex 63.0158 54.7721 7.5
+      vertex 63.1715 54.7525 7.5
+    endloop
+  endfacet
+  facet normal 0.124897 0.99217 0
+    outer loop
+      vertex 63.0158 54.7721 7.5
+      vertex 63.1715 54.7525 0
+      vertex 63.0158 54.7721 0
+    endloop
+  endfacet
+  facet normal 0.587907 -0.808929 0
+    outer loop
+      vertex 62.4532 56.9631 0
+      vertex 62.5802 57.0554 7.5
+      vertex 62.4532 56.9631 7.5
+    endloop
+  endfacet
+  facet normal 0.587907 -0.808929 0
+    outer loop
+      vertex 62.5802 57.0554 7.5
+      vertex 62.4532 56.9631 0
+      vertex 62.5802 57.0554 0
+    endloop
+  endfacet
+  facet normal -0.770513 0.637424 0
+    outer loop
+      vertex 64.1612 55.1443 0
+      vertex 64.2613 55.2653 7.5
+      vertex 64.2613 55.2653 0
+    endloop
+  endfacet
+  facet normal -0.770513 0.637424 0
+    outer loop
+      vertex 64.2613 55.2653 7.5
+      vertex 64.1612 55.1443 0
+      vertex 64.1612 55.1443 7.5
+    endloop
+  endfacet
+  facet normal 0.368312 -0.929702 0
+    outer loop
+      vertex 62.7178 57.131 0
+      vertex 62.8637 57.1888 7.5
+      vertex 62.7178 57.131 7.5
+    endloop
+  endfacet
+  facet normal 0.368312 -0.929702 0
+    outer loop
+      vertex 62.8637 57.1888 7.5
+      vertex 62.7178 57.131 0
+      vertex 62.8637 57.1888 0
+    endloop
+  endfacet
+  facet normal 0.248973 -0.96851 0
+    outer loop
+      vertex 62.8637 57.1888 0
+      vertex 63.0158 57.2279 7.5
+      vertex 62.8637 57.1888 7.5
+    endloop
+  endfacet
+  facet normal 0.248973 -0.96851 0
+    outer loop
+      vertex 63.0158 57.2279 7.5
+      vertex 62.8637 57.1888 0
+      vertex 63.0158 57.2279 0
+    endloop
+  endfacet
+  facet normal -0.124897 -0.99217 0
+    outer loop
+      vertex 63.3285 57.2475 0
+      vertex 63.4842 57.2279 7.5
+      vertex 63.3285 57.2475 7.5
+    endloop
+  endfacet
+  facet normal -0.124897 -0.99217 -0
+    outer loop
+      vertex 63.4842 57.2279 7.5
+      vertex 63.3285 57.2475 0
+      vertex 63.4842 57.2279 0
+    endloop
+  endfacet
+  facet normal -0.904876 0.425674 0
+    outer loop
+      vertex 64.3454 55.3978 0
+      vertex 64.4122 55.5398 7.5
+      vertex 64.4122 55.5398 0
+    endloop
+  endfacet
+  facet normal -0.904876 0.425674 0
+    outer loop
+      vertex 64.4122 55.5398 7.5
+      vertex 64.3454 55.3978 0
+      vertex 64.3454 55.3978 7.5
+    endloop
+  endfacet
+  facet normal -0.587907 -0.808929 0
+    outer loop
+      vertex 63.9198 57.0554 0
+      vertex 64.0468 56.9631 7.5
+      vertex 63.9198 57.0554 7.5
+    endloop
+  endfacet
+  facet normal -0.587907 -0.808929 -0
+    outer loop
+      vertex 64.0468 56.9631 7.5
+      vertex 63.9198 57.0554 0
+      vertex 64.0468 56.9631 0
+    endloop
+  endfacet
+  facet normal -0.481527 0.876431 0
+    outer loop
+      vertex 63.9198 54.9446 0
+      vertex 63.7822 54.869 7.5
+      vertex 63.9198 54.9446 7.5
+    endloop
+  endfacet
+  facet normal -0.481527 0.876431 0
+    outer loop
+      vertex 63.7822 54.869 7.5
+      vertex 63.9198 54.9446 0
+      vertex 63.7822 54.869 0
+    endloop
+  endfacet
+  facet normal 0.982305 0.187288 0
+    outer loop
+      vertex 62.0393 55.6891 7.5
+      vertex 62.0099 55.8433 0
+      vertex 62.0099 55.8433 7.5
+    endloop
+  endfacet
+  facet normal 0.982305 0.187288 0
+    outer loop
+      vertex 62.0099 55.8433 0
+      vertex 62.0393 55.6891 7.5
+      vertex 62.0393 55.6891 0
+    endloop
+  endfacet
+  facet normal -0.248973 0.96851 0
+    outer loop
+      vertex 63.6363 54.8112 0
+      vertex 63.4842 54.7721 7.5
+      vertex 63.6363 54.8112 7.5
+    endloop
+  endfacet
+  facet normal -0.248973 0.96851 0
+    outer loop
+      vertex 63.4842 54.7721 7.5
+      vertex 63.6363 54.8112 0
+      vertex 63.4842 54.7721 0
+    endloop
+  endfacet
+  facet normal 0.124897 -0.99217 0
+    outer loop
+      vertex 63.0158 57.2279 0
+      vertex 63.1715 57.2475 7.5
+      vertex 63.0158 57.2279 7.5
+    endloop
+  endfacet
+  facet normal 0.124897 -0.99217 0
+    outer loop
+      vertex 63.1715 57.2475 7.5
+      vertex 63.0158 57.2279 0
+      vertex 63.1715 57.2475 0
+    endloop
+  endfacet
+  facet normal 0.481527 0.876431 -0
+    outer loop
+      vertex 62.7178 54.869 0
+      vertex 62.5802 54.9446 7.5
+      vertex 62.7178 54.869 7.5
+    endloop
+  endfacet
+  facet normal 0.481527 0.876431 0
+    outer loop
+      vertex 62.5802 54.9446 7.5
+      vertex 62.7178 54.869 0
+      vertex 62.5802 54.9446 0
+    endloop
+  endfacet
+  facet normal 0.904876 0.425674 0
+    outer loop
+      vertex 62.1546 55.3978 7.5
+      vertex 62.0878 55.5398 0
+      vertex 62.0878 55.5398 7.5
+    endloop
+  endfacet
+  facet normal 0.904876 0.425674 0
+    outer loop
+      vertex 62.0878 55.5398 0
+      vertex 62.1546 55.3978 7.5
+      vertex 62.1546 55.3978 0
+    endloop
+  endfacet
+  facet normal -0.844291 0.535886 0
+    outer loop
+      vertex 64.2613 55.2653 0
+      vertex 64.3454 55.3978 7.5
+      vertex 64.3454 55.3978 0
+    endloop
+  endfacet
+  facet normal -0.844291 0.535886 0
+    outer loop
+      vertex 64.3454 55.3978 7.5
+      vertex 64.2613 55.2653 0
+      vertex 64.2613 55.2653 7.5
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 63.3285 54.7525 0
+      vertex 63.1715 54.7525 7.5
+      vertex 63.3285 54.7525 7.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 63.1715 54.7525 7.5
+      vertex 63.3285 54.7525 0
+      vertex 63.1715 54.7525 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 63.1715 57.2475 0
+      vertex 63.3285 57.2475 7.5
+      vertex 63.1715 57.2475 7.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 63.3285 57.2475 7.5
+      vertex 63.1715 57.2475 0
+      vertex 63.3285 57.2475 0
+    endloop
+  endfacet
+  facet normal -0.248973 -0.96851 0
+    outer loop
+      vertex 63.4842 57.2279 0
+      vertex 63.6363 57.1888 7.5
+      vertex 63.4842 57.2279 7.5
+    endloop
+  endfacet
+  facet normal -0.248973 -0.96851 -0
+    outer loop
+      vertex 63.6363 57.1888 7.5
+      vertex 63.4842 57.2279 0
+      vertex 63.6363 57.1888 0
+    endloop
+  endfacet
+  facet normal 0.951076 0.308956 0
+    outer loop
+      vertex 62.0878 55.5398 7.5
+      vertex 62.0393 55.6891 0
+      vertex 62.0393 55.6891 7.5
+    endloop
+  endfacet
+  facet normal 0.951076 0.308956 0
+    outer loop
+      vertex 62.0393 55.6891 0
+      vertex 62.0878 55.5398 7.5
+      vertex 62.0878 55.5398 0
+    endloop
+  endfacet
+  facet normal -0.770513 -0.637424 0
+    outer loop
+      vertex 64.2613 56.7347 0
+      vertex 64.1612 56.8557 7.5
+      vertex 64.1612 56.8557 0
+    endloop
+  endfacet
+  facet normal -0.770513 -0.637424 0
+    outer loop
+      vertex 64.1612 56.8557 7.5
+      vertex 64.2613 56.7347 0
+      vertex 64.2613 56.7347 7.5
+    endloop
+  endfacet
+  facet normal -0.587907 0.808929 0
+    outer loop
+      vertex 64.0468 55.0369 0
+      vertex 63.9198 54.9446 7.5
+      vertex 64.0468 55.0369 7.5
+    endloop
+  endfacet
+  facet normal -0.587907 0.808929 0
+    outer loop
+      vertex 63.9198 54.9446 7.5
+      vertex 64.0468 55.0369 0
+      vertex 63.9198 54.9446 0
+    endloop
+  endfacet
+  facet normal 0.248973 0.96851 -0
+    outer loop
+      vertex 63.0158 54.7721 0
+      vertex 62.8637 54.8112 7.5
+      vertex 63.0158 54.7721 7.5
+    endloop
+  endfacet
+  facet normal 0.248973 0.96851 0
+    outer loop
+      vertex 62.8637 54.8112 7.5
+      vertex 63.0158 54.7721 0
+      vertex 62.8637 54.8112 0
+    endloop
+  endfacet
+  facet normal 0.99801 0.0630523 0
+    outer loop
+      vertex 62.0099 55.8433 7.5
+      vertex 62 56 0
+      vertex 62 56 7.5
+    endloop
+  endfacet
+  facet normal 0.99801 0.0630523 0
+    outer loop
+      vertex 62 56 0
+      vertex 62.0099 55.8433 7.5
+      vertex 62.0099 55.8433 0
+    endloop
+  endfacet
+  facet normal 0.844291 -0.535886 0
+    outer loop
+      vertex 62.1546 56.6022 7.5
+      vertex 62.2387 56.7347 0
+      vertex 62.2387 56.7347 7.5
+    endloop
+  endfacet
+  facet normal 0.844291 -0.535886 0
+    outer loop
+      vertex 62.2387 56.7347 0
+      vertex 62.1546 56.6022 7.5
+      vertex 62.1546 56.6022 0
+    endloop
+  endfacet
+  facet normal 0.770513 -0.637424 0
+    outer loop
+      vertex 62.2387 56.7347 7.5
+      vertex 62.3388 56.8557 0
+      vertex 62.3388 56.8557 7.5
+    endloop
+  endfacet
+  facet normal 0.770513 -0.637424 0
+    outer loop
+      vertex 62.3388 56.8557 0
+      vertex 62.2387 56.7347 7.5
+      vertex 62.2387 56.7347 0
+    endloop
+  endfacet
+  facet normal 0.904876 -0.425674 0
+    outer loop
+      vertex 62.0878 56.4602 7.5
+      vertex 62.1546 56.6022 0
+      vertex 62.1546 56.6022 7.5
+    endloop
+  endfacet
+  facet normal 0.904876 -0.425674 0
+    outer loop
+      vertex 62.1546 56.6022 0
+      vertex 62.0878 56.4602 7.5
+      vertex 62.0878 56.4602 0
+    endloop
+  endfacet
+  facet normal 0.368312 0.929702 -0
+    outer loop
+      vertex 62.8637 54.8112 0
+      vertex 62.7178 54.869 7.5
+      vertex 62.8637 54.8112 7.5
+    endloop
+  endfacet
+  facet normal 0.368312 0.929702 0
+    outer loop
+      vertex 62.7178 54.869 7.5
+      vertex 62.8637 54.8112 0
+      vertex 62.7178 54.869 0
+    endloop
+  endfacet
+  facet normal 0.99801 -0.0630523 0
+    outer loop
+      vertex 62 56 7.5
+      vertex 62.0099 56.1567 0
+      vertex 62.0099 56.1567 7.5
+    endloop
+  endfacet
+  facet normal 0.99801 -0.0630523 0
+    outer loop
+      vertex 62.0099 56.1567 0
+      vertex 62 56 7.5
+      vertex 62 56 0
+    endloop
+  endfacet
+  facet normal 0.982305 -0.187288 0
+    outer loop
+      vertex 62.0099 56.1567 7.5
+      vertex 62.0393 56.3109 0
+      vertex 62.0393 56.3109 7.5
+    endloop
+  endfacet
+  facet normal 0.982305 -0.187288 0
+    outer loop
+      vertex 62.0393 56.3109 0
+      vertex 62.0099 56.1567 7.5
+      vertex 62.0099 56.1567 0
+    endloop
+  endfacet
+  facet normal 0.770513 0.637424 0
+    outer loop
+      vertex 62.3388 55.1443 7.5
+      vertex 62.2387 55.2653 0
+      vertex 62.2387 55.2653 7.5
+    endloop
+  endfacet
+  facet normal 0.770513 0.637424 0
+    outer loop
+      vertex 62.2387 55.2653 0
+      vertex 62.3388 55.1443 7.5
+      vertex 62.3388 55.1443 0
+    endloop
+  endfacet
+  facet normal 0.844291 0.535886 0
+    outer loop
+      vertex 62.2387 55.2653 7.5
+      vertex 62.1546 55.3978 0
+      vertex 62.1546 55.3978 7.5
+    endloop
+  endfacet
+  facet normal 0.844291 0.535886 0
+    outer loop
+      vertex 62.1546 55.3978 0
+      vertex 62.2387 55.2653 7.5
+      vertex 62.2387 55.2653 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 110.75 77.75 0
+      vertex 110.75 75 0.5
+      vertex 110.75 77.75 3
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 110.75 77.75 0
+      vertex 110.75 65 0.5
+      vertex 110.75 75 0.5
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 110.75 62.25 0
+      vertex 110.75 65 0.5
+      vertex 110.75 77.75 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 110.75 62.25 3
+      vertex 110.75 65 0.5
+      vertex 110.75 62.25 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 110.75 65 0.5
+      vertex 110.75 62.25 3
+      vertex 110.75 65 3
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 110.75 77.75 3
+      vertex 110.75 75 0.5
+      vertex 110.75 75 3
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 90.25 62.25 1.5
+      vertex 90.25 77.75 0
+      vertex 90.25 77.75 1.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 90.25 77.75 0
+      vertex 90.25 62.25 1.5
+      vertex 90.25 62.25 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 90.25 77.75 1.5
+      vertex 85.5 77.75 3
+      vertex 85.5 77.75 1.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 85.5 77.75 3
+      vertex 90.25 77.75 1.5
+      vertex 110.75 77.75 3
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 110.75 77.75 0
+      vertex 90.25 77.75 1.5
+      vertex 90.25 77.75 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 90.25 77.75 1.5
+      vertex 110.75 77.75 0
+      vertex 110.75 77.75 3
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 110.75 62.25 3
+      vertex 90.25 62.25 1.5
+      vertex 85.5 62.25 3
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 110.75 62.25 0
+      vertex 90.25 62.25 1.5
+      vertex 110.75 62.25 3
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 90.25 62.25 1.5
+      vertex 110.75 62.25 0
+      vertex 90.25 62.25 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 85.5 62.25 3
+      vertex 90.25 62.25 1.5
+      vertex 85.5 62.25 1.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 85.5 77.75 1.5
+      vertex 90.25 62.25 1.5
+      vertex 90.25 77.75 1.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 90.25 62.25 1.5
+      vertex 85.5 77.75 1.5
+      vertex 85.5 62.25 1.5
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 85.5 62.25 3
+      vertex 85.5 77.75 1.5
+      vertex 85.5 77.75 3
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 85.5 77.75 1.5
+      vertex 85.5 62.25 3
+      vertex 85.5 62.25 1.5
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 120.5 65 0.5
+      vertex 120.5 75 3
+      vertex 120.5 75 0.5
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 120.5 75 3
+      vertex 120.5 65 0.5
+      vertex 120.5 65 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 110.75 75 0.5
+      vertex 120.5 65 0.5
+      vertex 120.5 75 0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 120.5 65 0.5
+      vertex 110.75 75 0.5
+      vertex 110.75 65 0.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 110.75 75 0.5
+      vertex 120.5 75 3
+      vertex 110.75 75 3
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 120.5 75 3
+      vertex 110.75 75 0.5
+      vertex 120.5 75 0.5
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 120.5 65 0.5
+      vertex 110.75 65 3
+      vertex 120.5 65 3
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 110.75 65 3
+      vertex 120.5 65 0.5
+      vertex 110.75 65 0.5
+    endloop
+  endfacet
+  facet normal 0.950137 0.311833 0
+    outer loop
+      vertex 111.838 40.5398 3
+      vertex 111.789 40.6891 0
+      vertex 111.789 40.6891 3
+    endloop
+  endfacet
+  facet normal 0.950137 0.311833 0
+    outer loop
+      vertex 111.789 40.6891 0
+      vertex 111.838 40.5398 3
+      vertex 111.838 40.5398 0
+    endloop
+  endfacet
+  facet normal -0.982771 -0.184827 0
+    outer loop
+      vertex 114.24 41.1567 0
+      vertex 114.211 41.3109 3
+      vertex 114.211 41.3109 0
+    endloop
+  endfacet
+  facet normal -0.982771 -0.184827 0
+    outer loop
+      vertex 114.211 41.3109 3
+      vertex 114.24 41.1567 0
+      vertex 114.24 41.1567 3
+    endloop
+  endfacet
+  facet normal -0.99797 -0.0636867 0
+    outer loop
+      vertex 114.25 41 0
+      vertex 114.24 41.1567 3
+      vertex 114.24 41.1567 0
+    endloop
+  endfacet
+  facet normal -0.99797 -0.0636867 0
+    outer loop
+      vertex 114.24 41.1567 3
+      vertex 114.25 41 0
+      vertex 114.25 41 3
+    endloop
+  endfacet
+  facet normal 0.982771 -0.184827 0
+    outer loop
+      vertex 111.76 41.1567 3
+      vertex 111.789 41.3109 0
+      vertex 111.789 41.3109 3
+    endloop
+  endfacet
+  facet normal 0.982771 -0.184827 0
+    outer loop
+      vertex 111.789 41.3109 0
+      vertex 111.76 41.1567 3
+      vertex 111.76 41.1567 0
+    endloop
+  endfacet
+  facet normal 0.249126 -0.968471 0
+    outer loop
+      vertex 112.614 42.1888 0
+      vertex 112.766 42.2279 3
+      vertex 112.614 42.1888 3
+    endloop
+  endfacet
+  facet normal 0.249126 -0.968471 0
+    outer loop
+      vertex 112.766 42.2279 3
+      vertex 112.614 42.1888 0
+      vertex 112.766 42.2279 0
+    endloop
+  endfacet
+  facet normal -0.685723 -0.727863 0
+    outer loop
+      vertex 113.797 41.9631 0
+      vertex 113.911 41.8557 3
+      vertex 113.797 41.9631 3
+    endloop
+  endfacet
+  facet normal -0.685723 -0.727863 -0
+    outer loop
+      vertex 113.911 41.8557 3
+      vertex 113.797 41.9631 0
+      vertex 113.911 41.8557 0
+    endloop
+  endfacet
+  facet normal -0.249126 0.968471 0
+    outer loop
+      vertex 113.386 39.8112 0
+      vertex 113.234 39.7721 3
+      vertex 113.386 39.8112 3
+    endloop
+  endfacet
+  facet normal -0.249126 0.968471 0
+    outer loop
+      vertex 113.234 39.7721 3
+      vertex 113.386 39.8112 0
+      vertex 113.234 39.7721 0
+    endloop
+  endfacet
+  facet normal 0.904385 0.426717 0
+    outer loop
+      vertex 111.905 40.3978 3
+      vertex 111.838 40.5398 0
+      vertex 111.838 40.5398 3
+    endloop
+  endfacet
+  facet normal 0.904385 0.426717 0
+    outer loop
+      vertex 111.838 40.5398 0
+      vertex 111.905 40.3978 3
+      vertex 111.905 40.3978 0
+    endloop
+  endfacet
+  facet normal 0.950137 -0.311833 0
+    outer loop
+      vertex 111.789 41.3109 3
+      vertex 111.838 41.4602 0
+      vertex 111.838 41.4602 3
+    endloop
+  endfacet
+  facet normal 0.950137 -0.311833 0
+    outer loop
+      vertex 111.838 41.4602 0
+      vertex 111.789 41.3109 3
+      vertex 111.789 41.3109 0
+    endloop
+  endfacet
+  facet normal -0.124661 0.992199 0
+    outer loop
+      vertex 113.234 39.7721 0
+      vertex 113.078 39.7525 3
+      vertex 113.234 39.7721 3
+    endloop
+  endfacet
+  facet normal -0.124661 0.992199 0
+    outer loop
+      vertex 113.078 39.7525 3
+      vertex 113.234 39.7721 0
+      vertex 113.078 39.7525 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 113.078 39.7525 0
+      vertex 112.922 39.7525 3
+      vertex 113.078 39.7525 3
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 112.922 39.7525 3
+      vertex 113.078 39.7525 0
+      vertex 112.922 39.7525 0
+    endloop
+  endfacet
+  facet normal -0.982771 0.184827 0
+    outer loop
+      vertex 114.211 40.6891 0
+      vertex 114.24 40.8433 3
+      vertex 114.24 40.8433 0
+    endloop
+  endfacet
+  facet normal -0.982771 0.184827 0
+    outer loop
+      vertex 114.24 40.8433 3
+      vertex 114.211 40.6891 0
+      vertex 114.211 40.6891 3
+    endloop
+  endfacet
+  facet normal 0.587907 -0.808929 0
+    outer loop
+      vertex 112.203 41.9631 0
+      vertex 112.33 42.0554 3
+      vertex 112.203 41.9631 3
+    endloop
+  endfacet
+  facet normal 0.587907 -0.808929 0
+    outer loop
+      vertex 112.33 42.0554 3
+      vertex 112.203 41.9631 0
+      vertex 112.33 42.0554 0
+    endloop
+  endfacet
+  facet normal -0.950137 0.311833 0
+    outer loop
+      vertex 114.162 40.5398 0
+      vertex 114.211 40.6891 3
+      vertex 114.211 40.6891 0
+    endloop
+  endfacet
+  facet normal -0.950137 0.311833 0
+    outer loop
+      vertex 114.211 40.6891 3
+      vertex 114.162 40.5398 0
+      vertex 114.162 40.5398 3
+    endloop
+  endfacet
+  facet normal 0.99797 0.0636867 0
+    outer loop
+      vertex 111.76 40.8433 3
+      vertex 111.75 41 0
+      vertex 111.75 41 3
+    endloop
+  endfacet
+  facet normal 0.99797 0.0636867 0
+    outer loop
+      vertex 111.75 41 0
+      vertex 111.76 40.8433 3
+      vertex 111.76 40.8433 0
+    endloop
+  endfacet
+  facet normal 0.368094 -0.929788 0
+    outer loop
+      vertex 112.468 42.131 0
+      vertex 112.614 42.1888 3
+      vertex 112.468 42.131 3
+    endloop
+  endfacet
+  facet normal 0.368094 -0.929788 0
+    outer loop
+      vertex 112.614 42.1888 3
+      vertex 112.468 42.131 0
+      vertex 112.614 42.1888 0
+    endloop
+  endfacet
+  facet normal -0.124661 -0.992199 0
+    outer loop
+      vertex 113.078 42.2475 0
+      vertex 113.234 42.2279 3
+      vertex 113.078 42.2475 3
+    endloop
+  endfacet
+  facet normal -0.124661 -0.992199 -0
+    outer loop
+      vertex 113.234 42.2279 3
+      vertex 113.078 42.2475 0
+      vertex 113.234 42.2279 0
+    endloop
+  endfacet
+  facet normal -0.480454 0.87702 0
+    outer loop
+      vertex 113.67 39.9446 0
+      vertex 113.532 39.869 3
+      vertex 113.67 39.9446 3
+    endloop
+  endfacet
+  facet normal -0.480454 0.87702 0
+    outer loop
+      vertex 113.532 39.869 3
+      vertex 113.67 39.9446 0
+      vertex 113.532 39.869 0
+    endloop
+  endfacet
+  facet normal -0.904385 0.426717 0
+    outer loop
+      vertex 114.095 40.3978 0
+      vertex 114.162 40.5398 3
+      vertex 114.162 40.5398 0
+    endloop
+  endfacet
+  facet normal -0.904385 0.426717 0
+    outer loop
+      vertex 114.162 40.5398 3
+      vertex 114.095 40.3978 0
+      vertex 114.095 40.3978 3
+    endloop
+  endfacet
+  facet normal -0.368094 0.929788 0
+    outer loop
+      vertex 113.532 39.869 0
+      vertex 113.386 39.8112 3
+      vertex 113.532 39.869 3
+    endloop
+  endfacet
+  facet normal -0.368094 0.929788 0
+    outer loop
+      vertex 113.386 39.8112 3
+      vertex 113.532 39.869 0
+      vertex 113.386 39.8112 0
+    endloop
+  endfacet
+  facet normal 0.904385 -0.426717 0
+    outer loop
+      vertex 111.838 41.4602 3
+      vertex 111.905 41.6022 0
+      vertex 111.905 41.6022 3
+    endloop
+  endfacet
+  facet normal 0.904385 -0.426717 0
+    outer loop
+      vertex 111.905 41.6022 0
+      vertex 111.838 41.4602 3
+      vertex 111.838 41.4602 0
+    endloop
+  endfacet
+  facet normal -0.904385 -0.426717 0
+    outer loop
+      vertex 114.162 41.4602 0
+      vertex 114.095 41.6022 3
+      vertex 114.095 41.6022 0
+    endloop
+  endfacet
+  facet normal -0.904385 -0.426717 0
+    outer loop
+      vertex 114.095 41.6022 3
+      vertex 114.162 41.4602 0
+      vertex 114.162 41.4602 3
+    endloop
+  endfacet
+  facet normal 0.99797 -0.0636867 0
+    outer loop
+      vertex 111.75 41 3
+      vertex 111.76 41.1567 0
+      vertex 111.76 41.1567 3
+    endloop
+  endfacet
+  facet normal 0.99797 -0.0636867 0
+    outer loop
+      vertex 111.76 41.1567 0
+      vertex 111.75 41 3
+      vertex 111.75 41 0
+    endloop
+  endfacet
+  facet normal -0.844579 -0.535431 0
+    outer loop
+      vertex 114.095 41.6022 0
+      vertex 114.011 41.7347 3
+      vertex 114.011 41.7347 0
+    endloop
+  endfacet
+  facet normal -0.844579 -0.535431 0
+    outer loop
+      vertex 114.011 41.7347 3
+      vertex 114.095 41.6022 0
+      vertex 114.095 41.6022 3
+    endloop
+  endfacet
+  facet normal 0.685723 0.727863 -0
+    outer loop
+      vertex 112.203 40.0369 0
+      vertex 112.089 40.1443 3
+      vertex 112.203 40.0369 3
+    endloop
+  endfacet
+  facet normal 0.685723 0.727863 0
+    outer loop
+      vertex 112.089 40.1443 3
+      vertex 112.203 40.0369 0
+      vertex 112.089 40.1443 0
+    endloop
+  endfacet
+  facet normal 0.844579 0.535431 0
+    outer loop
+      vertex 111.989 40.2653 3
+      vertex 111.905 40.3978 0
+      vertex 111.905 40.3978 3
+    endloop
+  endfacet
+  facet normal 0.844579 0.535431 0
+    outer loop
+      vertex 111.905 40.3978 0
+      vertex 111.989 40.2653 3
+      vertex 111.989 40.2653 0
+    endloop
+  endfacet
+  facet normal 0.480454 0.87702 -0
+    outer loop
+      vertex 112.468 39.869 0
+      vertex 112.33 39.9446 3
+      vertex 112.468 39.869 3
+    endloop
+  endfacet
+  facet normal 0.480454 0.87702 0
+    outer loop
+      vertex 112.33 39.9446 3
+      vertex 112.468 39.869 0
+      vertex 112.33 39.9446 0
+    endloop
+  endfacet
+  facet normal -0.587907 -0.808929 0
+    outer loop
+      vertex 113.67 42.0554 0
+      vertex 113.797 41.9631 3
+      vertex 113.67 42.0554 3
+    endloop
+  endfacet
+  facet normal -0.587907 -0.808929 -0
+    outer loop
+      vertex 113.797 41.9631 3
+      vertex 113.67 42.0554 0
+      vertex 113.797 41.9631 0
+    endloop
+  endfacet
+  facet normal -0.99797 0.0636867 0
+    outer loop
+      vertex 114.24 40.8433 0
+      vertex 114.25 41 3
+      vertex 114.25 41 0
+    endloop
+  endfacet
+  facet normal -0.99797 0.0636867 0
+    outer loop
+      vertex 114.25 41 3
+      vertex 114.24 40.8433 0
+      vertex 114.24 40.8433 3
+    endloop
+  endfacet
+  facet normal 0.480454 -0.87702 0
+    outer loop
+      vertex 112.33 42.0554 0
+      vertex 112.468 42.131 3
+      vertex 112.33 42.0554 3
+    endloop
+  endfacet
+  facet normal 0.480454 -0.87702 0
+    outer loop
+      vertex 112.468 42.131 3
+      vertex 112.33 42.0554 0
+      vertex 112.468 42.131 0
+    endloop
+  endfacet
+  facet normal -0.587907 0.808929 0
+    outer loop
+      vertex 113.797 40.0369 0
+      vertex 113.67 39.9446 3
+      vertex 113.797 40.0369 3
+    endloop
+  endfacet
+  facet normal -0.587907 0.808929 0
+    outer loop
+      vertex 113.67 39.9446 3
+      vertex 113.797 40.0369 0
+      vertex 113.67 39.9446 0
+    endloop
+  endfacet
+  facet normal 0.844579 -0.535431 0
+    outer loop
+      vertex 111.905 41.6022 3
+      vertex 111.989 41.7347 0
+      vertex 111.989 41.7347 3
+    endloop
+  endfacet
+  facet normal 0.844579 -0.535431 0
+    outer loop
+      vertex 111.989 41.7347 0
+      vertex 111.905 41.6022 3
+      vertex 111.905 41.6022 0
+    endloop
+  endfacet
+  facet normal -0.249126 -0.968471 0
+    outer loop
+      vertex 113.234 42.2279 0
+      vertex 113.386 42.1888 3
+      vertex 113.234 42.2279 3
+    endloop
+  endfacet
+  facet normal -0.249126 -0.968471 -0
+    outer loop
+      vertex 113.386 42.1888 3
+      vertex 113.234 42.2279 0
+      vertex 113.386 42.1888 0
+    endloop
+  endfacet
+  facet normal 0.770826 0.637046 0
+    outer loop
+      vertex 112.089 40.1443 3
+      vertex 111.989 40.2653 0
+      vertex 111.989 40.2653 3
+    endloop
+  endfacet
+  facet normal 0.770826 0.637046 0
+    outer loop
+      vertex 111.989 40.2653 0
+      vertex 112.089 40.1443 3
+      vertex 112.089 40.1443 0
+    endloop
+  endfacet
+  facet normal -0.368094 -0.929788 0
+    outer loop
+      vertex 113.386 42.1888 0
+      vertex 113.532 42.131 3
+      vertex 113.386 42.1888 3
+    endloop
+  endfacet
+  facet normal -0.368094 -0.929788 -0
+    outer loop
+      vertex 113.532 42.131 3
+      vertex 113.386 42.1888 0
+      vertex 113.532 42.131 0
+    endloop
+  endfacet
+  facet normal 0.982771 0.184827 0
+    outer loop
+      vertex 111.789 40.6891 3
+      vertex 111.76 40.8433 0
+      vertex 111.76 40.8433 3
+    endloop
+  endfacet
+  facet normal 0.982771 0.184827 0
+    outer loop
+      vertex 111.76 40.8433 0
+      vertex 111.789 40.6891 3
+      vertex 111.789 40.6891 0
+    endloop
+  endfacet
+  facet normal -0.480454 -0.87702 0
+    outer loop
+      vertex 113.532 42.131 0
+      vertex 113.67 42.0554 3
+      vertex 113.532 42.131 3
+    endloop
+  endfacet
+  facet normal -0.480454 -0.87702 -0
+    outer loop
+      vertex 113.67 42.0554 3
+      vertex 113.532 42.131 0
+      vertex 113.67 42.0554 0
+    endloop
+  endfacet
+  facet normal 0.124661 0.992199 -0
+    outer loop
+      vertex 112.922 39.7525 0
+      vertex 112.766 39.7721 3
+      vertex 112.922 39.7525 3
+    endloop
+  endfacet
+  facet normal 0.124661 0.992199 0
+    outer loop
+      vertex 112.766 39.7721 3
+      vertex 112.922 39.7525 0
+      vertex 112.766 39.7721 0
+    endloop
+  endfacet
+  facet normal -0.844579 0.535431 0
+    outer loop
+      vertex 114.011 40.2653 0
+      vertex 114.095 40.3978 3
+      vertex 114.095 40.3978 0
+    endloop
+  endfacet
+  facet normal -0.844579 0.535431 0
+    outer loop
+      vertex 114.095 40.3978 3
+      vertex 114.011 40.2653 0
+      vertex 114.011 40.2653 3
+    endloop
+  endfacet
+  facet normal -0.770826 -0.637046 0
+    outer loop
+      vertex 114.011 41.7347 0
+      vertex 113.911 41.8557 3
+      vertex 113.911 41.8557 0
+    endloop
+  endfacet
+  facet normal -0.770826 -0.637046 0
+    outer loop
+      vertex 113.911 41.8557 3
+      vertex 114.011 41.7347 0
+      vertex 114.011 41.7347 3
+    endloop
+  endfacet
+  facet normal -0.950137 -0.311833 0
+    outer loop
+      vertex 114.211 41.3109 0
+      vertex 114.162 41.4602 3
+      vertex 114.162 41.4602 0
+    endloop
+  endfacet
+  facet normal -0.950137 -0.311833 0
+    outer loop
+      vertex 114.162 41.4602 3
+      vertex 114.211 41.3109 0
+      vertex 114.211 41.3109 3
+    endloop
+  endfacet
+  facet normal 0.685723 -0.727863 0
+    outer loop
+      vertex 112.089 41.8557 0
+      vertex 112.203 41.9631 3
+      vertex 112.089 41.8557 3
+    endloop
+  endfacet
+  facet normal 0.685723 -0.727863 0
+    outer loop
+      vertex 112.203 41.9631 3
+      vertex 112.089 41.8557 0
+      vertex 112.203 41.9631 0
+    endloop
+  endfacet
+  facet normal 0.770826 -0.637046 0
+    outer loop
+      vertex 111.989 41.7347 3
+      vertex 112.089 41.8557 0
+      vertex 112.089 41.8557 3
+    endloop
+  endfacet
+  facet normal 0.770826 -0.637046 0
+    outer loop
+      vertex 112.089 41.8557 0
+      vertex 111.989 41.7347 3
+      vertex 111.989 41.7347 0
+    endloop
+  endfacet
+  facet normal 0.587907 0.808929 -0
+    outer loop
+      vertex 112.33 39.9446 0
+      vertex 112.203 40.0369 3
+      vertex 112.33 39.9446 3
+    endloop
+  endfacet
+  facet normal 0.587907 0.808929 0
+    outer loop
+      vertex 112.203 40.0369 3
+      vertex 112.33 39.9446 0
+      vertex 112.203 40.0369 0
+    endloop
+  endfacet
+  facet normal 0.124661 -0.992199 0
+    outer loop
+      vertex 112.766 42.2279 0
+      vertex 112.922 42.2475 3
+      vertex 112.766 42.2279 3
+    endloop
+  endfacet
+  facet normal 0.124661 -0.992199 0
+    outer loop
+      vertex 112.922 42.2475 3
+      vertex 112.766 42.2279 0
+      vertex 112.922 42.2475 0
+    endloop
+  endfacet
+  facet normal -0.685723 0.727863 0
+    outer loop
+      vertex 113.911 40.1443 0
+      vertex 113.797 40.0369 3
+      vertex 113.911 40.1443 3
+    endloop
+  endfacet
+  facet normal -0.685723 0.727863 0
+    outer loop
+      vertex 113.797 40.0369 3
+      vertex 113.911 40.1443 0
+      vertex 113.797 40.0369 0
+    endloop
+  endfacet
+  facet normal -0.770826 0.637046 0
+    outer loop
+      vertex 113.911 40.1443 0
+      vertex 114.011 40.2653 3
+      vertex 114.011 40.2653 0
+    endloop
+  endfacet
+  facet normal -0.770826 0.637046 0
+    outer loop
+      vertex 114.011 40.2653 3
+      vertex 113.911 40.1443 0
+      vertex 113.911 40.1443 3
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 112.922 42.2475 0
+      vertex 113.078 42.2475 3
+      vertex 112.922 42.2475 3
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 113.078 42.2475 3
+      vertex 112.922 42.2475 0
+      vertex 113.078 42.2475 0
+    endloop
+  endfacet
+  facet normal 0.249126 0.968471 -0
+    outer loop
+      vertex 112.766 39.7721 0
+      vertex 112.614 39.8112 3
+      vertex 112.766 39.7721 3
+    endloop
+  endfacet
+  facet normal 0.249126 0.968471 0
+    outer loop
+      vertex 112.614 39.8112 3
+      vertex 112.766 39.7721 0
+      vertex 112.614 39.8112 0
+    endloop
+  endfacet
+  facet normal 0.368094 0.929788 -0
+    outer loop
+      vertex 112.614 39.8112 0
+      vertex 112.468 39.869 3
+      vertex 112.614 39.8112 3
+    endloop
+  endfacet
+  facet normal 0.368094 0.929788 0
+    outer loop
+      vertex 112.468 39.869 3
+      vertex 112.614 39.8112 0
+      vertex 112.468 39.869 0
+    endloop
+  endfacet
+  facet normal 0.950137 0.311833 0
+    outer loop
+      vertex 111.838 98.5398 3
+      vertex 111.789 98.6891 0
+      vertex 111.789 98.6891 3
+    endloop
+  endfacet
+  facet normal 0.950137 0.311833 0
+    outer loop
+      vertex 111.789 98.6891 0
+      vertex 111.838 98.5398 3
+      vertex 111.838 98.5398 0
+    endloop
+  endfacet
+  facet normal -0.982771 -0.184827 0
+    outer loop
+      vertex 114.24 99.1567 0
+      vertex 114.211 99.3109 3
+      vertex 114.211 99.3109 0
+    endloop
+  endfacet
+  facet normal -0.982771 -0.184827 0
+    outer loop
+      vertex 114.211 99.3109 3
+      vertex 114.24 99.1567 0
+      vertex 114.24 99.1567 3
+    endloop
+  endfacet
+  facet normal -0.99797 -0.0636867 0
+    outer loop
+      vertex 114.25 99 0
+      vertex 114.24 99.1567 3
+      vertex 114.24 99.1567 0
+    endloop
+  endfacet
+  facet normal -0.99797 -0.0636867 0
+    outer loop
+      vertex 114.24 99.1567 3
+      vertex 114.25 99 0
+      vertex 114.25 99 3
+    endloop
+  endfacet
+  facet normal 0.982771 -0.184827 0
+    outer loop
+      vertex 111.76 99.1567 3
+      vertex 111.789 99.3109 0
+      vertex 111.789 99.3109 3
+    endloop
+  endfacet
+  facet normal 0.982771 -0.184827 0
+    outer loop
+      vertex 111.789 99.3109 0
+      vertex 111.76 99.1567 3
+      vertex 111.76 99.1567 0
+    endloop
+  endfacet
+  facet normal 0.248529 -0.968625 0
+    outer loop
+      vertex 112.614 100.189 0
+      vertex 112.766 100.228 3
+      vertex 112.614 100.189 3
+    endloop
+  endfacet
+  facet normal 0.248529 -0.968625 0
+    outer loop
+      vertex 112.766 100.228 3
+      vertex 112.614 100.189 0
+      vertex 112.766 100.228 0
+    endloop
+  endfacet
+  facet normal -0.685723 -0.727863 0
+    outer loop
+      vertex 113.797 99.9631 0
+      vertex 113.911 99.8557 3
+      vertex 113.797 99.9631 3
+    endloop
+  endfacet
+  facet normal -0.685723 -0.727863 -0
+    outer loop
+      vertex 113.911 99.8557 3
+      vertex 113.797 99.9631 0
+      vertex 113.911 99.8557 0
+    endloop
+  endfacet
+  facet normal -0.249126 0.968471 0
+    outer loop
+      vertex 113.386 97.8112 0
+      vertex 113.234 97.7721 3
+      vertex 113.386 97.8112 3
+    endloop
+  endfacet
+  facet normal -0.249126 0.968471 0
+    outer loop
+      vertex 113.234 97.7721 3
+      vertex 113.386 97.8112 0
+      vertex 113.234 97.7721 0
+    endloop
+  endfacet
+  facet normal 0.904385 0.426717 0
+    outer loop
+      vertex 111.905 98.3978 3
+      vertex 111.838 98.5398 0
+      vertex 111.838 98.5398 3
+    endloop
+  endfacet
+  facet normal 0.904385 0.426717 0
+    outer loop
+      vertex 111.838 98.5398 0
+      vertex 111.905 98.3978 3
+      vertex 111.905 98.3978 0
+    endloop
+  endfacet
+  facet normal 0.950137 -0.311833 0
+    outer loop
+      vertex 111.789 99.3109 3
+      vertex 111.838 99.4602 0
+      vertex 111.838 99.4602 3
+    endloop
+  endfacet
+  facet normal 0.950137 -0.311833 0
+    outer loop
+      vertex 111.838 99.4602 0
+      vertex 111.789 99.3109 3
+      vertex 111.789 99.3109 0
+    endloop
+  endfacet
+  facet normal -0.124661 0.992199 0
+    outer loop
+      vertex 113.234 97.7721 0
+      vertex 113.078 97.7525 3
+      vertex 113.234 97.7721 3
+    endloop
+  endfacet
+  facet normal -0.124661 0.992199 0
+    outer loop
+      vertex 113.078 97.7525 3
+      vertex 113.234 97.7721 0
+      vertex 113.078 97.7525 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 113.078 97.7525 0
+      vertex 112.922 97.7525 3
+      vertex 113.078 97.7525 3
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 112.922 97.7525 3
+      vertex 113.078 97.7525 0
+      vertex 112.922 97.7525 0
+    endloop
+  endfacet
+  facet normal -0.982771 0.184827 0
+    outer loop
+      vertex 114.211 98.6891 0
+      vertex 114.24 98.8433 3
+      vertex 114.24 98.8433 0
+    endloop
+  endfacet
+  facet normal -0.982771 0.184827 0
+    outer loop
+      vertex 114.24 98.8433 3
+      vertex 114.211 98.6891 0
+      vertex 114.211 98.6891 3
+    endloop
+  endfacet
+  facet normal 0.586236 -0.810141 0
+    outer loop
+      vertex 112.203 99.9631 0
+      vertex 112.33 100.055 3
+      vertex 112.203 99.9631 3
+    endloop
+  endfacet
+  facet normal 0.586236 -0.810141 0
+    outer loop
+      vertex 112.33 100.055 3
+      vertex 112.203 99.9631 0
+      vertex 112.33 100.055 0
+    endloop
+  endfacet
+  facet normal -0.950137 0.311833 0
+    outer loop
+      vertex 114.162 98.5398 0
+      vertex 114.211 98.6891 3
+      vertex 114.211 98.6891 0
+    endloop
+  endfacet
+  facet normal -0.950137 0.311833 0
+    outer loop
+      vertex 114.211 98.6891 3
+      vertex 114.162 98.5398 0
+      vertex 114.162 98.5398 3
+    endloop
+  endfacet
+  facet normal 0.99797 0.0636867 0
+    outer loop
+      vertex 111.76 98.8433 3
+      vertex 111.75 99 0
+      vertex 111.75 99 3
+    endloop
+  endfacet
+  facet normal 0.99797 0.0636867 0
+    outer loop
+      vertex 111.75 99 0
+      vertex 111.76 98.8433 3
+      vertex 111.76 98.8433 0
+    endloop
+  endfacet
+  facet normal 0.369195 -0.929352 0
+    outer loop
+      vertex 112.468 100.131 0
+      vertex 112.614 100.189 3
+      vertex 112.468 100.131 3
+    endloop
+  endfacet
+  facet normal 0.369195 -0.929352 0
+    outer loop
+      vertex 112.614 100.189 3
+      vertex 112.468 100.131 0
+      vertex 112.614 100.189 0
+    endloop
+  endfacet
+  facet normal -0.127164 -0.991882 0
+    outer loop
+      vertex 113.078 100.248 0
+      vertex 113.234 100.228 3
+      vertex 113.078 100.248 3
+    endloop
+  endfacet
+  facet normal -0.127164 -0.991882 -0
+    outer loop
+      vertex 113.234 100.228 3
+      vertex 113.078 100.248 0
+      vertex 113.234 100.228 0
+    endloop
+  endfacet
+  facet normal -0.480454 0.87702 0
+    outer loop
+      vertex 113.67 97.9446 0
+      vertex 113.532 97.869 3
+      vertex 113.67 97.9446 3
+    endloop
+  endfacet
+  facet normal -0.480454 0.87702 0
+    outer loop
+      vertex 113.532 97.869 3
+      vertex 113.67 97.9446 0
+      vertex 113.532 97.869 0
+    endloop
+  endfacet
+  facet normal -0.904385 0.426717 0
+    outer loop
+      vertex 114.095 98.3978 0
+      vertex 114.162 98.5398 3
+      vertex 114.162 98.5398 0
+    endloop
+  endfacet
+  facet normal -0.904385 0.426717 0
+    outer loop
+      vertex 114.162 98.5398 3
+      vertex 114.095 98.3978 0
+      vertex 114.095 98.3978 3
+    endloop
+  endfacet
+  facet normal -0.368094 0.929788 0
+    outer loop
+      vertex 113.532 97.869 0
+      vertex 113.386 97.8112 3
+      vertex 113.532 97.869 3
+    endloop
+  endfacet
+  facet normal -0.368094 0.929788 0
+    outer loop
+      vertex 113.386 97.8112 3
+      vertex 113.532 97.869 0
+      vertex 113.386 97.8112 0
+    endloop
+  endfacet
+  facet normal 0.904385 -0.426717 0
+    outer loop
+      vertex 111.838 99.4602 3
+      vertex 111.905 99.6022 0
+      vertex 111.905 99.6022 3
+    endloop
+  endfacet
+  facet normal 0.904385 -0.426717 0
+    outer loop
+      vertex 111.905 99.6022 0
+      vertex 111.838 99.4602 3
+      vertex 111.838 99.4602 0
+    endloop
+  endfacet
+  facet normal -0.904385 -0.426717 0
+    outer loop
+      vertex 114.162 99.4602 0
+      vertex 114.095 99.6022 3
+      vertex 114.095 99.6022 0
+    endloop
+  endfacet
+  facet normal -0.904385 -0.426717 0
+    outer loop
+      vertex 114.095 99.6022 3
+      vertex 114.162 99.4602 0
+      vertex 114.162 99.4602 3
+    endloop
+  endfacet
+  facet normal 0.99797 -0.0636867 0
+    outer loop
+      vertex 111.75 99 3
+      vertex 111.76 99.1567 0
+      vertex 111.76 99.1567 3
+    endloop
+  endfacet
+  facet normal 0.99797 -0.0636867 0
+    outer loop
+      vertex 111.76 99.1567 0
+      vertex 111.75 99 3
+      vertex 111.75 99 0
+    endloop
+  endfacet
+  facet normal -0.844579 -0.535431 0
+    outer loop
+      vertex 114.095 99.6022 0
+      vertex 114.011 99.7347 3
+      vertex 114.011 99.7347 0
+    endloop
+  endfacet
+  facet normal -0.844579 -0.535431 0
+    outer loop
+      vertex 114.011 99.7347 3
+      vertex 114.095 99.6022 0
+      vertex 114.095 99.6022 3
+    endloop
+  endfacet
+  facet normal 0.685723 0.727863 -0
+    outer loop
+      vertex 112.203 98.0369 0
+      vertex 112.089 98.1443 3
+      vertex 112.203 98.0369 3
+    endloop
+  endfacet
+  facet normal 0.685723 0.727863 0
+    outer loop
+      vertex 112.089 98.1443 3
+      vertex 112.203 98.0369 0
+      vertex 112.089 98.1443 0
+    endloop
+  endfacet
+  facet normal 0.844579 0.535431 0
+    outer loop
+      vertex 111.989 98.2653 3
+      vertex 111.905 98.3978 0
+      vertex 111.905 98.3978 3
+    endloop
+  endfacet
+  facet normal 0.844579 0.535431 0
+    outer loop
+      vertex 111.905 98.3978 0
+      vertex 111.989 98.2653 3
+      vertex 111.989 98.2653 0
+    endloop
+  endfacet
+  facet normal 0.480454 0.87702 -0
+    outer loop
+      vertex 112.468 97.869 0
+      vertex 112.33 97.9446 3
+      vertex 112.468 97.869 3
+    endloop
+  endfacet
+  facet normal 0.480454 0.87702 0
+    outer loop
+      vertex 112.33 97.9446 3
+      vertex 112.468 97.869 0
+      vertex 112.33 97.9446 0
+    endloop
+  endfacet
+  facet normal -0.586236 -0.810141 0
+    outer loop
+      vertex 113.67 100.055 0
+      vertex 113.797 99.9631 3
+      vertex 113.67 100.055 3
+    endloop
+  endfacet
+  facet normal -0.586236 -0.810141 -0
+    outer loop
+      vertex 113.797 99.9631 3
+      vertex 113.67 100.055 0
+      vertex 113.797 99.9631 0
+    endloop
+  endfacet
+  facet normal -0.99797 0.0636867 0
+    outer loop
+      vertex 114.24 98.8433 0
+      vertex 114.25 99 3
+      vertex 114.25 99 0
+    endloop
+  endfacet
+  facet normal -0.99797 0.0636867 0
+    outer loop
+      vertex 114.25 99 3
+      vertex 114.24 98.8433 0
+      vertex 114.24 98.8433 3
+    endloop
+  endfacet
+  facet normal 0.482406 -0.875948 0
+    outer loop
+      vertex 112.33 100.055 0
+      vertex 112.468 100.131 3
+      vertex 112.33 100.055 3
+    endloop
+  endfacet
+  facet normal 0.482406 -0.875948 0
+    outer loop
+      vertex 112.468 100.131 3
+      vertex 112.33 100.055 0
+      vertex 112.468 100.131 0
+    endloop
+  endfacet
+  facet normal -0.587907 0.808929 0
+    outer loop
+      vertex 113.797 98.0369 0
+      vertex 113.67 97.9446 3
+      vertex 113.797 98.0369 3
+    endloop
+  endfacet
+  facet normal -0.587907 0.808929 0
+    outer loop
+      vertex 113.67 97.9446 3
+      vertex 113.797 98.0369 0
+      vertex 113.67 97.9446 0
+    endloop
+  endfacet
+  facet normal 0.844579 -0.535431 0
+    outer loop
+      vertex 111.905 99.6022 3
+      vertex 111.989 99.7347 0
+      vertex 111.989 99.7347 3
+    endloop
+  endfacet
+  facet normal 0.844579 -0.535431 0
+    outer loop
+      vertex 111.989 99.7347 0
+      vertex 111.905 99.6022 3
+      vertex 111.905 99.6022 0
+    endloop
+  endfacet
+  facet normal -0.248529 -0.968625 0
+    outer loop
+      vertex 113.234 100.228 0
+      vertex 113.386 100.189 3
+      vertex 113.234 100.228 3
+    endloop
+  endfacet
+  facet normal -0.248529 -0.968625 -0
+    outer loop
+      vertex 113.386 100.189 3
+      vertex 113.234 100.228 0
+      vertex 113.386 100.189 0
+    endloop
+  endfacet
+  facet normal 0.770826 0.637046 0
+    outer loop
+      vertex 112.089 98.1443 3
+      vertex 111.989 98.2653 0
+      vertex 111.989 98.2653 3
+    endloop
+  endfacet
+  facet normal 0.770826 0.637046 0
+    outer loop
+      vertex 111.989 98.2653 0
+      vertex 112.089 98.1443 3
+      vertex 112.089 98.1443 0
+    endloop
+  endfacet
+  facet normal -0.770826 0.637046 0
+    outer loop
+      vertex 113.911 98.1443 0
+      vertex 114.011 98.2653 3
+      vertex 114.011 98.2653 0
+    endloop
+  endfacet
+  facet normal -0.770826 0.637046 0
+    outer loop
+      vertex 114.011 98.2653 3
+      vertex 113.911 98.1443 0
+      vertex 113.911 98.1443 3
+    endloop
+  endfacet
+  facet normal -0.369195 -0.929352 0
+    outer loop
+      vertex 113.386 100.189 0
+      vertex 113.532 100.131 3
+      vertex 113.386 100.189 3
+    endloop
+  endfacet
+  facet normal -0.369195 -0.929352 -0
+    outer loop
+      vertex 113.532 100.131 3
+      vertex 113.386 100.189 0
+      vertex 113.532 100.131 0
+    endloop
+  endfacet
+  facet normal 0.982771 0.184827 0
+    outer loop
+      vertex 111.789 98.6891 3
+      vertex 111.76 98.8433 0
+      vertex 111.76 98.8433 3
+    endloop
+  endfacet
+  facet normal 0.982771 0.184827 0
+    outer loop
+      vertex 111.76 98.8433 0
+      vertex 111.789 98.6891 3
+      vertex 111.789 98.6891 0
+    endloop
+  endfacet
+  facet normal -0.482406 -0.875948 0
+    outer loop
+      vertex 113.532 100.131 0
+      vertex 113.67 100.055 3
+      vertex 113.532 100.131 3
+    endloop
+  endfacet
+  facet normal -0.482406 -0.875948 -0
+    outer loop
+      vertex 113.67 100.055 3
+      vertex 113.532 100.131 0
+      vertex 113.67 100.055 0
+    endloop
+  endfacet
+  facet normal 0.124661 0.992199 -0
+    outer loop
+      vertex 112.922 97.7525 0
+      vertex 112.766 97.7721 3
+      vertex 112.922 97.7525 3
+    endloop
+  endfacet
+  facet normal 0.124661 0.992199 0
+    outer loop
+      vertex 112.766 97.7721 3
+      vertex 112.922 97.7525 0
+      vertex 112.766 97.7721 0
+    endloop
+  endfacet
+  facet normal -0.844579 0.535431 0
+    outer loop
+      vertex 114.011 98.2653 0
+      vertex 114.095 98.3978 3
+      vertex 114.095 98.3978 0
+    endloop
+  endfacet
+  facet normal -0.844579 0.535431 0
+    outer loop
+      vertex 114.095 98.3978 3
+      vertex 114.011 98.2653 0
+      vertex 114.011 98.2653 3
+    endloop
+  endfacet
+  facet normal -0.770826 -0.637046 0
+    outer loop
+      vertex 114.011 99.7347 0
+      vertex 113.911 99.8557 3
+      vertex 113.911 99.8557 0
+    endloop
+  endfacet
+  facet normal -0.770826 -0.637046 0
+    outer loop
+      vertex 113.911 99.8557 3
+      vertex 114.011 99.7347 0
+      vertex 114.011 99.7347 3
+    endloop
+  endfacet
+  facet normal -0.950137 -0.311833 0
+    outer loop
+      vertex 114.211 99.3109 0
+      vertex 114.162 99.4602 3
+      vertex 114.162 99.4602 0
+    endloop
+  endfacet
+  facet normal -0.950137 -0.311833 0
+    outer loop
+      vertex 114.162 99.4602 3
+      vertex 114.211 99.3109 0
+      vertex 114.211 99.3109 3
+    endloop
+  endfacet
+  facet normal 0.685723 -0.727863 0
+    outer loop
+      vertex 112.089 99.8557 0
+      vertex 112.203 99.9631 3
+      vertex 112.089 99.8557 3
+    endloop
+  endfacet
+  facet normal 0.685723 -0.727863 0
+    outer loop
+      vertex 112.203 99.9631 3
+      vertex 112.089 99.8557 0
+      vertex 112.203 99.9631 0
+    endloop
+  endfacet
+  facet normal 0.770826 -0.637046 0
+    outer loop
+      vertex 111.989 99.7347 3
+      vertex 112.089 99.8557 0
+      vertex 112.089 99.8557 3
+    endloop
+  endfacet
+  facet normal 0.770826 -0.637046 0
+    outer loop
+      vertex 112.089 99.8557 0
+      vertex 111.989 99.7347 3
+      vertex 111.989 99.7347 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 112.922 100.248 0
+      vertex 113.078 100.248 3
+      vertex 112.922 100.248 3
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 113.078 100.248 3
+      vertex 112.922 100.248 0
+      vertex 113.078 100.248 0
+    endloop
+  endfacet
+  facet normal 0.587907 0.808929 -0
+    outer loop
+      vertex 112.33 97.9446 0
+      vertex 112.203 98.0369 3
+      vertex 112.33 97.9446 3
+    endloop
+  endfacet
+  facet normal 0.587907 0.808929 0
+    outer loop
+      vertex 112.203 98.0369 3
+      vertex 112.33 97.9446 0
+      vertex 112.203 98.0369 0
+    endloop
+  endfacet
+  facet normal 0.127164 -0.991882 0
+    outer loop
+      vertex 112.766 100.228 0
+      vertex 112.922 100.248 3
+      vertex 112.766 100.228 3
+    endloop
+  endfacet
+  facet normal 0.127164 -0.991882 0
+    outer loop
+      vertex 112.922 100.248 3
+      vertex 112.766 100.228 0
+      vertex 112.922 100.248 0
+    endloop
+  endfacet
+  facet normal -0.685723 0.727863 0
+    outer loop
+      vertex 113.911 98.1443 0
+      vertex 113.797 98.0369 3
+      vertex 113.911 98.1443 3
+    endloop
+  endfacet
+  facet normal -0.685723 0.727863 0
+    outer loop
+      vertex 113.797 98.0369 3
+      vertex 113.911 98.1443 0
+      vertex 113.797 98.0369 0
+    endloop
+  endfacet
+  facet normal 0.249126 0.968471 -0
+    outer loop
+      vertex 112.766 97.7721 0
+      vertex 112.614 97.8112 3
+      vertex 112.766 97.7721 3
+    endloop
+  endfacet
+  facet normal 0.249126 0.968471 0
+    outer loop
+      vertex 112.614 97.8112 3
+      vertex 112.766 97.7721 0
+      vertex 112.614 97.8112 0
+    endloop
+  endfacet
+  facet normal 0.368094 0.929788 -0
+    outer loop
+      vertex 112.614 97.8112 0
+      vertex 112.468 97.869 3
+      vertex 112.614 97.8112 3
+    endloop
+  endfacet
+  facet normal 0.368094 0.929788 0
+    outer loop
+      vertex 112.468 97.869 3
+      vertex 112.614 97.8112 0
+      vertex 112.468 97.869 0
+    endloop
+  endfacet
+  facet normal 0.951076 0.308956 0
+    outer loop
+      vertex 88.8378 40.5398 3
+      vertex 88.7893 40.6891 0
+      vertex 88.7893 40.6891 3
+    endloop
+  endfacet
+  facet normal 0.951076 0.308956 0
+    outer loop
+      vertex 88.7893 40.6891 0
+      vertex 88.8378 40.5398 3
+      vertex 88.8378 40.5398 0
+    endloop
+  endfacet
+  facet normal -0.982305 -0.187288 0
+    outer loop
+      vertex 91.2401 41.1567 0
+      vertex 91.2107 41.3109 3
+      vertex 91.2107 41.3109 0
+    endloop
+  endfacet
+  facet normal -0.982305 -0.187288 0
+    outer loop
+      vertex 91.2107 41.3109 3
+      vertex 91.2401 41.1567 0
+      vertex 91.2401 41.1567 3
+    endloop
+  endfacet
+  facet normal -0.99801 -0.0630523 0
+    outer loop
+      vertex 91.25 41 0
+      vertex 91.2401 41.1567 3
+      vertex 91.2401 41.1567 0
+    endloop
+  endfacet
+  facet normal -0.99801 -0.0630523 0
+    outer loop
+      vertex 91.2401 41.1567 3
+      vertex 91.25 41 0
+      vertex 91.25 41 3
+    endloop
+  endfacet
+  facet normal 0.982305 -0.187288 0
+    outer loop
+      vertex 88.7599 41.1567 3
+      vertex 88.7893 41.3109 0
+      vertex 88.7893 41.3109 3
+    endloop
+  endfacet
+  facet normal 0.982305 -0.187288 0
+    outer loop
+      vertex 88.7893 41.3109 0
+      vertex 88.7599 41.1567 3
+      vertex 88.7599 41.1567 0
+    endloop
+  endfacet
+  facet normal 0.248973 -0.96851 0
+    outer loop
+      vertex 89.6137 42.1888 0
+      vertex 89.7658 42.2279 3
+      vertex 89.6137 42.1888 3
+    endloop
+  endfacet
+  facet normal 0.248973 -0.96851 0
+    outer loop
+      vertex 89.7658 42.2279 3
+      vertex 89.6137 42.1888 0
+      vertex 89.7658 42.2279 0
+    endloop
+  endfacet
+  facet normal -0.68445 -0.72906 0
+    outer loop
+      vertex 90.7968 41.9631 0
+      vertex 90.9112 41.8557 3
+      vertex 90.7968 41.9631 3
+    endloop
+  endfacet
+  facet normal -0.68445 -0.72906 -0
+    outer loop
+      vertex 90.9112 41.8557 3
+      vertex 90.7968 41.9631 0
+      vertex 90.9112 41.8557 0
+    endloop
+  endfacet
+  facet normal -0.248973 0.96851 0
+    outer loop
+      vertex 90.3863 39.8112 0
+      vertex 90.2342 39.7721 3
+      vertex 90.3863 39.8112 3
+    endloop
+  endfacet
+  facet normal -0.248973 0.96851 0
+    outer loop
+      vertex 90.2342 39.7721 3
+      vertex 90.3863 39.8112 0
+      vertex 90.2342 39.7721 0
+    endloop
+  endfacet
+  facet normal 0.904876 0.425674 0
+    outer loop
+      vertex 88.9046 40.3978 3
+      vertex 88.8378 40.5398 0
+      vertex 88.8378 40.5398 3
+    endloop
+  endfacet
+  facet normal 0.904876 0.425674 0
+    outer loop
+      vertex 88.8378 40.5398 0
+      vertex 88.9046 40.3978 3
+      vertex 88.9046 40.3978 0
+    endloop
+  endfacet
+  facet normal 0.951076 -0.308956 0
+    outer loop
+      vertex 88.7893 41.3109 3
+      vertex 88.8378 41.4602 0
+      vertex 88.8378 41.4602 3
+    endloop
+  endfacet
+  facet normal 0.951076 -0.308956 0
+    outer loop
+      vertex 88.8378 41.4602 0
+      vertex 88.7893 41.3109 3
+      vertex 88.7893 41.3109 0
+    endloop
+  endfacet
+  facet normal -0.124897 0.99217 0
+    outer loop
+      vertex 90.2342 39.7721 0
+      vertex 90.0785 39.7525 3
+      vertex 90.2342 39.7721 3
+    endloop
+  endfacet
+  facet normal -0.124897 0.99217 0
+    outer loop
+      vertex 90.0785 39.7525 3
+      vertex 90.2342 39.7721 0
+      vertex 90.0785 39.7525 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 90.0785 39.7525 0
+      vertex 89.9215 39.7525 3
+      vertex 90.0785 39.7525 3
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 89.9215 39.7525 3
+      vertex 90.0785 39.7525 0
+      vertex 89.9215 39.7525 0
+    endloop
+  endfacet
+  facet normal -0.982305 0.187288 0
+    outer loop
+      vertex 91.2107 40.6891 0
+      vertex 91.2401 40.8433 3
+      vertex 91.2401 40.8433 0
+    endloop
+  endfacet
+  facet normal -0.982305 0.187288 0
+    outer loop
+      vertex 91.2401 40.8433 3
+      vertex 91.2107 40.6891 0
+      vertex 91.2107 40.6891 3
+    endloop
+  endfacet
+  facet normal 0.587907 -0.808929 0
+    outer loop
+      vertex 89.2032 41.9631 0
+      vertex 89.3302 42.0554 3
+      vertex 89.2032 41.9631 3
+    endloop
+  endfacet
+  facet normal 0.587907 -0.808929 0
+    outer loop
+      vertex 89.3302 42.0554 3
+      vertex 89.2032 41.9631 0
+      vertex 89.3302 42.0554 0
+    endloop
+  endfacet
+  facet normal -0.951076 0.308956 0
+    outer loop
+      vertex 91.1622 40.5398 0
+      vertex 91.2107 40.6891 3
+      vertex 91.2107 40.6891 0
+    endloop
+  endfacet
+  facet normal -0.951076 0.308956 0
+    outer loop
+      vertex 91.2107 40.6891 3
+      vertex 91.1622 40.5398 0
+      vertex 91.1622 40.5398 3
+    endloop
+  endfacet
+  facet normal 0.99801 0.0630523 0
+    outer loop
+      vertex 88.7599 40.8433 3
+      vertex 88.75 41 0
+      vertex 88.75 41 3
+    endloop
+  endfacet
+  facet normal 0.99801 0.0630523 0
+    outer loop
+      vertex 88.75 41 0
+      vertex 88.7599 40.8433 3
+      vertex 88.7599 40.8433 0
+    endloop
+  endfacet
+  facet normal 0.368312 -0.929702 0
+    outer loop
+      vertex 89.4678 42.131 0
+      vertex 89.6137 42.1888 3
+      vertex 89.4678 42.131 3
+    endloop
+  endfacet
+  facet normal 0.368312 -0.929702 0
+    outer loop
+      vertex 89.6137 42.1888 3
+      vertex 89.4678 42.131 0
+      vertex 89.6137 42.1888 0
+    endloop
+  endfacet
+  facet normal -0.124897 -0.99217 0
+    outer loop
+      vertex 90.0785 42.2475 0
+      vertex 90.2342 42.2279 3
+      vertex 90.0785 42.2475 3
+    endloop
+  endfacet
+  facet normal -0.124897 -0.99217 -0
+    outer loop
+      vertex 90.2342 42.2279 3
+      vertex 90.0785 42.2475 0
+      vertex 90.2342 42.2279 0
+    endloop
+  endfacet
+  facet normal -0.481527 0.876431 0
+    outer loop
+      vertex 90.6698 39.9446 0
+      vertex 90.5322 39.869 3
+      vertex 90.6698 39.9446 3
+    endloop
+  endfacet
+  facet normal -0.481527 0.876431 0
+    outer loop
+      vertex 90.5322 39.869 3
+      vertex 90.6698 39.9446 0
+      vertex 90.5322 39.869 0
+    endloop
+  endfacet
+  facet normal -0.904876 0.425674 0
+    outer loop
+      vertex 91.0954 40.3978 0
+      vertex 91.1622 40.5398 3
+      vertex 91.1622 40.5398 0
+    endloop
+  endfacet
+  facet normal -0.904876 0.425674 0
+    outer loop
+      vertex 91.1622 40.5398 3
+      vertex 91.0954 40.3978 0
+      vertex 91.0954 40.3978 3
+    endloop
+  endfacet
+  facet normal -0.368312 0.929702 0
+    outer loop
+      vertex 90.5322 39.869 0
+      vertex 90.3863 39.8112 3
+      vertex 90.5322 39.869 3
+    endloop
+  endfacet
+  facet normal -0.368312 0.929702 0
+    outer loop
+      vertex 90.3863 39.8112 3
+      vertex 90.5322 39.869 0
+      vertex 90.3863 39.8112 0
+    endloop
+  endfacet
+  facet normal 0.904876 -0.425674 0
+    outer loop
+      vertex 88.8378 41.4602 3
+      vertex 88.9046 41.6022 0
+      vertex 88.9046 41.6022 3
+    endloop
+  endfacet
+  facet normal 0.904876 -0.425674 0
+    outer loop
+      vertex 88.9046 41.6022 0
+      vertex 88.8378 41.4602 3
+      vertex 88.8378 41.4602 0
+    endloop
+  endfacet
+  facet normal -0.904876 -0.425674 0
+    outer loop
+      vertex 91.1622 41.4602 0
+      vertex 91.0954 41.6022 3
+      vertex 91.0954 41.6022 0
+    endloop
+  endfacet
+  facet normal -0.904876 -0.425674 0
+    outer loop
+      vertex 91.0954 41.6022 3
+      vertex 91.1622 41.4602 0
+      vertex 91.1622 41.4602 3
+    endloop
+  endfacet
+  facet normal 0.99801 -0.0630523 0
+    outer loop
+      vertex 88.75 41 3
+      vertex 88.7599 41.1567 0
+      vertex 88.7599 41.1567 3
+    endloop
+  endfacet
+  facet normal 0.99801 -0.0630523 0
+    outer loop
+      vertex 88.7599 41.1567 0
+      vertex 88.75 41 3
+      vertex 88.75 41 0
+    endloop
+  endfacet
+  facet normal -0.844291 -0.535886 0
+    outer loop
+      vertex 91.0954 41.6022 0
+      vertex 91.0113 41.7347 3
+      vertex 91.0113 41.7347 0
+    endloop
+  endfacet
+  facet normal -0.844291 -0.535886 0
+    outer loop
+      vertex 91.0113 41.7347 3
+      vertex 91.0954 41.6022 0
+      vertex 91.0954 41.6022 3
+    endloop
+  endfacet
+  facet normal 0.68445 0.72906 -0
+    outer loop
+      vertex 89.2032 40.0369 0
+      vertex 89.0888 40.1443 3
+      vertex 89.2032 40.0369 3
+    endloop
+  endfacet
+  facet normal 0.68445 0.72906 0
+    outer loop
+      vertex 89.0888 40.1443 3
+      vertex 89.2032 40.0369 0
+      vertex 89.0888 40.1443 0
+    endloop
+  endfacet
+  facet normal 0.844291 0.535886 0
+    outer loop
+      vertex 88.9887 40.2653 3
+      vertex 88.9046 40.3978 0
+      vertex 88.9046 40.3978 3
+    endloop
+  endfacet
+  facet normal 0.844291 0.535886 0
+    outer loop
+      vertex 88.9046 40.3978 0
+      vertex 88.9887 40.2653 3
+      vertex 88.9887 40.2653 0
+    endloop
+  endfacet
+  facet normal 0.481527 0.876431 -0
+    outer loop
+      vertex 89.4678 39.869 0
+      vertex 89.3302 39.9446 3
+      vertex 89.4678 39.869 3
+    endloop
+  endfacet
+  facet normal 0.481527 0.876431 0
+    outer loop
+      vertex 89.3302 39.9446 3
+      vertex 89.4678 39.869 0
+      vertex 89.3302 39.9446 0
+    endloop
+  endfacet
+  facet normal -0.587907 -0.808929 0
+    outer loop
+      vertex 90.6698 42.0554 0
+      vertex 90.7968 41.9631 3
+      vertex 90.6698 42.0554 3
+    endloop
+  endfacet
+  facet normal -0.587907 -0.808929 -0
+    outer loop
+      vertex 90.7968 41.9631 3
+      vertex 90.6698 42.0554 0
+      vertex 90.7968 41.9631 0
+    endloop
+  endfacet
+  facet normal -0.99801 0.0630523 0
+    outer loop
+      vertex 91.2401 40.8433 0
+      vertex 91.25 41 3
+      vertex 91.25 41 0
+    endloop
+  endfacet
+  facet normal -0.99801 0.0630523 0
+    outer loop
+      vertex 91.25 41 3
+      vertex 91.2401 40.8433 0
+      vertex 91.2401 40.8433 3
+    endloop
+  endfacet
+  facet normal 0.248973 0.96851 -0
+    outer loop
+      vertex 89.7658 39.7721 0
+      vertex 89.6137 39.8112 3
+      vertex 89.7658 39.7721 3
+    endloop
+  endfacet
+  facet normal 0.248973 0.96851 0
+    outer loop
+      vertex 89.6137 39.8112 3
+      vertex 89.7658 39.7721 0
+      vertex 89.6137 39.8112 0
+    endloop
+  endfacet
+  facet normal 0.481527 -0.876431 0
+    outer loop
+      vertex 89.3302 42.0554 0
+      vertex 89.4678 42.131 3
+      vertex 89.3302 42.0554 3
+    endloop
+  endfacet
+  facet normal 0.481527 -0.876431 0
+    outer loop
+      vertex 89.4678 42.131 3
+      vertex 89.3302 42.0554 0
+      vertex 89.4678 42.131 0
+    endloop
+  endfacet
+  facet normal -0.587907 0.808929 0
+    outer loop
+      vertex 90.7968 40.0369 0
+      vertex 90.6698 39.9446 3
+      vertex 90.7968 40.0369 3
+    endloop
+  endfacet
+  facet normal -0.587907 0.808929 0
+    outer loop
+      vertex 90.6698 39.9446 3
+      vertex 90.7968 40.0369 0
+      vertex 90.6698 39.9446 0
+    endloop
+  endfacet
+  facet normal 0.844291 -0.535886 0
+    outer loop
+      vertex 88.9046 41.6022 3
+      vertex 88.9887 41.7347 0
+      vertex 88.9887 41.7347 3
+    endloop
+  endfacet
+  facet normal 0.844291 -0.535886 0
+    outer loop
+      vertex 88.9887 41.7347 0
+      vertex 88.9046 41.6022 3
+      vertex 88.9046 41.6022 0
+    endloop
+  endfacet
+  facet normal -0.248973 -0.96851 0
+    outer loop
+      vertex 90.2342 42.2279 0
+      vertex 90.3863 42.1888 3
+      vertex 90.2342 42.2279 3
+    endloop
+  endfacet
+  facet normal -0.248973 -0.96851 -0
+    outer loop
+      vertex 90.3863 42.1888 3
+      vertex 90.2342 42.2279 0
+      vertex 90.3863 42.1888 0
+    endloop
+  endfacet
+  facet normal 0.770513 0.637424 0
+    outer loop
+      vertex 89.0888 40.1443 3
+      vertex 88.9887 40.2653 0
+      vertex 88.9887 40.2653 3
+    endloop
+  endfacet
+  facet normal 0.770513 0.637424 0
+    outer loop
+      vertex 88.9887 40.2653 0
+      vertex 89.0888 40.1443 3
+      vertex 89.0888 40.1443 0
+    endloop
+  endfacet
+  facet normal -0.368312 -0.929702 0
+    outer loop
+      vertex 90.3863 42.1888 0
+      vertex 90.5322 42.131 3
+      vertex 90.3863 42.1888 3
+    endloop
+  endfacet
+  facet normal -0.368312 -0.929702 -0
+    outer loop
+      vertex 90.5322 42.131 3
+      vertex 90.3863 42.1888 0
+      vertex 90.5322 42.131 0
+    endloop
+  endfacet
+  facet normal 0.982305 0.187288 0
+    outer loop
+      vertex 88.7893 40.6891 3
+      vertex 88.7599 40.8433 0
+      vertex 88.7599 40.8433 3
+    endloop
+  endfacet
+  facet normal 0.982305 0.187288 0
+    outer loop
+      vertex 88.7599 40.8433 0
+      vertex 88.7893 40.6891 3
+      vertex 88.7893 40.6891 0
+    endloop
+  endfacet
+  facet normal -0.481527 -0.876431 0
+    outer loop
+      vertex 90.5322 42.131 0
+      vertex 90.6698 42.0554 3
+      vertex 90.5322 42.131 3
+    endloop
+  endfacet
+  facet normal -0.481527 -0.876431 -0
+    outer loop
+      vertex 90.6698 42.0554 3
+      vertex 90.5322 42.131 0
+      vertex 90.6698 42.0554 0
+    endloop
+  endfacet
+  facet normal 0.124897 0.99217 -0
+    outer loop
+      vertex 89.9215 39.7525 0
+      vertex 89.7658 39.7721 3
+      vertex 89.9215 39.7525 3
+    endloop
+  endfacet
+  facet normal 0.124897 0.99217 0
+    outer loop
+      vertex 89.7658 39.7721 3
+      vertex 89.9215 39.7525 0
+      vertex 89.7658 39.7721 0
+    endloop
+  endfacet
+  facet normal -0.844291 0.535886 0
+    outer loop
+      vertex 91.0113 40.2653 0
+      vertex 91.0954 40.3978 3
+      vertex 91.0954 40.3978 0
+    endloop
+  endfacet
+  facet normal -0.844291 0.535886 0
+    outer loop
+      vertex 91.0954 40.3978 3
+      vertex 91.0113 40.2653 0
+      vertex 91.0113 40.2653 3
+    endloop
+  endfacet
+  facet normal -0.770513 -0.637424 0
+    outer loop
+      vertex 91.0113 41.7347 0
+      vertex 90.9112 41.8557 3
+      vertex 90.9112 41.8557 0
+    endloop
+  endfacet
+  facet normal -0.770513 -0.637424 0
+    outer loop
+      vertex 90.9112 41.8557 3
+      vertex 91.0113 41.7347 0
+      vertex 91.0113 41.7347 3
+    endloop
+  endfacet
+  facet normal -0.951076 -0.308956 0
+    outer loop
+      vertex 91.2107 41.3109 0
+      vertex 91.1622 41.4602 3
+      vertex 91.1622 41.4602 0
+    endloop
+  endfacet
+  facet normal -0.951076 -0.308956 0
+    outer loop
+      vertex 91.1622 41.4602 3
+      vertex 91.2107 41.3109 0
+      vertex 91.2107 41.3109 3
+    endloop
+  endfacet
+  facet normal 0.68445 -0.72906 0
+    outer loop
+      vertex 89.0888 41.8557 0
+      vertex 89.2032 41.9631 3
+      vertex 89.0888 41.8557 3
+    endloop
+  endfacet
+  facet normal 0.68445 -0.72906 0
+    outer loop
+      vertex 89.2032 41.9631 3
+      vertex 89.0888 41.8557 0
+      vertex 89.2032 41.9631 0
+    endloop
+  endfacet
+  facet normal 0.770513 -0.637424 0
+    outer loop
+      vertex 88.9887 41.7347 3
+      vertex 89.0888 41.8557 0
+      vertex 89.0888 41.8557 3
+    endloop
+  endfacet
+  facet normal 0.770513 -0.637424 0
+    outer loop
+      vertex 89.0888 41.8557 0
+      vertex 88.9887 41.7347 3
+      vertex 88.9887 41.7347 0
+    endloop
+  endfacet
+  facet normal 0.587907 0.808929 -0
+    outer loop
+      vertex 89.3302 39.9446 0
+      vertex 89.2032 40.0369 3
+      vertex 89.3302 39.9446 3
+    endloop
+  endfacet
+  facet normal 0.587907 0.808929 0
+    outer loop
+      vertex 89.2032 40.0369 3
+      vertex 89.3302 39.9446 0
+      vertex 89.2032 40.0369 0
+    endloop
+  endfacet
+  facet normal 0.124897 -0.99217 0
+    outer loop
+      vertex 89.7658 42.2279 0
+      vertex 89.9215 42.2475 3
+      vertex 89.7658 42.2279 3
+    endloop
+  endfacet
+  facet normal 0.124897 -0.99217 0
+    outer loop
+      vertex 89.9215 42.2475 3
+      vertex 89.7658 42.2279 0
+      vertex 89.9215 42.2475 0
+    endloop
+  endfacet
+  facet normal -0.68445 0.72906 0
+    outer loop
+      vertex 90.9112 40.1443 0
+      vertex 90.7968 40.0369 3
+      vertex 90.9112 40.1443 3
+    endloop
+  endfacet
+  facet normal -0.68445 0.72906 0
+    outer loop
+      vertex 90.7968 40.0369 3
+      vertex 90.9112 40.1443 0
+      vertex 90.7968 40.0369 0
+    endloop
+  endfacet
+  facet normal -0.770513 0.637424 0
+    outer loop
+      vertex 90.9112 40.1443 0
+      vertex 91.0113 40.2653 3
+      vertex 91.0113 40.2653 0
+    endloop
+  endfacet
+  facet normal -0.770513 0.637424 0
+    outer loop
+      vertex 91.0113 40.2653 3
+      vertex 90.9112 40.1443 0
+      vertex 90.9112 40.1443 3
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 89.9215 42.2475 0
+      vertex 90.0785 42.2475 3
+      vertex 89.9215 42.2475 3
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 90.0785 42.2475 3
+      vertex 89.9215 42.2475 0
+      vertex 90.0785 42.2475 0
+    endloop
+  endfacet
+  facet normal 0.368312 0.929702 -0
+    outer loop
+      vertex 89.6137 39.8112 0
+      vertex 89.4678 39.869 3
+      vertex 89.6137 39.8112 3
+    endloop
+  endfacet
+  facet normal 0.368312 0.929702 0
+    outer loop
+      vertex 89.4678 39.869 3
+      vertex 89.6137 39.8112 0
+      vertex 89.4678 39.869 0
+    endloop
+  endfacet
+  facet normal 0.951076 0.308956 0
+    outer loop
+      vertex 88.8378 98.5398 3
+      vertex 88.7893 98.6891 0
+      vertex 88.7893 98.6891 3
+    endloop
+  endfacet
+  facet normal 0.951076 0.308956 0
+    outer loop
+      vertex 88.7893 98.6891 0
+      vertex 88.8378 98.5398 3
+      vertex 88.8378 98.5398 0
+    endloop
+  endfacet
+  facet normal -0.982305 -0.187288 0
+    outer loop
+      vertex 91.2401 99.1567 0
+      vertex 91.2107 99.3109 3
+      vertex 91.2107 99.3109 0
+    endloop
+  endfacet
+  facet normal -0.982305 -0.187288 0
+    outer loop
+      vertex 91.2107 99.3109 3
+      vertex 91.2401 99.1567 0
+      vertex 91.2401 99.1567 3
+    endloop
+  endfacet
+  facet normal -0.99801 -0.0630523 0
+    outer loop
+      vertex 91.25 99 0
+      vertex 91.2401 99.1567 3
+      vertex 91.2401 99.1567 0
+    endloop
+  endfacet
+  facet normal -0.99801 -0.0630523 0
+    outer loop
+      vertex 91.2401 99.1567 3
+      vertex 91.25 99 0
+      vertex 91.25 99 3
+    endloop
+  endfacet
+  facet normal 0.982305 -0.187288 0
+    outer loop
+      vertex 88.7599 99.1567 3
+      vertex 88.7893 99.3109 0
+      vertex 88.7893 99.3109 3
+    endloop
+  endfacet
+  facet normal 0.982305 -0.187288 0
+    outer loop
+      vertex 88.7893 99.3109 0
+      vertex 88.7599 99.1567 3
+      vertex 88.7599 99.1567 0
+    endloop
+  endfacet
+  facet normal 0.248375 -0.968664 0
+    outer loop
+      vertex 89.6137 100.189 0
+      vertex 89.7658 100.228 3
+      vertex 89.6137 100.189 3
+    endloop
+  endfacet
+  facet normal 0.248375 -0.968664 0
+    outer loop
+      vertex 89.7658 100.228 3
+      vertex 89.6137 100.189 0
+      vertex 89.7658 100.228 0
+    endloop
+  endfacet
+  facet normal -0.68445 -0.72906 0
+    outer loop
+      vertex 90.7968 99.9631 0
+      vertex 90.9112 99.8557 3
+      vertex 90.7968 99.9631 3
+    endloop
+  endfacet
+  facet normal -0.68445 -0.72906 -0
+    outer loop
+      vertex 90.9112 99.8557 3
+      vertex 90.7968 99.9631 0
+      vertex 90.9112 99.8557 0
+    endloop
+  endfacet
+  facet normal -0.248973 0.96851 0
+    outer loop
+      vertex 90.3863 97.8112 0
+      vertex 90.2342 97.7721 3
+      vertex 90.3863 97.8112 3
+    endloop
+  endfacet
+  facet normal -0.248973 0.96851 0
+    outer loop
+      vertex 90.2342 97.7721 3
+      vertex 90.3863 97.8112 0
+      vertex 90.2342 97.7721 0
+    endloop
+  endfacet
+  facet normal 0.904876 0.425674 0
+    outer loop
+      vertex 88.9046 98.3978 3
+      vertex 88.8378 98.5398 0
+      vertex 88.8378 98.5398 3
+    endloop
+  endfacet
+  facet normal 0.904876 0.425674 0
+    outer loop
+      vertex 88.8378 98.5398 0
+      vertex 88.9046 98.3978 3
+      vertex 88.9046 98.3978 0
+    endloop
+  endfacet
+  facet normal 0.951076 -0.308956 0
+    outer loop
+      vertex 88.7893 99.3109 3
+      vertex 88.8378 99.4602 0
+      vertex 88.8378 99.4602 3
+    endloop
+  endfacet
+  facet normal 0.951076 -0.308956 0
+    outer loop
+      vertex 88.8378 99.4602 0
+      vertex 88.7893 99.3109 3
+      vertex 88.7893 99.3109 0
+    endloop
+  endfacet
+  facet normal -0.124897 0.99217 0
+    outer loop
+      vertex 90.2342 97.7721 0
+      vertex 90.0785 97.7525 3
+      vertex 90.2342 97.7721 3
+    endloop
+  endfacet
+  facet normal -0.124897 0.99217 0
+    outer loop
+      vertex 90.0785 97.7525 3
+      vertex 90.2342 97.7721 0
+      vertex 90.0785 97.7525 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 90.0785 97.7525 0
+      vertex 89.9215 97.7525 3
+      vertex 90.0785 97.7525 3
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 89.9215 97.7525 3
+      vertex 90.0785 97.7525 0
+      vertex 89.9215 97.7525 0
+    endloop
+  endfacet
+  facet normal -0.982305 0.187288 0
+    outer loop
+      vertex 91.2107 98.6891 0
+      vertex 91.2401 98.8433 3
+      vertex 91.2401 98.8433 0
+    endloop
+  endfacet
+  facet normal -0.982305 0.187288 0
+    outer loop
+      vertex 91.2401 98.8433 3
+      vertex 91.2107 98.6891 0
+      vertex 91.2107 98.6891 3
+    endloop
+  endfacet
+  facet normal 0.586236 -0.810141 0
+    outer loop
+      vertex 89.2032 99.9631 0
+      vertex 89.3302 100.055 3
+      vertex 89.2032 99.9631 3
+    endloop
+  endfacet
+  facet normal 0.586236 -0.810141 0
+    outer loop
+      vertex 89.3302 100.055 3
+      vertex 89.2032 99.9631 0
+      vertex 89.3302 100.055 0
+    endloop
+  endfacet
+  facet normal -0.951076 0.308956 0
+    outer loop
+      vertex 91.1622 98.5398 0
+      vertex 91.2107 98.6891 3
+      vertex 91.2107 98.6891 0
+    endloop
+  endfacet
+  facet normal -0.951076 0.308956 0
+    outer loop
+      vertex 91.2107 98.6891 3
+      vertex 91.1622 98.5398 0
+      vertex 91.1622 98.5398 3
+    endloop
+  endfacet
+  facet normal 0.99801 0.0630523 0
+    outer loop
+      vertex 88.7599 98.8433 3
+      vertex 88.75 99 0
+      vertex 88.75 99 3
+    endloop
+  endfacet
+  facet normal 0.99801 0.0630523 0
+    outer loop
+      vertex 88.75 99 0
+      vertex 88.7599 98.8433 3
+      vertex 88.7599 98.8433 0
+    endloop
+  endfacet
+  facet normal 0.369413 -0.929265 0
+    outer loop
+      vertex 89.4678 100.131 0
+      vertex 89.6137 100.189 3
+      vertex 89.4678 100.131 3
+    endloop
+  endfacet
+  facet normal 0.369413 -0.929265 0
+    outer loop
+      vertex 89.6137 100.189 3
+      vertex 89.4678 100.131 0
+      vertex 89.6137 100.189 0
+    endloop
+  endfacet
+  facet normal -0.127405 -0.991851 0
+    outer loop
+      vertex 90.0785 100.248 0
+      vertex 90.2342 100.228 3
+      vertex 90.0785 100.248 3
+    endloop
+  endfacet
+  facet normal -0.127405 -0.991851 -0
+    outer loop
+      vertex 90.2342 100.228 3
+      vertex 90.0785 100.248 0
+      vertex 90.2342 100.228 0
+    endloop
+  endfacet
+  facet normal -0.481527 0.876431 0
+    outer loop
+      vertex 90.6698 97.9446 0
+      vertex 90.5322 97.869 3
+      vertex 90.6698 97.9446 3
+    endloop
+  endfacet
+  facet normal -0.481527 0.876431 0
+    outer loop
+      vertex 90.5322 97.869 3
+      vertex 90.6698 97.9446 0
+      vertex 90.5322 97.869 0
+    endloop
+  endfacet
+  facet normal -0.904876 0.425674 0
+    outer loop
+      vertex 91.0954 98.3978 0
+      vertex 91.1622 98.5398 3
+      vertex 91.1622 98.5398 0
+    endloop
+  endfacet
+  facet normal -0.904876 0.425674 0
+    outer loop
+      vertex 91.1622 98.5398 3
+      vertex 91.0954 98.3978 0
+      vertex 91.0954 98.3978 3
+    endloop
+  endfacet
+  facet normal -0.368312 0.929702 0
+    outer loop
+      vertex 90.5322 97.869 0
+      vertex 90.3863 97.8112 3
+      vertex 90.5322 97.869 3
+    endloop
+  endfacet
+  facet normal -0.368312 0.929702 0
+    outer loop
+      vertex 90.3863 97.8112 3
+      vertex 90.5322 97.869 0
+      vertex 90.3863 97.8112 0
+    endloop
+  endfacet
+  facet normal 0.904876 -0.425674 0
+    outer loop
+      vertex 88.8378 99.4602 3
+      vertex 88.9046 99.6022 0
+      vertex 88.9046 99.6022 3
+    endloop
+  endfacet
+  facet normal 0.904876 -0.425674 0
+    outer loop
+      vertex 88.9046 99.6022 0
+      vertex 88.8378 99.4602 3
+      vertex 88.8378 99.4602 0
+    endloop
+  endfacet
+  facet normal -0.904876 -0.425674 0
+    outer loop
+      vertex 91.1622 99.4602 0
+      vertex 91.0954 99.6022 3
+      vertex 91.0954 99.6022 0
+    endloop
+  endfacet
+  facet normal -0.904876 -0.425674 0
+    outer loop
+      vertex 91.0954 99.6022 3
+      vertex 91.1622 99.4602 0
+      vertex 91.1622 99.4602 3
+    endloop
+  endfacet
+  facet normal 0.99801 -0.0630523 0
+    outer loop
+      vertex 88.75 99 3
+      vertex 88.7599 99.1567 0
+      vertex 88.7599 99.1567 3
+    endloop
+  endfacet
+  facet normal 0.99801 -0.0630523 0
+    outer loop
+      vertex 88.7599 99.1567 0
+      vertex 88.75 99 3
+      vertex 88.75 99 0
+    endloop
+  endfacet
+  facet normal -0.844291 -0.535886 0
+    outer loop
+      vertex 91.0954 99.6022 0
+      vertex 91.0113 99.7347 3
+      vertex 91.0113 99.7347 0
+    endloop
+  endfacet
+  facet normal -0.844291 -0.535886 0
+    outer loop
+      vertex 91.0113 99.7347 3
+      vertex 91.0954 99.6022 0
+      vertex 91.0954 99.6022 3
+    endloop
+  endfacet
+  facet normal 0.68445 0.72906 -0
+    outer loop
+      vertex 89.2032 98.0369 0
+      vertex 89.0888 98.1443 3
+      vertex 89.2032 98.0369 3
+    endloop
+  endfacet
+  facet normal 0.68445 0.72906 0
+    outer loop
+      vertex 89.0888 98.1443 3
+      vertex 89.2032 98.0369 0
+      vertex 89.0888 98.1443 0
+    endloop
+  endfacet
+  facet normal 0.844291 0.535886 0
+    outer loop
+      vertex 88.9887 98.2653 3
+      vertex 88.9046 98.3978 0
+      vertex 88.9046 98.3978 3
+    endloop
+  endfacet
+  facet normal 0.844291 0.535886 0
+    outer loop
+      vertex 88.9046 98.3978 0
+      vertex 88.9887 98.2653 3
+      vertex 88.9887 98.2653 0
+    endloop
+  endfacet
+  facet normal 0.481527 0.876431 -0
+    outer loop
+      vertex 89.4678 97.869 0
+      vertex 89.3302 97.9446 3
+      vertex 89.4678 97.869 3
+    endloop
+  endfacet
+  facet normal 0.481527 0.876431 0
+    outer loop
+      vertex 89.3302 97.9446 3
+      vertex 89.4678 97.869 0
+      vertex 89.3302 97.9446 0
+    endloop
+  endfacet
+  facet normal -0.586236 -0.810141 0
+    outer loop
+      vertex 90.6698 100.055 0
+      vertex 90.7968 99.9631 3
+      vertex 90.6698 100.055 3
+    endloop
+  endfacet
+  facet normal -0.586236 -0.810141 -0
+    outer loop
+      vertex 90.7968 99.9631 3
+      vertex 90.6698 100.055 0
+      vertex 90.7968 99.9631 0
+    endloop
+  endfacet
+  facet normal -0.99801 0.0630523 0
+    outer loop
+      vertex 91.2401 98.8433 0
+      vertex 91.25 99 3
+      vertex 91.25 99 0
+    endloop
+  endfacet
+  facet normal -0.99801 0.0630523 0
+    outer loop
+      vertex 91.25 99 3
+      vertex 91.2401 98.8433 0
+      vertex 91.2401 98.8433 3
+    endloop
+  endfacet
+  facet normal 0.248973 0.96851 -0
+    outer loop
+      vertex 89.7658 97.7721 0
+      vertex 89.6137 97.8112 3
+      vertex 89.7658 97.7721 3
+    endloop
+  endfacet
+  facet normal 0.248973 0.96851 0
+    outer loop
+      vertex 89.6137 97.8112 3
+      vertex 89.7658 97.7721 0
+      vertex 89.6137 97.8112 0
+    endloop
+  endfacet
+  facet normal 0.483481 -0.875355 0
+    outer loop
+      vertex 89.3302 100.055 0
+      vertex 89.4678 100.131 3
+      vertex 89.3302 100.055 3
+    endloop
+  endfacet
+  facet normal 0.483481 -0.875355 0
+    outer loop
+      vertex 89.4678 100.131 3
+      vertex 89.3302 100.055 0
+      vertex 89.4678 100.131 0
+    endloop
+  endfacet
+  facet normal -0.587907 0.808929 0
+    outer loop
+      vertex 90.7968 98.0369 0
+      vertex 90.6698 97.9446 3
+      vertex 90.7968 98.0369 3
+    endloop
+  endfacet
+  facet normal -0.587907 0.808929 0
+    outer loop
+      vertex 90.6698 97.9446 3
+      vertex 90.7968 98.0369 0
+      vertex 90.6698 97.9446 0
+    endloop
+  endfacet
+  facet normal 0.844291 -0.535886 0
+    outer loop
+      vertex 88.9046 99.6022 3
+      vertex 88.9887 99.7347 0
+      vertex 88.9887 99.7347 3
+    endloop
+  endfacet
+  facet normal 0.844291 -0.535886 0
+    outer loop
+      vertex 88.9887 99.7347 0
+      vertex 88.9046 99.6022 3
+      vertex 88.9046 99.6022 0
+    endloop
+  endfacet
+  facet normal -0.248375 -0.968664 0
+    outer loop
+      vertex 90.2342 100.228 0
+      vertex 90.3863 100.189 3
+      vertex 90.2342 100.228 3
+    endloop
+  endfacet
+  facet normal -0.248375 -0.968664 -0
+    outer loop
+      vertex 90.3863 100.189 3
+      vertex 90.2342 100.228 0
+      vertex 90.3863 100.189 0
+    endloop
+  endfacet
+  facet normal 0.770513 0.637424 0
+    outer loop
+      vertex 89.0888 98.1443 3
+      vertex 88.9887 98.2653 0
+      vertex 88.9887 98.2653 3
+    endloop
+  endfacet
+  facet normal 0.770513 0.637424 0
+    outer loop
+      vertex 88.9887 98.2653 0
+      vertex 89.0888 98.1443 3
+      vertex 89.0888 98.1443 0
+    endloop
+  endfacet
+  facet normal -0.369413 -0.929265 0
+    outer loop
+      vertex 90.3863 100.189 0
+      vertex 90.5322 100.131 3
+      vertex 90.3863 100.189 3
+    endloop
+  endfacet
+  facet normal -0.369413 -0.929265 -0
+    outer loop
+      vertex 90.5322 100.131 3
+      vertex 90.3863 100.189 0
+      vertex 90.5322 100.131 0
+    endloop
+  endfacet
+  facet normal 0.982305 0.187288 0
+    outer loop
+      vertex 88.7893 98.6891 3
+      vertex 88.7599 98.8433 0
+      vertex 88.7599 98.8433 3
+    endloop
+  endfacet
+  facet normal 0.982305 0.187288 0
+    outer loop
+      vertex 88.7599 98.8433 0
+      vertex 88.7893 98.6891 3
+      vertex 88.7893 98.6891 0
+    endloop
+  endfacet
+  facet normal -0.483481 -0.875355 0
+    outer loop
+      vertex 90.5322 100.131 0
+      vertex 90.6698 100.055 3
+      vertex 90.5322 100.131 3
+    endloop
+  endfacet
+  facet normal -0.483481 -0.875355 -0
+    outer loop
+      vertex 90.6698 100.055 3
+      vertex 90.5322 100.131 0
+      vertex 90.6698 100.055 0
+    endloop
+  endfacet
+  facet normal 0.124897 0.99217 -0
+    outer loop
+      vertex 89.9215 97.7525 0
+      vertex 89.7658 97.7721 3
+      vertex 89.9215 97.7525 3
+    endloop
+  endfacet
+  facet normal 0.124897 0.99217 0
+    outer loop
+      vertex 89.7658 97.7721 3
+      vertex 89.9215 97.7525 0
+      vertex 89.7658 97.7721 0
+    endloop
+  endfacet
+  facet normal -0.844291 0.535886 0
+    outer loop
+      vertex 91.0113 98.2653 0
+      vertex 91.0954 98.3978 3
+      vertex 91.0954 98.3978 0
+    endloop
+  endfacet
+  facet normal -0.844291 0.535886 0
+    outer loop
+      vertex 91.0954 98.3978 3
+      vertex 91.0113 98.2653 0
+      vertex 91.0113 98.2653 3
+    endloop
+  endfacet
+  facet normal -0.770513 -0.637424 0
+    outer loop
+      vertex 91.0113 99.7347 0
+      vertex 90.9112 99.8557 3
+      vertex 90.9112 99.8557 0
+    endloop
+  endfacet
+  facet normal -0.770513 -0.637424 0
+    outer loop
+      vertex 90.9112 99.8557 3
+      vertex 91.0113 99.7347 0
+      vertex 91.0113 99.7347 3
+    endloop
+  endfacet
+  facet normal -0.951076 -0.308956 0
+    outer loop
+      vertex 91.2107 99.3109 0
+      vertex 91.1622 99.4602 3
+      vertex 91.1622 99.4602 0
+    endloop
+  endfacet
+  facet normal -0.951076 -0.308956 0
+    outer loop
+      vertex 91.1622 99.4602 3
+      vertex 91.2107 99.3109 0
+      vertex 91.2107 99.3109 3
+    endloop
+  endfacet
+  facet normal 0.68445 -0.72906 0
+    outer loop
+      vertex 89.0888 99.8557 0
+      vertex 89.2032 99.9631 3
+      vertex 89.0888 99.8557 3
+    endloop
+  endfacet
+  facet normal 0.68445 -0.72906 0
+    outer loop
+      vertex 89.2032 99.9631 3
+      vertex 89.0888 99.8557 0
+      vertex 89.2032 99.9631 0
+    endloop
+  endfacet
+  facet normal 0.770513 -0.637424 0
+    outer loop
+      vertex 88.9887 99.7347 3
+      vertex 89.0888 99.8557 0
+      vertex 89.0888 99.8557 3
+    endloop
+  endfacet
+  facet normal 0.770513 -0.637424 0
+    outer loop
+      vertex 89.0888 99.8557 0
+      vertex 88.9887 99.7347 3
+      vertex 88.9887 99.7347 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 89.9215 100.248 0
+      vertex 90.0785 100.248 3
+      vertex 89.9215 100.248 3
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 90.0785 100.248 3
+      vertex 89.9215 100.248 0
+      vertex 90.0785 100.248 0
+    endloop
+  endfacet
+  facet normal 0.587907 0.808929 -0
+    outer loop
+      vertex 89.3302 97.9446 0
+      vertex 89.2032 98.0369 3
+      vertex 89.3302 97.9446 3
+    endloop
+  endfacet
+  facet normal 0.587907 0.808929 0
+    outer loop
+      vertex 89.2032 98.0369 3
+      vertex 89.3302 97.9446 0
+      vertex 89.2032 98.0369 0
+    endloop
+  endfacet
+  facet normal 0.127405 -0.991851 0
+    outer loop
+      vertex 89.7658 100.228 0
+      vertex 89.9215 100.248 3
+      vertex 89.7658 100.228 3
+    endloop
+  endfacet
+  facet normal 0.127405 -0.991851 0
+    outer loop
+      vertex 89.9215 100.248 3
+      vertex 89.7658 100.228 0
+      vertex 89.9215 100.248 0
+    endloop
+  endfacet
+  facet normal -0.68445 0.72906 0
+    outer loop
+      vertex 90.9112 98.1443 0
+      vertex 90.7968 98.0369 3
+      vertex 90.9112 98.1443 3
+    endloop
+  endfacet
+  facet normal -0.68445 0.72906 0
+    outer loop
+      vertex 90.7968 98.0369 3
+      vertex 90.9112 98.1443 0
+      vertex 90.7968 98.0369 0
+    endloop
+  endfacet
+  facet normal -0.770513 0.637424 0
+    outer loop
+      vertex 90.9112 98.1443 0
+      vertex 91.0113 98.2653 3
+      vertex 91.0113 98.2653 0
+    endloop
+  endfacet
+  facet normal -0.770513 0.637424 0
+    outer loop
+      vertex 91.0113 98.2653 3
+      vertex 90.9112 98.1443 0
+      vertex 90.9112 98.1443 3
+    endloop
+  endfacet
+  facet normal 0.368312 0.929702 -0
+    outer loop
+      vertex 89.6137 97.8112 0
+      vertex 89.4678 97.869 3
+      vertex 89.6137 97.8112 3
+    endloop
+  endfacet
+  facet normal 0.368312 0.929702 0
+    outer loop
+      vertex 89.4678 97.869 3
+      vertex 89.6137 97.8112 0
+      vertex 89.4678 97.869 0
+    endloop
+  endfacet
+  facet normal -0.982333 -0.187141 0
+    outer loop
+      vertex 71.9842 6.25067 0
+      vertex 71.9372 6.49738 25.9013
+      vertex 71.9372 6.49738 0
+    endloop
+  endfacet
+  facet normal -0.982333 -0.187141 0
+    outer loop
+      vertex 71.9372 6.49738 25.9013
+      vertex 71.9842 6.25067 0
+      vertex 71.9842 6.25067 25.911
+    endloop
+  endfacet
+  facet normal -0.998019 -0.0629062 0
+    outer loop
+      vertex 72 6 0
+      vertex 71.9842 6.25067 25.911
+      vertex 71.9842 6.25067 0
+    endloop
+  endfacet
+  facet normal -0.998019 -0.0629062 0
+    outer loop
+      vertex 71.9842 6.25067 25.911
+      vertex 72 6 0
+      vertex 72 6 25.9143
+    endloop
+  endfacet
+  facet normal -0.844287 -0.535891 0
+    outer loop
+      vertex 71.7526 6.96351 0
+      vertex 71.618 7.17557 25.8352
+      vertex 71.618 7.17557 0
+    endloop
+  endfacet
+  facet normal -0.844287 -0.535891 0
+    outer loop
+      vertex 71.618 7.17557 25.8352
+      vertex 71.7526 6.96351 0
+      vertex 71.7526 6.96351 25.863
+    endloop
+  endfacet
+  facet normal -0.684542 -0.728973 0
+    outer loop
+      vertex 71.4579 7.36909 0
+      vertex 71.2748 7.54103 25.7641
+      vertex 71.2748 7.54103 0
+    endloop
+  endfacet
+  facet normal -0.684542 -0.728973 0
+    outer loop
+      vertex 71.2748 7.54103 25.7641
+      vertex 71.4579 7.36909 0
+      vertex 71.4579 7.36909 25.802
+    endloop
+  endfacet
+  facet normal 0.248753 -0.968567 0
+    outer loop
+      vertex 69.6252 7.96457 0
+      vertex 69.382 7.90211 25.372
+      vertex 69.382 7.90211 0
+    endloop
+  endfacet
+  facet normal 0.248753 -0.968567 0
+    outer loop
+      vertex 69.382 7.90211 25.372
+      vertex 69.6252 7.96457 0
+      vertex 69.6252 7.96457 25.4224
+    endloop
+  endfacet
+  facet normal 0.770501 0.637439 -0
+    outer loop
+      vertex 68.5421 4.63091 0
+      vertex 68.382 4.82443 25.1648
+      vertex 68.5421 4.63091 25.198
+    endloop
+  endfacet
+  facet normal 0.770501 0.637439 0
+    outer loop
+      vertex 68.382 4.82443 25.1648
+      vertex 68.5421 4.63091 0
+      vertex 68.382 4.82443 0
+    endloop
+  endfacet
+  facet normal -0.904736 0.425973 0
+    outer loop
+      vertex 71.7526 5.03649 25.863
+      vertex 71.8596 5.26375 0
+      vertex 71.7526 5.03649 0
+    endloop
+  endfacet
+  facet normal -0.904736 0.425973 0
+    outer loop
+      vertex 71.8596 5.26375 0
+      vertex 71.7526 5.03649 25.863
+      vertex 71.8596 5.26375 25.8852
+    endloop
+  endfacet
+  facet normal -0.48172 -0.876325 0
+    outer loop
+      vertex 71.0717 7.68866 0
+      vertex 70.8516 7.80965 25.6764
+      vertex 70.8516 7.80965 0
+    endloop
+  endfacet
+  facet normal -0.48172 -0.876325 0
+    outer loop
+      vertex 70.8516 7.80965 25.6764
+      vertex 71.0717 7.68866 0
+      vertex 71.0717 7.68866 25.722
+    endloop
+  endfacet
+  facet normal -0.248753 0.968567 0
+    outer loop
+      vertex 70.618 4.09789 0
+      vertex 70.3748 4.03543 25.5776
+      vertex 70.618 4.09789 25.628
+    endloop
+  endfacet
+  facet normal -0.248753 0.968567 0
+    outer loop
+      vertex 70.3748 4.03543 25.5776
+      vertex 70.618 4.09789 0
+      vertex 70.3748 4.03543 0
+    endloop
+  endfacet
+  facet normal 0.951072 -0.308968 0
+    outer loop
+      vertex 68.0628 6.49738 25.0987
+      vertex 68.1404 6.73625 0
+      vertex 68.1404 6.73625 25.1148
+    endloop
+  endfacet
+  facet normal 0.951072 -0.308968 0
+    outer loop
+      vertex 68.1404 6.73625 0
+      vertex 68.0628 6.49738 25.0987
+      vertex 68.0628 6.49738 0
+    endloop
+  endfacet
+  facet normal 0.125328 -0.992115 0
+    outer loop
+      vertex 69.8744 7.99605 0
+      vertex 69.6252 7.96457 25.4224
+      vertex 69.6252 7.96457 0
+    endloop
+  endfacet
+  facet normal 0.125328 -0.992115 0
+    outer loop
+      vertex 69.6252 7.96457 25.4224
+      vertex 69.8744 7.99605 0
+      vertex 69.8744 7.99605 25.474
+    endloop
+  endfacet
+  facet normal 0.48172 -0.876325 0
+    outer loop
+      vertex 69.1484 7.80965 0
+      vertex 68.9283 7.68866 25.278
+      vertex 68.9283 7.68866 0
+    endloop
+  endfacet
+  facet normal 0.48172 -0.876325 0
+    outer loop
+      vertex 68.9283 7.68866 25.278
+      vertex 69.1484 7.80965 0
+      vertex 69.1484 7.80965 25.3236
+    endloop
+  endfacet
+  facet normal 0.998019 -0.0629062 0
+    outer loop
+      vertex 68 6 25.0857
+      vertex 68.0158 6.25067 0
+      vertex 68.0158 6.25067 25.089
+    endloop
+  endfacet
+  facet normal 0.998019 -0.0629062 0
+    outer loop
+      vertex 68.0158 6.25067 0
+      vertex 68 6 25.0857
+      vertex 68 6 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 70.1256 7.99605 0
+      vertex 69.8744 7.99605 25.474
+      vertex 69.8744 7.99605 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 69.8744 7.99605 25.474
+      vertex 70.1256 7.99605 0
+      vertex 70.1256 7.99605 25.526
+    endloop
+  endfacet
+  facet normal -0.844287 0.535891 0
+    outer loop
+      vertex 71.618 4.82443 25.8352
+      vertex 71.7526 5.03649 0
+      vertex 71.618 4.82443 0
+    endloop
+  endfacet
+  facet normal -0.844287 0.535891 0
+    outer loop
+      vertex 71.7526 5.03649 0
+      vertex 71.618 4.82443 25.8352
+      vertex 71.7526 5.03649 25.863
+    endloop
+  endfacet
+  facet normal 0.844287 -0.535891 0
+    outer loop
+      vertex 68.2474 6.96351 25.137
+      vertex 68.382 7.17557 0
+      vertex 68.382 7.17557 25.1648
+    endloop
+  endfacet
+  facet normal 0.844287 -0.535891 0
+    outer loop
+      vertex 68.382 7.17557 0
+      vertex 68.2474 6.96351 25.137
+      vertex 68.2474 6.96351 0
+    endloop
+  endfacet
+  facet normal -0.684542 0.728973 0
+    outer loop
+      vertex 71.4579 4.63091 0
+      vertex 71.2748 4.45897 25.7641
+      vertex 71.4579 4.63091 25.802
+    endloop
+  endfacet
+  facet normal -0.684542 0.728973 0
+    outer loop
+      vertex 71.2748 4.45897 25.7641
+      vertex 71.4579 4.63091 0
+      vertex 71.2748 4.45897 0
+    endloop
+  endfacet
+  facet normal 0.982333 0.187141 -0
+    outer loop
+      vertex 68.0628 5.50262 0
+      vertex 68.0158 5.74933 25.089
+      vertex 68.0628 5.50262 25.0987
+    endloop
+  endfacet
+  facet normal 0.982333 0.187141 0
+    outer loop
+      vertex 68.0158 5.74933 25.089
+      vertex 68.0628 5.50262 0
+      vertex 68.0158 5.74933 0
+    endloop
+  endfacet
+  facet normal 0.248753 0.968567 -0
+    outer loop
+      vertex 69.6252 4.03543 0
+      vertex 69.382 4.09789 25.372
+      vertex 69.6252 4.03543 25.4224
+    endloop
+  endfacet
+  facet normal 0.248753 0.968567 0
+    outer loop
+      vertex 69.382 4.09789 25.372
+      vertex 69.6252 4.03543 0
+      vertex 69.382 4.09789 0
+    endloop
+  endfacet
+  facet normal 0.904736 0.425973 -0
+    outer loop
+      vertex 68.2474 5.03649 0
+      vertex 68.1404 5.26375 25.1148
+      vertex 68.2474 5.03649 25.137
+    endloop
+  endfacet
+  facet normal 0.904736 0.425973 0
+    outer loop
+      vertex 68.1404 5.26375 25.1148
+      vertex 68.2474 5.03649 0
+      vertex 68.1404 5.26375 0
+    endloop
+  endfacet
+  facet normal -0.125328 0.992115 0
+    outer loop
+      vertex 70.3748 4.03543 0
+      vertex 70.1256 4.00395 25.526
+      vertex 70.3748 4.03543 25.5776
+    endloop
+  endfacet
+  facet normal -0.125328 0.992115 0
+    outer loop
+      vertex 70.1256 4.00395 25.526
+      vertex 70.3748 4.03543 0
+      vertex 70.1256 4.00395 0
+    endloop
+  endfacet
+  facet normal 0.684542 -0.728973 0
+    outer loop
+      vertex 68.7252 7.54103 0
+      vertex 68.5421 7.36909 25.198
+      vertex 68.5421 7.36909 0
+    endloop
+  endfacet
+  facet normal 0.684542 -0.728973 0
+    outer loop
+      vertex 68.5421 7.36909 25.198
+      vertex 68.7252 7.54103 0
+      vertex 68.7252 7.54103 25.2359
+    endloop
+  endfacet
+  facet normal 0.844287 0.535891 -0
+    outer loop
+      vertex 68.382 4.82443 0
+      vertex 68.2474 5.03649 25.137
+      vertex 68.382 4.82443 25.1648
+    endloop
+  endfacet
+  facet normal 0.844287 0.535891 0
+    outer loop
+      vertex 68.2474 5.03649 25.137
+      vertex 68.382 4.82443 0
+      vertex 68.2474 5.03649 0
+    endloop
+  endfacet
+  facet normal -0.904736 -0.425973 0
+    outer loop
+      vertex 71.8596 6.73625 0
+      vertex 71.7526 6.96351 25.863
+      vertex 71.7526 6.96351 0
+    endloop
+  endfacet
+  facet normal -0.904736 -0.425973 0
+    outer loop
+      vertex 71.7526 6.96351 25.863
+      vertex 71.8596 6.73625 0
+      vertex 71.8596 6.73625 25.8852
+    endloop
+  endfacet
+  facet normal 0.770501 -0.637439 0
+    outer loop
+      vertex 68.382 7.17557 25.1648
+      vertex 68.5421 7.36909 0
+      vertex 68.5421 7.36909 25.198
+    endloop
+  endfacet
+  facet normal 0.770501 -0.637439 0
+    outer loop
+      vertex 68.5421 7.36909 0
+      vertex 68.382 7.17557 25.1648
+      vertex 68.382 7.17557 0
+    endloop
+  endfacet
+  facet normal -0.587966 -0.808886 0
+    outer loop
+      vertex 71.2748 7.54103 0
+      vertex 71.0717 7.68866 25.722
+      vertex 71.0717 7.68866 0
+    endloop
+  endfacet
+  facet normal -0.587966 -0.808886 0
+    outer loop
+      vertex 71.0717 7.68866 25.722
+      vertex 71.2748 7.54103 0
+      vertex 71.2748 7.54103 25.7641
+    endloop
+  endfacet
+  facet normal -0.481751 0.876308 0
+    outer loop
+      vertex 71.0717 4.31135 0
+      vertex 70.8516 4.19035 25.6764
+      vertex 71.0717 4.31135 25.722
+    endloop
+  endfacet
+  facet normal -0.481751 0.876308 0
+    outer loop
+      vertex 70.8516 4.19035 25.6764
+      vertex 71.0717 4.31135 0
+      vertex 70.8516 4.19035 0
+    endloop
+  endfacet
+  facet normal 0.368026 -0.929816 0
+    outer loop
+      vertex 69.382 7.90211 0
+      vertex 69.1484 7.80965 25.3236
+      vertex 69.1484 7.80965 0
+    endloop
+  endfacet
+  facet normal 0.368026 -0.929816 0
+    outer loop
+      vertex 69.1484 7.80965 25.3236
+      vertex 69.382 7.90211 0
+      vertex 69.382 7.90211 25.372
+    endloop
+  endfacet
+  facet normal -0.982333 0.187141 0
+    outer loop
+      vertex 71.9372 5.50262 25.9013
+      vertex 71.9842 5.74933 0
+      vertex 71.9372 5.50262 0
+    endloop
+  endfacet
+  facet normal -0.982333 0.187141 0
+    outer loop
+      vertex 71.9842 5.74933 0
+      vertex 71.9372 5.50262 25.9013
+      vertex 71.9842 5.74933 25.911
+    endloop
+  endfacet
+  facet normal -0.998019 0.0629062 0
+    outer loop
+      vertex 71.9842 5.74933 25.911
+      vertex 72 6 0
+      vertex 71.9842 5.74933 0
+    endloop
+  endfacet
+  facet normal -0.998019 0.0629062 0
+    outer loop
+      vertex 72 6 0
+      vertex 71.9842 5.74933 25.911
+      vertex 72 6 25.9143
+    endloop
+  endfacet
+  facet normal 0.951072 0.308968 -0
+    outer loop
+      vertex 68.1404 5.26375 0
+      vertex 68.0628 5.50262 25.0987
+      vertex 68.1404 5.26375 25.1148
+    endloop
+  endfacet
+  facet normal 0.951072 0.308968 0
+    outer loop
+      vertex 68.0628 5.50262 25.0987
+      vertex 68.1404 5.26375 0
+      vertex 68.0628 5.50262 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 70.1256 4.00395 0
+      vertex 69.8744 4.00395 25.474
+      vertex 70.1256 4.00395 25.526
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 69.8744 4.00395 25.474
+      vertex 70.1256 4.00395 0
+      vertex 69.8744 4.00395 0
+    endloop
+  endfacet
+  facet normal -0.951072 -0.308968 0
+    outer loop
+      vertex 71.9372 6.49738 0
+      vertex 71.8596 6.73625 25.8852
+      vertex 71.8596 6.73625 0
+    endloop
+  endfacet
+  facet normal -0.951072 -0.308968 0
+    outer loop
+      vertex 71.8596 6.73625 25.8852
+      vertex 71.9372 6.49738 0
+      vertex 71.9372 6.49738 25.9013
+    endloop
+  endfacet
+  facet normal -0.368026 0.929816 0
+    outer loop
+      vertex 70.8516 4.19035 0
+      vertex 70.618 4.09789 25.628
+      vertex 70.8516 4.19035 25.6764
+    endloop
+  endfacet
+  facet normal -0.368026 0.929816 0
+    outer loop
+      vertex 70.618 4.09789 25.628
+      vertex 70.8516 4.19035 0
+      vertex 70.618 4.09789 0
+    endloop
+  endfacet
+  facet normal 0.587966 -0.808886 0
+    outer loop
+      vertex 68.9283 7.68866 0
+      vertex 68.7252 7.54103 25.2359
+      vertex 68.7252 7.54103 0
+    endloop
+  endfacet
+  facet normal 0.587966 -0.808886 0
+    outer loop
+      vertex 68.7252 7.54103 25.2359
+      vertex 68.9283 7.68866 0
+      vertex 68.9283 7.68866 25.278
+    endloop
+  endfacet
+  facet normal -0.951072 0.308968 0
+    outer loop
+      vertex 71.8596 5.26375 25.8852
+      vertex 71.9372 5.50262 0
+      vertex 71.8596 5.26375 0
+    endloop
+  endfacet
+  facet normal -0.951072 0.308968 0
+    outer loop
+      vertex 71.9372 5.50262 0
+      vertex 71.8596 5.26375 25.8852
+      vertex 71.9372 5.50262 25.9013
+    endloop
+  endfacet
+  facet normal 0.982333 -0.187141 0
+    outer loop
+      vertex 68.0158 6.25067 25.089
+      vertex 68.0628 6.49738 0
+      vertex 68.0628 6.49738 25.0987
+    endloop
+  endfacet
+  facet normal 0.982333 -0.187141 0
+    outer loop
+      vertex 68.0628 6.49738 0
+      vertex 68.0158 6.25067 25.089
+      vertex 68.0158 6.25067 0
+    endloop
+  endfacet
+  facet normal -0.368026 -0.929816 0
+    outer loop
+      vertex 70.8516 7.80965 0
+      vertex 70.618 7.90211 25.628
+      vertex 70.618 7.90211 0
+    endloop
+  endfacet
+  facet normal -0.368026 -0.929816 0
+    outer loop
+      vertex 70.618 7.90211 25.628
+      vertex 70.8516 7.80965 0
+      vertex 70.8516 7.80965 25.6764
+    endloop
+  endfacet
+  facet normal -0.770501 -0.637439 0
+    outer loop
+      vertex 71.618 7.17557 0
+      vertex 71.4579 7.36909 25.802
+      vertex 71.4579 7.36909 0
+    endloop
+  endfacet
+  facet normal -0.770501 -0.637439 0
+    outer loop
+      vertex 71.4579 7.36909 25.802
+      vertex 71.618 7.17557 0
+      vertex 71.618 7.17557 25.8352
+    endloop
+  endfacet
+  facet normal 0.368026 0.929816 -0
+    outer loop
+      vertex 69.382 4.09789 0
+      vertex 69.1484 4.19035 25.3236
+      vertex 69.382 4.09789 25.372
+    endloop
+  endfacet
+  facet normal 0.368026 0.929816 0
+    outer loop
+      vertex 69.1484 4.19035 25.3236
+      vertex 69.382 4.09789 0
+      vertex 69.1484 4.19035 0
+    endloop
+  endfacet
+  facet normal -0.770501 0.637439 0
+    outer loop
+      vertex 71.4579 4.63091 25.802
+      vertex 71.618 4.82443 0
+      vertex 71.4579 4.63091 0
+    endloop
+  endfacet
+  facet normal -0.770501 0.637439 0
+    outer loop
+      vertex 71.618 4.82443 0
+      vertex 71.4579 4.63091 25.802
+      vertex 71.618 4.82443 25.8352
+    endloop
+  endfacet
+  facet normal 0.58794 0.808905 -0
+    outer loop
+      vertex 68.9283 4.31135 0
+      vertex 68.7252 4.45897 25.2359
+      vertex 68.9283 4.31135 25.278
+    endloop
+  endfacet
+  facet normal 0.58794 0.808905 0
+    outer loop
+      vertex 68.7252 4.45897 25.2359
+      vertex 68.9283 4.31135 0
+      vertex 68.7252 4.45897 0
+    endloop
+  endfacet
+  facet normal -0.125328 -0.992115 0
+    outer loop
+      vertex 70.3748 7.96457 0
+      vertex 70.1256 7.99605 25.526
+      vertex 70.1256 7.99605 0
+    endloop
+  endfacet
+  facet normal -0.125328 -0.992115 0
+    outer loop
+      vertex 70.1256 7.99605 25.526
+      vertex 70.3748 7.96457 0
+      vertex 70.3748 7.96457 25.5776
+    endloop
+  endfacet
+  facet normal 0.684542 0.728973 -0
+    outer loop
+      vertex 68.7252 4.45897 0
+      vertex 68.5421 4.63091 25.198
+      vertex 68.7252 4.45897 25.2359
+    endloop
+  endfacet
+  facet normal 0.684542 0.728973 0
+    outer loop
+      vertex 68.5421 4.63091 25.198
+      vertex 68.7252 4.45897 0
+      vertex 68.5421 4.63091 0
+    endloop
+  endfacet
+  facet normal 0.998019 0.0629062 -0
+    outer loop
+      vertex 68.0158 5.74933 0
+      vertex 68 6 25.0857
+      vertex 68.0158 5.74933 25.089
+    endloop
+  endfacet
+  facet normal 0.998019 0.0629062 0
+    outer loop
+      vertex 68 6 25.0857
+      vertex 68.0158 5.74933 0
+      vertex 68 6 0
+    endloop
+  endfacet
+  facet normal 0.904736 -0.425973 0
+    outer loop
+      vertex 68.1404 6.73625 25.1148
+      vertex 68.2474 6.96351 0
+      vertex 68.2474 6.96351 25.137
+    endloop
+  endfacet
+  facet normal 0.904736 -0.425973 0
+    outer loop
+      vertex 68.2474 6.96351 0
+      vertex 68.1404 6.73625 25.1148
+      vertex 68.1404 6.73625 0
+    endloop
+  endfacet
+  facet normal 0.125328 0.992115 -0
+    outer loop
+      vertex 69.8744 4.00395 0
+      vertex 69.6252 4.03543 25.4224
+      vertex 69.8744 4.00395 25.474
+    endloop
+  endfacet
+  facet normal 0.125328 0.992115 0
+    outer loop
+      vertex 69.6252 4.03543 25.4224
+      vertex 69.8744 4.00395 0
+      vertex 69.6252 4.03543 0
+    endloop
+  endfacet
+  facet normal -0.58794 0.808905 0
+    outer loop
+      vertex 71.2748 4.45897 0
+      vertex 71.0717 4.31135 25.722
+      vertex 71.2748 4.45897 25.7641
+    endloop
+  endfacet
+  facet normal -0.58794 0.808905 0
+    outer loop
+      vertex 71.0717 4.31135 25.722
+      vertex 71.2748 4.45897 0
+      vertex 71.0717 4.31135 0
+    endloop
+  endfacet
+  facet normal 0.481751 0.876308 -0
+    outer loop
+      vertex 69.1484 4.19035 0
+      vertex 68.9283 4.31135 25.278
+      vertex 69.1484 4.19035 25.3236
+    endloop
+  endfacet
+  facet normal 0.481751 0.876308 0
+    outer loop
+      vertex 68.9283 4.31135 25.278
+      vertex 69.1484 4.19035 0
+      vertex 68.9283 4.31135 0
+    endloop
+  endfacet
+  facet normal -0.248753 -0.968567 0
+    outer loop
+      vertex 70.618 7.90211 0
+      vertex 70.3748 7.96457 25.5776
+      vertex 70.3748 7.96457 0
+    endloop
+  endfacet
+  facet normal -0.248753 -0.968567 0
+    outer loop
+      vertex 70.3748 7.96457 25.5776
+      vertex 70.618 7.90211 0
+      vertex 70.618 7.90211 25.628
+    endloop
+  endfacet
+  facet normal 0.588929 0.808185 -0
+    outer loop
+      vertex 68.9283 132.311 0
+      vertex 68.7252 132.459 25.2359
+      vertex 68.9283 132.311 25.278
+    endloop
+  endfacet
+  facet normal 0.588929 0.808185 0
+    outer loop
+      vertex 68.7252 132.459 25.2359
+      vertex 68.9283 132.311 0
+      vertex 68.7252 132.459 0
+    endloop
+  endfacet
+  facet normal -0.982234 -0.187663 0
+    outer loop
+      vertex 71.9842 134.251 0
+      vertex 71.9372 134.497 25.9013
+      vertex 71.9372 134.497 0
+    endloop
+  endfacet
+  facet normal -0.982234 -0.187663 0
+    outer loop
+      vertex 71.9372 134.497 25.9013
+      vertex 71.9842 134.251 0
+      vertex 71.9842 134.251 25.911
+    endloop
+  endfacet
+  facet normal -0.998025 -0.0628239 0
+    outer loop
+      vertex 72 134 0
+      vertex 71.9842 134.251 25.911
+      vertex 71.9842 134.251 0
+    endloop
+  endfacet
+  facet normal -0.998025 -0.0628239 0
+    outer loop
+      vertex 71.9842 134.251 25.911
+      vertex 72 134 0
+      vertex 72 134 25.9143
+    endloop
+  endfacet
+  facet normal -0.481751 0.876308 0
+    outer loop
+      vertex 71.0717 132.311 0
+      vertex 70.8516 132.19 25.6764
+      vertex 71.0717 132.311 25.722
+    endloop
+  endfacet
+  facet normal -0.481751 0.876308 0
+    outer loop
+      vertex 70.8516 132.19 25.6764
+      vertex 71.0717 132.311 0
+      vertex 70.8516 132.19 0
+    endloop
+  endfacet
+  facet normal 0.481751 -0.876308 0
+    outer loop
+      vertex 69.1484 135.81 0
+      vertex 68.9283 135.689 25.278
+      vertex 68.9283 135.689 0
+    endloop
+  endfacet
+  facet normal 0.481751 -0.876308 0
+    outer loop
+      vertex 68.9283 135.689 25.278
+      vertex 69.1484 135.81 0
+      vertex 69.1484 135.81 25.3236
+    endloop
+  endfacet
+  facet normal -0.684669 -0.728854 0
+    outer loop
+      vertex 71.4579 135.369 0
+      vertex 71.2748 135.541 25.7641
+      vertex 71.2748 135.541 0
+    endloop
+  endfacet
+  facet normal -0.684669 -0.728854 0
+    outer loop
+      vertex 71.2748 135.541 25.7641
+      vertex 71.4579 135.369 0
+      vertex 71.4579 135.369 25.802
+    endloop
+  endfacet
+  facet normal 0.905268 -0.424841 0
+    outer loop
+      vertex 68.1404 134.736 25.1148
+      vertex 68.2474 134.964 0
+      vertex 68.2474 134.964 25.137
+    endloop
+  endfacet
+  facet normal 0.905268 -0.424841 0
+    outer loop
+      vertex 68.2474 134.964 0
+      vertex 68.1404 134.736 25.1148
+      vertex 68.1404 134.736 0
+    endloop
+  endfacet
+  facet normal -0.684669 0.728854 0
+    outer loop
+      vertex 71.4579 132.631 0
+      vertex 71.2748 132.459 25.7641
+      vertex 71.4579 132.631 25.802
+    endloop
+  endfacet
+  facet normal -0.684669 0.728854 0
+    outer loop
+      vertex 71.2748 132.459 25.7641
+      vertex 71.4579 132.631 0
+      vertex 71.2748 132.459 0
+    endloop
+  endfacet
+  facet normal -0.951122 0.308816 0
+    outer loop
+      vertex 71.8596 133.264 25.8852
+      vertex 71.9372 133.503 0
+      vertex 71.8596 133.264 0
+    endloop
+  endfacet
+  facet normal -0.951122 0.308816 0
+    outer loop
+      vertex 71.9372 133.503 0
+      vertex 71.8596 133.264 25.8852
+      vertex 71.9372 133.503 25.9013
+    endloop
+  endfacet
+  facet normal -0.123447 -0.992351 0
+    outer loop
+      vertex 70.3748 135.965 0
+      vertex 70.1256 135.996 25.526
+      vertex 70.1256 135.996 0
+    endloop
+  endfacet
+  facet normal -0.123447 -0.992351 0
+    outer loop
+      vertex 70.1256 135.996 25.526
+      vertex 70.3748 135.965 0
+      vertex 70.3748 135.965 25.5776
+    endloop
+  endfacet
+  facet normal 0.769658 0.638457 -0
+    outer loop
+      vertex 68.5421 132.631 0
+      vertex 68.382 132.824 25.1648
+      vertex 68.5421 132.631 25.198
+    endloop
+  endfacet
+  facet normal 0.769658 0.638457 0
+    outer loop
+      vertex 68.382 132.824 25.1648
+      vertex 68.5421 132.631 0
+      vertex 68.382 132.824 0
+    endloop
+  endfacet
+  facet normal 0.684669 -0.728854 0
+    outer loop
+      vertex 68.7252 135.541 0
+      vertex 68.5421 135.369 25.198
+      vertex 68.5421 135.369 0
+    endloop
+  endfacet
+  facet normal 0.684669 -0.728854 0
+    outer loop
+      vertex 68.5421 135.369 25.198
+      vertex 68.7252 135.541 0
+      vertex 68.7252 135.541 25.2359
+    endloop
+  endfacet
+  facet normal -0.588929 0.808185 0
+    outer loop
+      vertex 71.2748 132.459 0
+      vertex 71.0717 132.311 25.722
+      vertex 71.2748 132.459 25.7641
+    endloop
+  endfacet
+  facet normal -0.588929 0.808185 0
+    outer loop
+      vertex 71.0717 132.311 25.722
+      vertex 71.2748 132.459 0
+      vertex 71.0717 132.311 0
+    endloop
+  endfacet
+  facet normal -0.844219 0.535999 0
+    outer loop
+      vertex 71.618 132.824 25.8352
+      vertex 71.7526 133.036 0
+      vertex 71.618 132.824 0
+    endloop
+  endfacet
+  facet normal -0.844219 0.535999 0
+    outer loop
+      vertex 71.7526 133.036 0
+      vertex 71.618 132.824 25.8352
+      vertex 71.7526 133.036 25.863
+    endloop
+  endfacet
+  facet normal 0.998025 0.0628239 -0
+    outer loop
+      vertex 68.0158 133.749 0
+      vertex 68 134 25.0857
+      vertex 68.0158 133.749 25.089
+    endloop
+  endfacet
+  facet normal 0.998025 0.0628239 0
+    outer loop
+      vertex 68 134 25.0857
+      vertex 68.0158 133.749 0
+      vertex 68 134 0
+    endloop
+  endfacet
+  facet normal -0.844219 -0.535999 0
+    outer loop
+      vertex 71.7526 134.964 0
+      vertex 71.618 135.176 25.8352
+      vertex 71.618 135.176 0
+    endloop
+  endfacet
+  facet normal -0.844219 -0.535999 0
+    outer loop
+      vertex 71.618 135.176 25.8352
+      vertex 71.7526 134.964 0
+      vertex 71.7526 134.964 25.863
+    endloop
+  endfacet
+  facet normal 0.769658 -0.638457 0
+    outer loop
+      vertex 68.382 135.176 25.1648
+      vertex 68.5421 135.369 0
+      vertex 68.5421 135.369 25.198
+    endloop
+  endfacet
+  facet normal 0.769658 -0.638457 0
+    outer loop
+      vertex 68.5421 135.369 0
+      vertex 68.382 135.176 25.1648
+      vertex 68.382 135.176 0
+    endloop
+  endfacet
+  facet normal -0.905268 0.424841 0
+    outer loop
+      vertex 71.7526 133.036 25.863
+      vertex 71.8596 133.264 0
+      vertex 71.7526 133.036 0
+    endloop
+  endfacet
+  facet normal -0.905268 0.424841 0
+    outer loop
+      vertex 71.8596 133.264 0
+      vertex 71.7526 133.036 25.863
+      vertex 71.8596 133.264 25.8852
+    endloop
+  endfacet
+  facet normal -0.982234 0.187663 0
+    outer loop
+      vertex 71.9372 133.503 25.9013
+      vertex 71.9842 133.749 0
+      vertex 71.9372 133.503 0
+    endloop
+  endfacet
+  facet normal -0.982234 0.187663 0
+    outer loop
+      vertex 71.9842 133.749 0
+      vertex 71.9372 133.503 25.9013
+      vertex 71.9842 133.749 25.911
+    endloop
+  endfacet
+  facet normal -0.123447 0.992351 0
+    outer loop
+      vertex 70.3748 132.035 0
+      vertex 70.1256 132.004 25.526
+      vertex 70.3748 132.035 25.5776
+    endloop
+  endfacet
+  facet normal -0.123447 0.992351 0
+    outer loop
+      vertex 70.1256 132.004 25.526
+      vertex 70.3748 132.035 0
+      vertex 70.1256 132.004 0
+    endloop
+  endfacet
+  facet normal -0.588929 -0.808185 0
+    outer loop
+      vertex 71.2748 135.541 0
+      vertex 71.0717 135.689 25.722
+      vertex 71.0717 135.689 0
+    endloop
+  endfacet
+  facet normal -0.588929 -0.808185 0
+    outer loop
+      vertex 71.0717 135.689 25.722
+      vertex 71.2748 135.541 0
+      vertex 71.2748 135.541 25.7641
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 70.1256 132.004 0
+      vertex 69.8744 132.004 25.474
+      vertex 70.1256 132.004 25.526
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 69.8744 132.004 25.474
+      vertex 70.1256 132.004 0
+      vertex 69.8744 132.004 0
+    endloop
+  endfacet
+  facet normal 0.905268 0.424841 -0
+    outer loop
+      vertex 68.2474 133.036 0
+      vertex 68.1404 133.264 25.1148
+      vertex 68.2474 133.036 25.137
+    endloop
+  endfacet
+  facet normal 0.905268 0.424841 0
+    outer loop
+      vertex 68.1404 133.264 25.1148
+      vertex 68.2474 133.036 0
+      vertex 68.1404 133.264 0
+    endloop
+  endfacet
+  facet normal -0.481751 -0.876308 0
+    outer loop
+      vertex 71.0717 135.689 0
+      vertex 70.8516 135.81 25.6764
+      vertex 70.8516 135.81 0
+    endloop
+  endfacet
+  facet normal -0.481751 -0.876308 0
+    outer loop
+      vertex 70.8516 135.81 25.6764
+      vertex 71.0717 135.689 0
+      vertex 71.0717 135.689 25.722
+    endloop
+  endfacet
+  facet normal 0.250769 -0.968047 0
+    outer loop
+      vertex 69.6252 135.965 0
+      vertex 69.382 135.902 25.372
+      vertex 69.382 135.902 0
+    endloop
+  endfacet
+  facet normal 0.250769 -0.968047 0
+    outer loop
+      vertex 69.382 135.902 25.372
+      vertex 69.6252 135.965 0
+      vertex 69.6252 135.965 25.4224
+    endloop
+  endfacet
+  facet normal -0.998025 0.0628239 0
+    outer loop
+      vertex 71.9842 133.749 25.911
+      vertex 72 134 0
+      vertex 71.9842 133.749 0
+    endloop
+  endfacet
+  facet normal -0.998025 0.0628239 0
+    outer loop
+      vertex 72 134 0
+      vertex 71.9842 133.749 25.911
+      vertex 72 134 25.9143
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 70.1256 135.996 0
+      vertex 69.8744 135.996 25.474
+      vertex 69.8744 135.996 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 69.8744 135.996 25.474
+      vertex 70.1256 135.996 0
+      vertex 70.1256 135.996 25.526
+    endloop
+  endfacet
+  facet normal -0.905268 -0.424841 0
+    outer loop
+      vertex 71.8596 134.736 0
+      vertex 71.7526 134.964 25.863
+      vertex 71.7526 134.964 0
+    endloop
+  endfacet
+  facet normal -0.905268 -0.424841 0
+    outer loop
+      vertex 71.7526 134.964 25.863
+      vertex 71.8596 134.736 0
+      vertex 71.8596 134.736 25.8852
+    endloop
+  endfacet
+  facet normal 0.123447 0.992351 -0
+    outer loop
+      vertex 69.8744 132.004 0
+      vertex 69.6252 132.035 25.4224
+      vertex 69.8744 132.004 25.474
+    endloop
+  endfacet
+  facet normal 0.123447 0.992351 0
+    outer loop
+      vertex 69.6252 132.035 25.4224
+      vertex 69.8744 132.004 0
+      vertex 69.6252 132.035 0
+    endloop
+  endfacet
+  facet normal -0.366441 -0.930441 0
+    outer loop
+      vertex 70.8516 135.81 0
+      vertex 70.618 135.902 25.628
+      vertex 70.618 135.902 0
+    endloop
+  endfacet
+  facet normal -0.366441 -0.930441 0
+    outer loop
+      vertex 70.618 135.902 25.628
+      vertex 70.8516 135.81 0
+      vertex 70.8516 135.81 25.6764
+    endloop
+  endfacet
+  facet normal 0.366441 0.930441 -0
+    outer loop
+      vertex 69.382 132.098 0
+      vertex 69.1484 132.19 25.3236
+      vertex 69.382 132.098 25.372
+    endloop
+  endfacet
+  facet normal 0.366441 0.930441 0
+    outer loop
+      vertex 69.1484 132.19 25.3236
+      vertex 69.382 132.098 0
+      vertex 69.1484 132.19 0
+    endloop
+  endfacet
+  facet normal 0.250769 0.968047 -0
+    outer loop
+      vertex 69.6252 132.035 0
+      vertex 69.382 132.098 25.372
+      vertex 69.6252 132.035 25.4224
+    endloop
+  endfacet
+  facet normal 0.250769 0.968047 0
+    outer loop
+      vertex 69.382 132.098 25.372
+      vertex 69.6252 132.035 0
+      vertex 69.382 132.098 0
+    endloop
+  endfacet
+  facet normal -0.250769 0.968047 0
+    outer loop
+      vertex 70.618 132.098 0
+      vertex 70.3748 132.035 25.5776
+      vertex 70.618 132.098 25.628
+    endloop
+  endfacet
+  facet normal -0.250769 0.968047 0
+    outer loop
+      vertex 70.3748 132.035 25.5776
+      vertex 70.618 132.098 0
+      vertex 70.3748 132.035 0
+    endloop
+  endfacet
+  facet normal 0.844219 -0.535999 0
+    outer loop
+      vertex 68.2474 134.964 25.137
+      vertex 68.382 135.176 0
+      vertex 68.382 135.176 25.1648
+    endloop
+  endfacet
+  facet normal 0.844219 -0.535999 0
+    outer loop
+      vertex 68.382 135.176 0
+      vertex 68.2474 134.964 25.137
+      vertex 68.2474 134.964 0
+    endloop
+  endfacet
+  facet normal 0.684669 0.728854 -0
+    outer loop
+      vertex 68.7252 132.459 0
+      vertex 68.5421 132.631 25.198
+      vertex 68.7252 132.459 25.2359
+    endloop
+  endfacet
+  facet normal 0.684669 0.728854 0
+    outer loop
+      vertex 68.5421 132.631 25.198
+      vertex 68.7252 132.459 0
+      vertex 68.5421 132.631 0
+    endloop
+  endfacet
+  facet normal -0.366441 0.930441 0
+    outer loop
+      vertex 70.8516 132.19 0
+      vertex 70.618 132.098 25.628
+      vertex 70.8516 132.19 25.6764
+    endloop
+  endfacet
+  facet normal -0.366441 0.930441 0
+    outer loop
+      vertex 70.618 132.098 25.628
+      vertex 70.8516 132.19 0
+      vertex 70.618 132.098 0
+    endloop
+  endfacet
+  facet normal 0.982234 0.187663 -0
+    outer loop
+      vertex 68.0628 133.503 0
+      vertex 68.0158 133.749 25.089
+      vertex 68.0628 133.503 25.0987
+    endloop
+  endfacet
+  facet normal 0.982234 0.187663 0
+    outer loop
+      vertex 68.0158 133.749 25.089
+      vertex 68.0628 133.503 0
+      vertex 68.0158 133.749 0
+    endloop
+  endfacet
+  facet normal 0.844219 0.535999 -0
+    outer loop
+      vertex 68.382 132.824 0
+      vertex 68.2474 133.036 25.137
+      vertex 68.382 132.824 25.1648
+    endloop
+  endfacet
+  facet normal 0.844219 0.535999 0
+    outer loop
+      vertex 68.2474 133.036 25.137
+      vertex 68.382 132.824 0
+      vertex 68.2474 133.036 0
+    endloop
+  endfacet
+  facet normal -0.769658 -0.638457 0
+    outer loop
+      vertex 71.618 135.176 0
+      vertex 71.4579 135.369 25.802
+      vertex 71.4579 135.369 0
+    endloop
+  endfacet
+  facet normal -0.769658 -0.638457 0
+    outer loop
+      vertex 71.4579 135.369 25.802
+      vertex 71.618 135.176 0
+      vertex 71.618 135.176 25.8352
+    endloop
+  endfacet
+  facet normal -0.250769 -0.968047 0
+    outer loop
+      vertex 70.618 135.902 0
+      vertex 70.3748 135.965 25.5776
+      vertex 70.3748 135.965 0
+    endloop
+  endfacet
+  facet normal -0.250769 -0.968047 0
+    outer loop
+      vertex 70.3748 135.965 25.5776
+      vertex 70.618 135.902 0
+      vertex 70.618 135.902 25.628
+    endloop
+  endfacet
+  facet normal -0.951122 -0.308816 0
+    outer loop
+      vertex 71.9372 134.497 0
+      vertex 71.8596 134.736 25.8852
+      vertex 71.8596 134.736 0
+    endloop
+  endfacet
+  facet normal -0.951122 -0.308816 0
+    outer loop
+      vertex 71.8596 134.736 25.8852
+      vertex 71.9372 134.497 0
+      vertex 71.9372 134.497 25.9013
+    endloop
+  endfacet
+  facet normal 0.481751 0.876308 -0
+    outer loop
+      vertex 69.1484 132.19 0
+      vertex 68.9283 132.311 25.278
+      vertex 69.1484 132.19 25.3236
+    endloop
+  endfacet
+  facet normal 0.481751 0.876308 0
+    outer loop
+      vertex 68.9283 132.311 25.278
+      vertex 69.1484 132.19 0
+      vertex 68.9283 132.311 0
+    endloop
+  endfacet
+  facet normal -0.769658 0.638457 0
+    outer loop
+      vertex 71.4579 132.631 25.802
+      vertex 71.618 132.824 0
+      vertex 71.4579 132.631 0
+    endloop
+  endfacet
+  facet normal -0.769658 0.638457 0
+    outer loop
+      vertex 71.618 132.824 0
+      vertex 71.4579 132.631 25.802
+      vertex 71.618 132.824 25.8352
+    endloop
+  endfacet
+  facet normal 0.366441 -0.930441 0
+    outer loop
+      vertex 69.382 135.902 0
+      vertex 69.1484 135.81 25.3236
+      vertex 69.1484 135.81 0
+    endloop
+  endfacet
+  facet normal 0.366441 -0.930441 0
+    outer loop
+      vertex 69.1484 135.81 25.3236
+      vertex 69.382 135.902 0
+      vertex 69.382 135.902 25.372
+    endloop
+  endfacet
+  facet normal 0.588929 -0.808185 0
+    outer loop
+      vertex 68.9283 135.689 0
+      vertex 68.7252 135.541 25.2359
+      vertex 68.7252 135.541 0
+    endloop
+  endfacet
+  facet normal 0.588929 -0.808185 0
+    outer loop
+      vertex 68.7252 135.541 25.2359
+      vertex 68.9283 135.689 0
+      vertex 68.9283 135.689 25.278
+    endloop
+  endfacet
+  facet normal 0.951122 0.308816 -0
+    outer loop
+      vertex 68.1404 133.264 0
+      vertex 68.0628 133.503 25.0987
+      vertex 68.1404 133.264 25.1148
+    endloop
+  endfacet
+  facet normal 0.951122 0.308816 0
+    outer loop
+      vertex 68.0628 133.503 25.0987
+      vertex 68.1404 133.264 0
+      vertex 68.0628 133.503 0
+    endloop
+  endfacet
+  facet normal 0.123447 -0.992351 0
+    outer loop
+      vertex 69.8744 135.996 0
+      vertex 69.6252 135.965 25.4224
+      vertex 69.6252 135.965 0
+    endloop
+  endfacet
+  facet normal 0.123447 -0.992351 0
+    outer loop
+      vertex 69.6252 135.965 25.4224
+      vertex 69.8744 135.996 0
+      vertex 69.8744 135.996 25.474
+    endloop
+  endfacet
+  facet normal 0.982234 -0.187663 0
+    outer loop
+      vertex 68.0158 134.251 25.089
+      vertex 68.0628 134.497 0
+      vertex 68.0628 134.497 25.0987
+    endloop
+  endfacet
+  facet normal 0.982234 -0.187663 0
+    outer loop
+      vertex 68.0628 134.497 0
+      vertex 68.0158 134.251 25.089
+      vertex 68.0158 134.251 0
+    endloop
+  endfacet
+  facet normal 0.998025 -0.0628239 0
+    outer loop
+      vertex 68 134 25.0857
+      vertex 68.0158 134.251 0
+      vertex 68.0158 134.251 25.089
+    endloop
+  endfacet
+  facet normal 0.998025 -0.0628239 0
+    outer loop
+      vertex 68.0158 134.251 0
+      vertex 68 134 25.0857
+      vertex 68 134 0
+    endloop
+  endfacet
+  facet normal 0.951122 -0.308816 0
+    outer loop
+      vertex 68.0628 134.497 25.0987
+      vertex 68.1404 134.736 0
+      vertex 68.1404 134.736 25.1148
+    endloop
+  endfacet
+  facet normal 0.951122 -0.308816 0
+    outer loop
+      vertex 68.1404 134.736 0
+      vertex 68.0628 134.497 25.0987
+      vertex 68.0628 134.497 0
+    endloop
+  endfacet
+  facet normal -0.58795 0.808897 0
+    outer loop
+      vertex 75.4908 85.9842 3
+      vertex 75.2521 85.8107 7.5
+      vertex 75.4908 85.9842 7.5
+    endloop
+  endfacet
+  facet normal -0.58795 0.808897 0
+    outer loop
+      vertex 75.2521 85.8107 7.5
+      vertex 75.4908 85.9842 3
+      vertex 75.2521 85.8107 3
+    endloop
+  endfacet
+  facet normal 0.982288 0.187377 0
+    outer loop
+      vertex 79.0815 84.2945 7.5
+      vertex 79.0262 84.5844 3
+      vertex 79.0262 84.5844 7.5
+    endloop
+  endfacet
+  facet normal 0.982288 0.187377 0
+    outer loop
+      vertex 79.0262 84.5844 3
+      vertex 79.0815 84.2945 7.5
+      vertex 79.0815 84.2945 3
+    endloop
+  endfacet
+  facet normal 0.998033 0.0626948 0
+    outer loop
+      vertex 79.1 84 7.5
+      vertex 79.0815 84.2945 3
+      vertex 79.0815 84.2945 7.5
+    endloop
+  endfacet
+  facet normal 0.998033 0.0626948 0
+    outer loop
+      vertex 79.0815 84.2945 3
+      vertex 79.1 84 7.5
+      vertex 79.1 84 3
+    endloop
+  endfacet
+  facet normal 0.951061 0.309002 0
+    outer loop
+      vertex 79.0262 84.5844 7.5
+      vertex 78.935 84.8651 3
+      vertex 78.935 84.8651 7.5
+    endloop
+  endfacet
+  facet normal 0.951061 0.309002 0
+    outer loop
+      vertex 78.935 84.8651 3
+      vertex 79.0262 84.5844 7.5
+      vertex 79.0262 84.5844 3
+    endloop
+  endfacet
+  facet normal 0.951061 -0.309002 0
+    outer loop
+      vertex 78.935 83.1349 7.5
+      vertex 79.0262 83.4156 3
+      vertex 79.0262 83.4156 7.5
+    endloop
+  endfacet
+  facet normal 0.951061 -0.309002 0
+    outer loop
+      vertex 79.0262 83.4156 3
+      vertex 78.935 83.1349 7.5
+      vertex 78.935 83.1349 3
+    endloop
+  endfacet
+  facet normal 0.8444 0.535713 0
+    outer loop
+      vertex 78.8093 85.1321 7.5
+      vertex 78.6512 85.3813 3
+      vertex 78.6512 85.3813 7.5
+    endloop
+  endfacet
+  facet normal 0.8444 0.535713 0
+    outer loop
+      vertex 78.6512 85.3813 3
+      vertex 78.8093 85.1321 7.5
+      vertex 78.8093 85.1321 3
+    endloop
+  endfacet
+  facet normal 0.48158 -0.876402 0
+    outer loop
+      vertex 77.7506 81.8737 3
+      vertex 78.0092 82.0158 7.5
+      vertex 77.7506 81.8737 7.5
+    endloop
+  endfacet
+  facet normal 0.48158 -0.876402 0
+    outer loop
+      vertex 78.0092 82.0158 7.5
+      vertex 77.7506 81.8737 3
+      vertex 78.0092 82.0158 3
+    endloop
+  endfacet
+  facet normal 0.248669 -0.968589 0
+    outer loop
+      vertex 77.1903 81.6916 3
+      vertex 77.4762 81.765 7.5
+      vertex 77.1903 81.6916 7.5
+    endloop
+  endfacet
+  facet normal 0.248669 -0.968589 0
+    outer loop
+      vertex 77.4762 81.765 7.5
+      vertex 77.1903 81.6916 3
+      vertex 77.4762 81.765 3
+    endloop
+  endfacet
+  facet normal 0.684392 0.729114 -0
+    outer loop
+      vertex 78.4631 85.6087 3
+      vertex 78.2479 85.8107 7.5
+      vertex 78.4631 85.6087 7.5
+    endloop
+  endfacet
+  facet normal 0.684392 0.729114 0
+    outer loop
+      vertex 78.2479 85.8107 7.5
+      vertex 78.4631 85.6087 3
+      vertex 78.2479 85.8107 3
+    endloop
+  endfacet
+  facet normal 0.90475 0.425944 0
+    outer loop
+      vertex 78.935 84.8651 7.5
+      vertex 78.8093 85.1321 3
+      vertex 78.8093 85.1321 7.5
+    endloop
+  endfacet
+  facet normal 0.90475 0.425944 0
+    outer loop
+      vertex 78.8093 85.1321 3
+      vertex 78.935 84.8651 7.5
+      vertex 78.935 84.8651 3
+    endloop
+  endfacet
+  facet normal 0.8444 -0.535713 0
+    outer loop
+      vertex 78.6512 82.6187 7.5
+      vertex 78.8093 82.8679 3
+      vertex 78.8093 82.8679 7.5
+    endloop
+  endfacet
+  facet normal 0.8444 -0.535713 0
+    outer loop
+      vertex 78.8093 82.8679 3
+      vertex 78.6512 82.6187 7.5
+      vertex 78.6512 82.6187 3
+    endloop
+  endfacet
+  facet normal -0.982288 -0.187377 0
+    outer loop
+      vertex 74.4738 83.4156 3
+      vertex 74.4185 83.7055 7.5
+      vertex 74.4185 83.7055 3
+    endloop
+  endfacet
+  facet normal -0.982288 -0.187377 0
+    outer loop
+      vertex 74.4185 83.7055 7.5
+      vertex 74.4738 83.4156 3
+      vertex 74.4738 83.4156 7.5
+    endloop
+  endfacet
+  facet normal 0.90475 -0.425944 0
+    outer loop
+      vertex 78.8093 82.8679 7.5
+      vertex 78.935 83.1349 3
+      vertex 78.935 83.1349 7.5
+    endloop
+  endfacet
+  facet normal 0.90475 -0.425944 0
+    outer loop
+      vertex 78.935 83.1349 3
+      vertex 78.8093 82.8679 7.5
+      vertex 78.8093 82.8679 3
+    endloop
+  endfacet
+  facet normal -0.48158 0.876402 0
+    outer loop
+      vertex 75.7494 86.1263 3
+      vertex 75.4908 85.9842 7.5
+      vertex 75.7494 86.1263 7.5
+    endloop
+  endfacet
+  facet normal -0.48158 0.876402 0
+    outer loop
+      vertex 75.4908 85.9842 7.5
+      vertex 75.7494 86.1263 3
+      vertex 75.4908 85.9842 3
+    endloop
+  endfacet
+  facet normal 0.770549 0.63738 0
+    outer loop
+      vertex 78.6512 85.3813 7.5
+      vertex 78.4631 85.6087 3
+      vertex 78.4631 85.6087 7.5
+    endloop
+  endfacet
+  facet normal 0.770549 0.63738 0
+    outer loop
+      vertex 78.4631 85.6087 3
+      vertex 78.6512 85.3813 7.5
+      vertex 78.6512 85.3813 3
+    endloop
+  endfacet
+  facet normal -0.48158 -0.876402 0
+    outer loop
+      vertex 75.4908 82.0158 3
+      vertex 75.7494 81.8737 7.5
+      vertex 75.4908 82.0158 7.5
+    endloop
+  endfacet
+  facet normal -0.48158 -0.876402 -0
+    outer loop
+      vertex 75.7494 81.8737 7.5
+      vertex 75.4908 82.0158 3
+      vertex 75.7494 81.8737 3
+    endloop
+  endfacet
+  facet normal -0.90475 -0.425944 0
+    outer loop
+      vertex 74.6907 82.8679 3
+      vertex 74.565 83.1349 7.5
+      vertex 74.565 83.1349 3
+    endloop
+  endfacet
+  facet normal -0.90475 -0.425944 0
+    outer loop
+      vertex 74.565 83.1349 7.5
+      vertex 74.6907 82.8679 3
+      vertex 74.6907 82.8679 7.5
+    endloop
+  endfacet
+  facet normal 0.368293 -0.92971 0
+    outer loop
+      vertex 77.4762 81.765 3
+      vertex 77.7506 81.8737 7.5
+      vertex 77.4762 81.765 7.5
+    endloop
+  endfacet
+  facet normal 0.368293 -0.92971 0
+    outer loop
+      vertex 77.7506 81.8737 7.5
+      vertex 77.4762 81.765 3
+      vertex 77.7506 81.8737 3
+    endloop
+  endfacet
+  facet normal -0.770549 0.63738 0
+    outer loop
+      vertex 74.8488 85.3813 3
+      vertex 75.0369 85.6087 7.5
+      vertex 75.0369 85.6087 3
+    endloop
+  endfacet
+  facet normal -0.770549 0.63738 0
+    outer loop
+      vertex 75.0369 85.6087 7.5
+      vertex 74.8488 85.3813 3
+      vertex 74.8488 85.3813 7.5
+    endloop
+  endfacet
+  facet normal 0.125411 -0.992105 0
+    outer loop
+      vertex 76.8976 81.6546 3
+      vertex 77.1903 81.6916 7.5
+      vertex 76.8976 81.6546 7.5
+    endloop
+  endfacet
+  facet normal 0.125411 -0.992105 0
+    outer loop
+      vertex 77.1903 81.6916 7.5
+      vertex 76.8976 81.6546 3
+      vertex 77.1903 81.6916 3
+    endloop
+  endfacet
+  facet normal -0.951061 -0.309002 0
+    outer loop
+      vertex 74.565 83.1349 3
+      vertex 74.4738 83.4156 7.5
+      vertex 74.4738 83.4156 3
+    endloop
+  endfacet
+  facet normal -0.951061 -0.309002 0
+    outer loop
+      vertex 74.4738 83.4156 7.5
+      vertex 74.565 83.1349 3
+      vertex 74.565 83.1349 7.5
+    endloop
+  endfacet
+  facet normal -0.982288 0.187377 0
+    outer loop
+      vertex 74.4185 84.2945 3
+      vertex 74.4738 84.5844 7.5
+      vertex 74.4738 84.5844 3
+    endloop
+  endfacet
+  facet normal -0.982288 0.187377 0
+    outer loop
+      vertex 74.4738 84.5844 7.5
+      vertex 74.4185 84.2945 3
+      vertex 74.4185 84.2945 7.5
+    endloop
+  endfacet
+  facet normal 0.368293 0.92971 -0
+    outer loop
+      vertex 77.7506 86.1263 3
+      vertex 77.4762 86.235 7.5
+      vertex 77.7506 86.1263 7.5
+    endloop
+  endfacet
+  facet normal 0.368293 0.92971 0
+    outer loop
+      vertex 77.4762 86.235 7.5
+      vertex 77.7506 86.1263 3
+      vertex 77.4762 86.235 3
+    endloop
+  endfacet
+  facet normal 0.998033 -0.0626948 0
+    outer loop
+      vertex 79.0815 83.7055 7.5
+      vertex 79.1 84 3
+      vertex 79.1 84 7.5
+    endloop
+  endfacet
+  facet normal 0.998033 -0.0626948 0
+    outer loop
+      vertex 79.1 84 3
+      vertex 79.0815 83.7055 7.5
+      vertex 79.0815 83.7055 3
+    endloop
+  endfacet
+  facet normal -0.684392 -0.729114 0
+    outer loop
+      vertex 75.0369 82.3913 3
+      vertex 75.2521 82.1893 7.5
+      vertex 75.0369 82.3913 7.5
+    endloop
+  endfacet
+  facet normal -0.684392 -0.729114 -0
+    outer loop
+      vertex 75.2521 82.1893 7.5
+      vertex 75.0369 82.3913 3
+      vertex 75.2521 82.1893 3
+    endloop
+  endfacet
+  facet normal -0.998033 -0.0626948 0
+    outer loop
+      vertex 74.4185 83.7055 3
+      vertex 74.4 84 7.5
+      vertex 74.4 84 3
+    endloop
+  endfacet
+  facet normal -0.998033 -0.0626948 0
+    outer loop
+      vertex 74.4 84 7.5
+      vertex 74.4185 83.7055 3
+      vertex 74.4185 83.7055 7.5
+    endloop
+  endfacet
+  facet normal 0.58795 -0.808897 0
+    outer loop
+      vertex 78.0092 82.0158 3
+      vertex 78.2479 82.1893 7.5
+      vertex 78.0092 82.0158 7.5
+    endloop
+  endfacet
+  facet normal 0.58795 -0.808897 0
+    outer loop
+      vertex 78.2479 82.1893 7.5
+      vertex 78.0092 82.0158 3
+      vertex 78.2479 82.1893 3
+    endloop
+  endfacet
+  facet normal -0.125411 -0.992105 0
+    outer loop
+      vertex 76.3097 81.6916 3
+      vertex 76.6024 81.6546 7.5
+      vertex 76.3097 81.6916 7.5
+    endloop
+  endfacet
+  facet normal -0.125411 -0.992105 -0
+    outer loop
+      vertex 76.6024 81.6546 7.5
+      vertex 76.3097 81.6916 3
+      vertex 76.6024 81.6546 3
+    endloop
+  endfacet
+  facet normal -0.368293 0.92971 0
+    outer loop
+      vertex 76.0238 86.235 3
+      vertex 75.7494 86.1263 7.5
+      vertex 76.0238 86.235 7.5
+    endloop
+  endfacet
+  facet normal -0.368293 0.92971 0
+    outer loop
+      vertex 75.7494 86.1263 7.5
+      vertex 76.0238 86.235 3
+      vertex 75.7494 86.1263 3
+    endloop
+  endfacet
+  facet normal 0.684392 -0.729114 0
+    outer loop
+      vertex 78.2479 82.1893 3
+      vertex 78.4631 82.3913 7.5
+      vertex 78.2479 82.1893 7.5
+    endloop
+  endfacet
+  facet normal 0.684392 -0.729114 0
+    outer loop
+      vertex 78.4631 82.3913 7.5
+      vertex 78.2479 82.1893 3
+      vertex 78.4631 82.3913 3
+    endloop
+  endfacet
+  facet normal 0.58795 0.808897 -0
+    outer loop
+      vertex 78.2479 85.8107 3
+      vertex 78.0092 85.9842 7.5
+      vertex 78.2479 85.8107 7.5
+    endloop
+  endfacet
+  facet normal 0.58795 0.808897 0
+    outer loop
+      vertex 78.0092 85.9842 7.5
+      vertex 78.2479 85.8107 3
+      vertex 78.0092 85.9842 3
+    endloop
+  endfacet
+  facet normal 0.770549 -0.63738 0
+    outer loop
+      vertex 78.4631 82.3913 7.5
+      vertex 78.6512 82.6187 3
+      vertex 78.6512 82.6187 7.5
+    endloop
+  endfacet
+  facet normal 0.770549 -0.63738 0
+    outer loop
+      vertex 78.6512 82.6187 3
+      vertex 78.4631 82.3913 7.5
+      vertex 78.4631 82.3913 3
+    endloop
+  endfacet
+  facet normal 0.48158 0.876402 -0
+    outer loop
+      vertex 78.0092 85.9842 3
+      vertex 77.7506 86.1263 7.5
+      vertex 78.0092 85.9842 7.5
+    endloop
+  endfacet
+  facet normal 0.48158 0.876402 0
+    outer loop
+      vertex 77.7506 86.1263 7.5
+      vertex 78.0092 85.9842 3
+      vertex 77.7506 86.1263 3
+    endloop
+  endfacet
+  facet normal -0.684392 0.729114 0
+    outer loop
+      vertex 75.2521 85.8107 3
+      vertex 75.0369 85.6087 7.5
+      vertex 75.2521 85.8107 7.5
+    endloop
+  endfacet
+  facet normal -0.684392 0.729114 0
+    outer loop
+      vertex 75.0369 85.6087 7.5
+      vertex 75.2521 85.8107 3
+      vertex 75.0369 85.6087 3
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 76.6024 81.6546 3
+      vertex 76.8976 81.6546 7.5
+      vertex 76.6024 81.6546 7.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 76.8976 81.6546 7.5
+      vertex 76.6024 81.6546 3
+      vertex 76.8976 81.6546 3
+    endloop
+  endfacet
+  facet normal -0.951061 0.309002 0
+    outer loop
+      vertex 74.4738 84.5844 3
+      vertex 74.565 84.8651 7.5
+      vertex 74.565 84.8651 3
+    endloop
+  endfacet
+  facet normal -0.951061 0.309002 0
+    outer loop
+      vertex 74.565 84.8651 7.5
+      vertex 74.4738 84.5844 3
+      vertex 74.4738 84.5844 7.5
+    endloop
+  endfacet
+  facet normal -0.90475 0.425944 0
+    outer loop
+      vertex 74.565 84.8651 3
+      vertex 74.6907 85.1321 7.5
+      vertex 74.6907 85.1321 3
+    endloop
+  endfacet
+  facet normal -0.90475 0.425944 0
+    outer loop
+      vertex 74.6907 85.1321 7.5
+      vertex 74.565 84.8651 3
+      vertex 74.565 84.8651 7.5
+    endloop
+  endfacet
+  facet normal -0.8444 -0.535713 0
+    outer loop
+      vertex 74.8488 82.6187 3
+      vertex 74.6907 82.8679 7.5
+      vertex 74.6907 82.8679 3
+    endloop
+  endfacet
+  facet normal -0.8444 -0.535713 0
+    outer loop
+      vertex 74.6907 82.8679 7.5
+      vertex 74.8488 82.6187 3
+      vertex 74.8488 82.6187 7.5
+    endloop
+  endfacet
+  facet normal 0.125411 0.992105 -0
+    outer loop
+      vertex 77.1903 86.3084 3
+      vertex 76.8976 86.3454 7.5
+      vertex 77.1903 86.3084 7.5
+    endloop
+  endfacet
+  facet normal 0.125411 0.992105 0
+    outer loop
+      vertex 76.8976 86.3454 7.5
+      vertex 77.1903 86.3084 3
+      vertex 76.8976 86.3454 3
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 76.8976 86.3454 3
+      vertex 76.6024 86.3454 7.5
+      vertex 76.8976 86.3454 7.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 76.6024 86.3454 7.5
+      vertex 76.8976 86.3454 3
+      vertex 76.6024 86.3454 3
+    endloop
+  endfacet
+  facet normal -0.368293 -0.92971 0
+    outer loop
+      vertex 75.7494 81.8737 3
+      vertex 76.0238 81.765 7.5
+      vertex 75.7494 81.8737 7.5
+    endloop
+  endfacet
+  facet normal -0.368293 -0.92971 -0
+    outer loop
+      vertex 76.0238 81.765 7.5
+      vertex 75.7494 81.8737 3
+      vertex 76.0238 81.765 3
+    endloop
+  endfacet
+  facet normal -0.248669 -0.968589 0
+    outer loop
+      vertex 76.0238 81.765 3
+      vertex 76.3097 81.6916 7.5
+      vertex 76.0238 81.765 7.5
+    endloop
+  endfacet
+  facet normal -0.248669 -0.968589 -0
+    outer loop
+      vertex 76.3097 81.6916 7.5
+      vertex 76.0238 81.765 3
+      vertex 76.3097 81.6916 3
+    endloop
+  endfacet
+  facet normal -0.58795 -0.808897 0
+    outer loop
+      vertex 75.2521 82.1893 3
+      vertex 75.4908 82.0158 7.5
+      vertex 75.2521 82.1893 7.5
+    endloop
+  endfacet
+  facet normal -0.58795 -0.808897 -0
+    outer loop
+      vertex 75.4908 82.0158 7.5
+      vertex 75.2521 82.1893 3
+      vertex 75.4908 82.0158 3
+    endloop
+  endfacet
+  facet normal -0.248669 0.968589 0
+    outer loop
+      vertex 76.3097 86.3084 3
+      vertex 76.0238 86.235 7.5
+      vertex 76.3097 86.3084 7.5
+    endloop
+  endfacet
+  facet normal -0.248669 0.968589 0
+    outer loop
+      vertex 76.0238 86.235 7.5
+      vertex 76.3097 86.3084 3
+      vertex 76.0238 86.235 3
+    endloop
+  endfacet
+  facet normal -0.8444 0.535713 0
+    outer loop
+      vertex 74.6907 85.1321 3
+      vertex 74.8488 85.3813 7.5
+      vertex 74.8488 85.3813 3
+    endloop
+  endfacet
+  facet normal -0.8444 0.535713 0
+    outer loop
+      vertex 74.8488 85.3813 7.5
+      vertex 74.6907 85.1321 3
+      vertex 74.6907 85.1321 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78 84 7.5
+      vertex 79.1 84 7.5
+      vertex 79.0815 84.2945 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.9901 84.1567 7.5
+      vertex 79.0815 84.2945 7.5
+      vertex 79.0262 84.5844 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.1 84 7.5
+      vertex 78 84 7.5
+      vertex 79.0815 83.7055 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.9607 84.3109 7.5
+      vertex 79.0262 84.5844 7.5
+      vertex 78.935 84.8651 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 77.9901 83.8433 7.5
+      vertex 79.0815 83.7055 7.5
+      vertex 78 84 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.9122 84.4602 7.5
+      vertex 78.935 84.8651 7.5
+      vertex 78.8093 85.1321 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.0815 83.7055 7.5
+      vertex 77.9901 83.8433 7.5
+      vertex 79.0262 83.4156 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.8454 84.6022 7.5
+      vertex 78.8093 85.1321 7.5
+      vertex 78.6512 85.3813 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 77.9607 83.6891 7.5
+      vertex 79.0262 83.4156 7.5
+      vertex 77.9901 83.8433 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.7613 84.7347 7.5
+      vertex 78.6512 85.3813 7.5
+      vertex 78.4631 85.6087 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.0262 83.4156 7.5
+      vertex 77.9607 83.6891 7.5
+      vertex 78.935 83.1349 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.6612 84.8557 7.5
+      vertex 78.4631 85.6087 7.5
+      vertex 78.2479 85.8107 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 77.9122 83.5398 7.5
+      vertex 78.935 83.1349 7.5
+      vertex 77.9607 83.6891 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.5468 84.9631 7.5
+      vertex 78.2479 85.8107 7.5
+      vertex 78.0092 85.9842 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.935 83.1349 7.5
+      vertex 77.9122 83.5398 7.5
+      vertex 78.8093 82.8679 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 77.8454 83.3978 7.5
+      vertex 78.8093 82.8679 7.5
+      vertex 77.9122 83.5398 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.0815 84.2945 7.5
+      vertex 77.9901 84.1567 7.5
+      vertex 78 84 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.0262 84.5844 7.5
+      vertex 77.9607 84.3109 7.5
+      vertex 77.9901 84.1567 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.935 84.8651 7.5
+      vertex 77.9122 84.4602 7.5
+      vertex 77.9607 84.3109 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.8093 85.1321 7.5
+      vertex 77.8454 84.6022 7.5
+      vertex 77.9122 84.4602 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.6512 85.3813 7.5
+      vertex 77.7613 84.7347 7.5
+      vertex 77.8454 84.6022 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.4198 85.0554 7.5
+      vertex 78.0092 85.9842 7.5
+      vertex 77.7506 86.1263 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.4631 85.6087 7.5
+      vertex 77.6612 84.8557 7.5
+      vertex 77.7613 84.7347 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.2479 85.8107 7.5
+      vertex 77.5468 84.9631 7.5
+      vertex 77.6612 84.8557 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.2822 85.131 7.5
+      vertex 77.7506 86.1263 7.5
+      vertex 77.4762 86.235 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.0092 85.9842 7.5
+      vertex 77.4198 85.0554 7.5
+      vertex 77.5468 84.9631 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.7506 86.1263 7.5
+      vertex 77.2822 85.131 7.5
+      vertex 77.4198 85.0554 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.1363 85.1888 7.5
+      vertex 77.4762 86.235 7.5
+      vertex 77.1903 86.3084 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.4762 86.235 7.5
+      vertex 77.1363 85.1888 7.5
+      vertex 77.2822 85.131 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.1903 86.3084 7.5
+      vertex 76.9842 85.2279 7.5
+      vertex 77.1363 85.1888 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.8976 86.3454 7.5
+      vertex 76.9842 85.2279 7.5
+      vertex 77.1903 86.3084 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.8976 86.3454 7.5
+      vertex 76.8285 85.2475 7.5
+      vertex 76.9842 85.2279 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.8976 86.3454 7.5
+      vertex 76.6715 85.2475 7.5
+      vertex 76.8285 85.2475 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 76.6024 86.3454 7.5
+      vertex 76.6715 85.2475 7.5
+      vertex 76.8976 86.3454 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.6024 86.3454 7.5
+      vertex 76.5158 85.2279 7.5
+      vertex 76.6715 85.2475 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 76.3097 86.3084 7.5
+      vertex 76.5158 85.2279 7.5
+      vertex 76.6024 86.3454 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.5158 85.2279 7.5
+      vertex 76.3097 86.3084 7.5
+      vertex 76.3637 85.1888 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 76.0238 86.235 7.5
+      vertex 76.3637 85.1888 7.5
+      vertex 76.3097 86.3084 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.3637 85.1888 7.5
+      vertex 76.0238 86.235 7.5
+      vertex 76.2178 85.131 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 75.7494 86.1263 7.5
+      vertex 76.2178 85.131 7.5
+      vertex 76.0238 86.235 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.2178 85.131 7.5
+      vertex 75.7494 86.1263 7.5
+      vertex 76.0802 85.0554 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 75.4908 85.9842 7.5
+      vertex 76.0802 85.0554 7.5
+      vertex 75.7494 86.1263 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.0802 85.0554 7.5
+      vertex 75.4908 85.9842 7.5
+      vertex 75.9532 84.9631 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 75.2521 85.8107 7.5
+      vertex 75.9532 84.9631 7.5
+      vertex 75.4908 85.9842 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.9532 84.9631 7.5
+      vertex 75.2521 85.8107 7.5
+      vertex 75.8388 84.8557 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 75.0369 85.6087 7.5
+      vertex 75.8388 84.8557 7.5
+      vertex 75.2521 85.8107 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.8388 84.8557 7.5
+      vertex 75.0369 85.6087 7.5
+      vertex 75.7387 84.7347 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 74.8488 85.3813 7.5
+      vertex 75.7387 84.7347 7.5
+      vertex 75.0369 85.6087 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 74.6907 85.1321 7.5
+      vertex 75.6546 84.6022 7.5
+      vertex 74.8488 85.3813 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.7387 84.7347 7.5
+      vertex 74.8488 85.3813 7.5
+      vertex 75.6546 84.6022 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.8093 82.8679 7.5
+      vertex 77.8454 83.3978 7.5
+      vertex 78.6512 82.6187 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 77.7613 83.2653 7.5
+      vertex 78.6512 82.6187 7.5
+      vertex 77.8454 83.3978 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.6512 82.6187 7.5
+      vertex 77.7613 83.2653 7.5
+      vertex 78.4631 82.3913 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 77.6612 83.1443 7.5
+      vertex 78.4631 82.3913 7.5
+      vertex 77.7613 83.2653 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.4631 82.3913 7.5
+      vertex 77.6612 83.1443 7.5
+      vertex 78.2479 82.1893 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 77.5468 83.0369 7.5
+      vertex 78.2479 82.1893 7.5
+      vertex 77.6612 83.1443 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.2479 82.1893 7.5
+      vertex 77.5468 83.0369 7.5
+      vertex 78.0092 82.0158 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 77.4198 82.9446 7.5
+      vertex 78.0092 82.0158 7.5
+      vertex 77.5468 83.0369 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.0092 82.0158 7.5
+      vertex 77.4198 82.9446 7.5
+      vertex 77.7506 81.8737 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 77.2822 82.869 7.5
+      vertex 77.7506 81.8737 7.5
+      vertex 77.4198 82.9446 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.7506 81.8737 7.5
+      vertex 77.2822 82.869 7.5
+      vertex 77.4762 81.765 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 77.1363 82.8112 7.5
+      vertex 77.4762 81.765 7.5
+      vertex 77.2822 82.869 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.4762 81.765 7.5
+      vertex 77.1363 82.8112 7.5
+      vertex 77.1903 81.6916 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 76.9842 82.7721 7.5
+      vertex 77.1903 81.6916 7.5
+      vertex 77.1363 82.8112 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.9842 82.7721 7.5
+      vertex 76.8976 81.6546 7.5
+      vertex 77.1903 81.6916 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 76.8285 82.7525 7.5
+      vertex 76.8976 81.6546 7.5
+      vertex 76.9842 82.7721 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 76.6715 82.7525 7.5
+      vertex 76.8976 81.6546 7.5
+      vertex 76.8285 82.7525 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.6715 82.7525 7.5
+      vertex 76.6024 81.6546 7.5
+      vertex 76.8976 81.6546 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.5158 82.7721 7.5
+      vertex 76.6024 81.6546 7.5
+      vertex 76.6715 82.7525 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.3097 81.6916 7.5
+      vertex 76.5158 82.7721 7.5
+      vertex 76.3637 82.8112 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.5158 82.7721 7.5
+      vertex 76.3097 81.6916 7.5
+      vertex 76.6024 81.6546 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.0238 81.765 7.5
+      vertex 76.3637 82.8112 7.5
+      vertex 76.2178 82.869 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.7494 81.8737 7.5
+      vertex 76.2178 82.869 7.5
+      vertex 76.0802 82.9446 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.3637 82.8112 7.5
+      vertex 76.0238 81.765 7.5
+      vertex 76.3097 81.6916 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.4908 82.0158 7.5
+      vertex 76.0802 82.9446 7.5
+      vertex 75.9532 83.0369 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.2521 82.1893 7.5
+      vertex 75.9532 83.0369 7.5
+      vertex 75.8388 83.1443 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.2178 82.869 7.5
+      vertex 75.7494 81.8737 7.5
+      vertex 76.0238 81.765 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.0369 82.3913 7.5
+      vertex 75.8388 83.1443 7.5
+      vertex 75.7387 83.2653 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.8488 82.6187 7.5
+      vertex 75.7387 83.2653 7.5
+      vertex 75.6546 83.3978 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.6907 82.8679 7.5
+      vertex 75.6546 83.3978 7.5
+      vertex 75.5878 83.5398 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.565 83.1349 7.5
+      vertex 75.5878 83.5398 7.5
+      vertex 75.5393 83.6891 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.4738 83.4156 7.5
+      vertex 75.5393 83.6891 7.5
+      vertex 75.5099 83.8433 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.0802 82.9446 7.5
+      vertex 75.4908 82.0158 7.5
+      vertex 75.7494 81.8737 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.4185 83.7055 7.5
+      vertex 75.5099 83.8433 7.5
+      vertex 75.5 84 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.6546 84.6022 7.5
+      vertex 74.6907 85.1321 7.5
+      vertex 75.5878 84.4602 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 74.565 84.8651 7.5
+      vertex 75.5878 84.4602 7.5
+      vertex 74.6907 85.1321 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.9532 83.0369 7.5
+      vertex 75.2521 82.1893 7.5
+      vertex 75.4908 82.0158 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.5878 84.4602 7.5
+      vertex 74.565 84.8651 7.5
+      vertex 75.5393 84.3109 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.8388 83.1443 7.5
+      vertex 75.0369 82.3913 7.5
+      vertex 75.2521 82.1893 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 74.4738 84.5844 7.5
+      vertex 75.5393 84.3109 7.5
+      vertex 74.565 84.8651 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.7387 83.2653 7.5
+      vertex 74.8488 82.6187 7.5
+      vertex 75.0369 82.3913 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.5393 84.3109 7.5
+      vertex 74.4738 84.5844 7.5
+      vertex 75.5099 84.1567 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.6546 83.3978 7.5
+      vertex 74.6907 82.8679 7.5
+      vertex 74.8488 82.6187 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 74.4185 84.2945 7.5
+      vertex 75.5099 84.1567 7.5
+      vertex 74.4738 84.5844 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.5878 83.5398 7.5
+      vertex 74.565 83.1349 7.5
+      vertex 74.6907 82.8679 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.5099 84.1567 7.5
+      vertex 74.4185 84.2945 7.5
+      vertex 75.5 84 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.5393 83.6891 7.5
+      vertex 74.4738 83.4156 7.5
+      vertex 74.565 83.1349 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.4 84 7.5
+      vertex 75.5 84 7.5
+      vertex 74.4185 84.2945 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.5099 83.8433 7.5
+      vertex 74.4185 83.7055 7.5
+      vertex 74.4738 83.4156 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.5 84 7.5
+      vertex 74.4 84 7.5
+      vertex 74.4185 83.7055 7.5
+    endloop
+  endfacet
+  facet normal 0.248669 0.968589 -0
+    outer loop
+      vertex 77.4762 86.235 3
+      vertex 77.1903 86.3084 7.5
+      vertex 77.4762 86.235 7.5
+    endloop
+  endfacet
+  facet normal 0.248669 0.968589 0
+    outer loop
+      vertex 77.1903 86.3084 7.5
+      vertex 77.4762 86.235 3
+      vertex 77.1903 86.3084 3
+    endloop
+  endfacet
+  facet normal 0.982288 -0.187377 0
+    outer loop
+      vertex 79.0262 83.4156 7.5
+      vertex 79.0815 83.7055 3
+      vertex 79.0815 83.7055 7.5
+    endloop
+  endfacet
+  facet normal 0.982288 -0.187377 0
+    outer loop
+      vertex 79.0815 83.7055 3
+      vertex 79.0262 83.4156 7.5
+      vertex 79.0262 83.4156 3
+    endloop
+  endfacet
+  facet normal -0.125411 0.992105 0
+    outer loop
+      vertex 76.6024 86.3454 3
+      vertex 76.3097 86.3084 7.5
+      vertex 76.6024 86.3454 7.5
+    endloop
+  endfacet
+  facet normal -0.125411 0.992105 0
+    outer loop
+      vertex 76.3097 86.3084 7.5
+      vertex 76.6024 86.3454 3
+      vertex 76.3097 86.3084 3
+    endloop
+  endfacet
+  facet normal -0.770549 -0.63738 0
+    outer loop
+      vertex 75.0369 82.3913 3
+      vertex 74.8488 82.6187 7.5
+      vertex 74.8488 82.6187 3
+    endloop
+  endfacet
+  facet normal -0.770549 -0.63738 0
+    outer loop
+      vertex 74.8488 82.6187 7.5
+      vertex 75.0369 82.3913 3
+      vertex 75.0369 82.3913 7.5
+    endloop
+  endfacet
+  facet normal -0.998033 0.0626948 0
+    outer loop
+      vertex 74.4 84 3
+      vertex 74.4185 84.2945 7.5
+      vertex 74.4185 84.2945 3
+    endloop
+  endfacet
+  facet normal -0.998033 0.0626948 0
+    outer loop
+      vertex 74.4185 84.2945 7.5
+      vertex 74.4 84 3
+      vertex 74.4 84 7.5
+    endloop
+  endfacet
+  facet normal -0.8444 0.535713 0
+    outer loop
+      vertex 74.6907 57.1321 3
+      vertex 74.8488 57.3813 7.5
+      vertex 74.8488 57.3813 3
+    endloop
+  endfacet
+  facet normal -0.8444 0.535713 0
+    outer loop
+      vertex 74.8488 57.3813 7.5
+      vertex 74.6907 57.1321 3
+      vertex 74.6907 57.1321 7.5
+    endloop
+  endfacet
+  facet normal -0.684392 -0.729114 0
+    outer loop
+      vertex 75.0369 54.3913 3
+      vertex 75.2521 54.1893 7.5
+      vertex 75.0369 54.3913 7.5
+    endloop
+  endfacet
+  facet normal -0.684392 -0.729114 -0
+    outer loop
+      vertex 75.2521 54.1893 7.5
+      vertex 75.0369 54.3913 3
+      vertex 75.2521 54.1893 3
+    endloop
+  endfacet
+  facet normal 0.982288 0.187377 0
+    outer loop
+      vertex 79.0815 56.2945 7.5
+      vertex 79.0262 56.5844 3
+      vertex 79.0262 56.5844 7.5
+    endloop
+  endfacet
+  facet normal 0.982288 0.187377 0
+    outer loop
+      vertex 79.0262 56.5844 3
+      vertex 79.0815 56.2945 7.5
+      vertex 79.0815 56.2945 3
+    endloop
+  endfacet
+  facet normal 0.998033 0.0626948 0
+    outer loop
+      vertex 79.1 56 7.5
+      vertex 79.0815 56.2945 3
+      vertex 79.0815 56.2945 7.5
+    endloop
+  endfacet
+  facet normal 0.998033 0.0626948 0
+    outer loop
+      vertex 79.0815 56.2945 3
+      vertex 79.1 56 7.5
+      vertex 79.1 56 3
+    endloop
+  endfacet
+  facet normal 0.951061 0.309002 0
+    outer loop
+      vertex 79.0262 56.5844 7.5
+      vertex 78.935 56.8651 3
+      vertex 78.935 56.8651 7.5
+    endloop
+  endfacet
+  facet normal 0.951061 0.309002 0
+    outer loop
+      vertex 78.935 56.8651 3
+      vertex 79.0262 56.5844 7.5
+      vertex 79.0262 56.5844 3
+    endloop
+  endfacet
+  facet normal -0.998033 -0.0626948 0
+    outer loop
+      vertex 74.4185 55.7055 3
+      vertex 74.4 56 7.5
+      vertex 74.4 56 3
+    endloop
+  endfacet
+  facet normal -0.998033 -0.0626948 0
+    outer loop
+      vertex 74.4 56 7.5
+      vertex 74.4185 55.7055 3
+      vertex 74.4185 55.7055 7.5
+    endloop
+  endfacet
+  facet normal -0.684392 0.729114 0
+    outer loop
+      vertex 75.2521 57.8107 3
+      vertex 75.0369 57.6087 7.5
+      vertex 75.2521 57.8107 7.5
+    endloop
+  endfacet
+  facet normal -0.684392 0.729114 0
+    outer loop
+      vertex 75.0369 57.6087 7.5
+      vertex 75.2521 57.8107 3
+      vertex 75.0369 57.6087 3
+    endloop
+  endfacet
+  facet normal 0.770549 -0.63738 0
+    outer loop
+      vertex 78.4631 54.3913 7.5
+      vertex 78.6512 54.6187 3
+      vertex 78.6512 54.6187 7.5
+    endloop
+  endfacet
+  facet normal 0.770549 -0.63738 0
+    outer loop
+      vertex 78.6512 54.6187 3
+      vertex 78.4631 54.3913 7.5
+      vertex 78.4631 54.3913 3
+    endloop
+  endfacet
+  facet normal 0.8444 0.535713 0
+    outer loop
+      vertex 78.8093 57.1321 7.5
+      vertex 78.6512 57.3813 3
+      vertex 78.6512 57.3813 7.5
+    endloop
+  endfacet
+  facet normal 0.8444 0.535713 0
+    outer loop
+      vertex 78.6512 57.3813 3
+      vertex 78.8093 57.1321 7.5
+      vertex 78.8093 57.1321 3
+    endloop
+  endfacet
+  facet normal 0.90475 0.425944 0
+    outer loop
+      vertex 78.935 56.8651 7.5
+      vertex 78.8093 57.1321 3
+      vertex 78.8093 57.1321 7.5
+    endloop
+  endfacet
+  facet normal 0.90475 0.425944 0
+    outer loop
+      vertex 78.8093 57.1321 3
+      vertex 78.935 56.8651 7.5
+      vertex 78.935 56.8651 3
+    endloop
+  endfacet
+  facet normal 0.951061 -0.309002 0
+    outer loop
+      vertex 78.935 55.1349 7.5
+      vertex 79.0262 55.4156 3
+      vertex 79.0262 55.4156 7.5
+    endloop
+  endfacet
+  facet normal 0.951061 -0.309002 0
+    outer loop
+      vertex 79.0262 55.4156 3
+      vertex 78.935 55.1349 7.5
+      vertex 78.935 55.1349 3
+    endloop
+  endfacet
+  facet normal 0.368293 0.92971 -0
+    outer loop
+      vertex 77.7506 58.1263 3
+      vertex 77.4762 58.235 7.5
+      vertex 77.7506 58.1263 7.5
+    endloop
+  endfacet
+  facet normal 0.368293 0.92971 0
+    outer loop
+      vertex 77.4762 58.235 7.5
+      vertex 77.7506 58.1263 3
+      vertex 77.4762 58.235 3
+    endloop
+  endfacet
+  facet normal -0.982288 -0.187377 0
+    outer loop
+      vertex 74.4738 55.4156 3
+      vertex 74.4185 55.7055 7.5
+      vertex 74.4185 55.7055 3
+    endloop
+  endfacet
+  facet normal -0.982288 -0.187377 0
+    outer loop
+      vertex 74.4185 55.7055 7.5
+      vertex 74.4738 55.4156 3
+      vertex 74.4738 55.4156 7.5
+    endloop
+  endfacet
+  facet normal -0.248669 0.968589 0
+    outer loop
+      vertex 76.3097 58.3084 3
+      vertex 76.0238 58.235 7.5
+      vertex 76.3097 58.3084 7.5
+    endloop
+  endfacet
+  facet normal -0.248669 0.968589 0
+    outer loop
+      vertex 76.0238 58.235 7.5
+      vertex 76.3097 58.3084 3
+      vertex 76.0238 58.235 3
+    endloop
+  endfacet
+  facet normal -0.951061 -0.309002 0
+    outer loop
+      vertex 74.565 55.1349 3
+      vertex 74.4738 55.4156 7.5
+      vertex 74.4738 55.4156 3
+    endloop
+  endfacet
+  facet normal -0.951061 -0.309002 0
+    outer loop
+      vertex 74.4738 55.4156 7.5
+      vertex 74.565 55.1349 3
+      vertex 74.565 55.1349 7.5
+    endloop
+  endfacet
+  facet normal -0.90475 0.425944 0
+    outer loop
+      vertex 74.565 56.8651 3
+      vertex 74.6907 57.1321 7.5
+      vertex 74.6907 57.1321 3
+    endloop
+  endfacet
+  facet normal -0.90475 0.425944 0
+    outer loop
+      vertex 74.6907 57.1321 7.5
+      vertex 74.565 56.8651 3
+      vertex 74.565 56.8651 7.5
+    endloop
+  endfacet
+  facet normal 0.587834 -0.808981 0
+    outer loop
+      vertex 78.0767 54.0649 3
+      vertex 78.2479 54.1893 7.5
+      vertex 78.0767 54.0649 7.5
+    endloop
+  endfacet
+  facet normal 0.587834 -0.808981 0
+    outer loop
+      vertex 78.2479 54.1893 7.5
+      vertex 78.0767 54.0649 3
+      vertex 78.2479 54.1893 3
+    endloop
+  endfacet
+  facet normal 0.684392 -0.729114 0
+    outer loop
+      vertex 78.2479 54.1893 3
+      vertex 78.4631 54.3913 7.5
+      vertex 78.2479 54.1893 7.5
+    endloop
+  endfacet
+  facet normal 0.684392 -0.729114 0
+    outer loop
+      vertex 78.4631 54.3913 7.5
+      vertex 78.2479 54.1893 3
+      vertex 78.4631 54.3913 3
+    endloop
+  endfacet
+  facet normal 0.58795 0.808897 -0
+    outer loop
+      vertex 78.2479 57.8107 3
+      vertex 78.0092 57.9842 7.5
+      vertex 78.2479 57.8107 7.5
+    endloop
+  endfacet
+  facet normal 0.58795 0.808897 0
+    outer loop
+      vertex 78.0092 57.9842 7.5
+      vertex 78.2479 57.8107 3
+      vertex 78.0092 57.9842 3
+    endloop
+  endfacet
+  facet normal -0.368293 0.92971 0
+    outer loop
+      vertex 76.0238 58.235 3
+      vertex 75.7494 58.1263 7.5
+      vertex 76.0238 58.235 7.5
+    endloop
+  endfacet
+  facet normal -0.368293 0.92971 0
+    outer loop
+      vertex 75.7494 58.1263 7.5
+      vertex 76.0238 58.235 3
+      vertex 75.7494 58.1263 3
+    endloop
+  endfacet
+  facet normal 0.998033 -0.0626948 0
+    outer loop
+      vertex 79.0815 55.7055 7.5
+      vertex 79.1 56 3
+      vertex 79.1 56 7.5
+    endloop
+  endfacet
+  facet normal 0.998033 -0.0626948 0
+    outer loop
+      vertex 79.1 56 3
+      vertex 79.0815 55.7055 7.5
+      vertex 79.0815 55.7055 3
+    endloop
+  endfacet
+  facet normal -0.48158 0.876402 0
+    outer loop
+      vertex 75.7494 58.1263 3
+      vertex 75.4908 57.9842 7.5
+      vertex 75.7494 58.1263 7.5
+    endloop
+  endfacet
+  facet normal -0.48158 0.876402 0
+    outer loop
+      vertex 75.4908 57.9842 7.5
+      vertex 75.7494 58.1263 3
+      vertex 75.4908 57.9842 3
+    endloop
+  endfacet
+  facet normal -0.48174 -0.876314 0
+    outer loop
+      vertex 75.4908 54.0158 3
+      vertex 75.6225 53.9434 7.5
+      vertex 75.4908 54.0158 7.5
+    endloop
+  endfacet
+  facet normal -0.48174 -0.876314 -0
+    outer loop
+      vertex 75.6225 53.9434 7.5
+      vertex 75.4908 54.0158 3
+      vertex 75.6225 53.9434 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78 56 7.5
+      vertex 79.1 56 7.5
+      vertex 79.0815 56.2945 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.9901 56.1567 7.5
+      vertex 79.0815 56.2945 7.5
+      vertex 79.0262 56.5844 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.1 56 7.5
+      vertex 78 56 7.5
+      vertex 79.0815 55.7055 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.9607 56.3109 7.5
+      vertex 79.0262 56.5844 7.5
+      vertex 78.935 56.8651 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 77.9901 55.8433 7.5
+      vertex 79.0815 55.7055 7.5
+      vertex 78 56 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.9122 56.4602 7.5
+      vertex 78.935 56.8651 7.5
+      vertex 78.8093 57.1321 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.0815 55.7055 7.5
+      vertex 77.9901 55.8433 7.5
+      vertex 79.0262 55.4156 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.8454 56.6022 7.5
+      vertex 78.8093 57.1321 7.5
+      vertex 78.6512 57.3813 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 77.9607 55.6891 7.5
+      vertex 79.0262 55.4156 7.5
+      vertex 77.9901 55.8433 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.7613 56.7347 7.5
+      vertex 78.6512 57.3813 7.5
+      vertex 78.4631 57.6087 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.0262 55.4156 7.5
+      vertex 77.9607 55.6891 7.5
+      vertex 78.935 55.1349 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.6612 56.8557 7.5
+      vertex 78.4631 57.6087 7.5
+      vertex 78.2479 57.8107 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 77.9122 55.5398 7.5
+      vertex 78.935 55.1349 7.5
+      vertex 77.9607 55.6891 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.935 55.1349 7.5
+      vertex 77.9122 55.5398 7.5
+      vertex 78.8093 54.8679 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.5468 56.9631 7.5
+      vertex 78.2479 57.8107 7.5
+      vertex 78.0092 57.9842 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 77.8454 55.3978 7.5
+      vertex 78.8093 54.8679 7.5
+      vertex 77.9122 55.5398 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.8093 54.8679 7.5
+      vertex 77.8454 55.3978 7.5
+      vertex 78.6512 54.6187 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.0815 56.2945 7.5
+      vertex 77.9901 56.1567 7.5
+      vertex 78 56 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.0262 56.5844 7.5
+      vertex 77.9607 56.3109 7.5
+      vertex 77.9901 56.1567 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.935 56.8651 7.5
+      vertex 77.9122 56.4602 7.5
+      vertex 77.9607 56.3109 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.8093 57.1321 7.5
+      vertex 77.8454 56.6022 7.5
+      vertex 77.9122 56.4602 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.6512 57.3813 7.5
+      vertex 77.7613 56.7347 7.5
+      vertex 77.8454 56.6022 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.4198 57.0554 7.5
+      vertex 78.0092 57.9842 7.5
+      vertex 77.7506 58.1263 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.4631 57.6087 7.5
+      vertex 77.6612 56.8557 7.5
+      vertex 77.7613 56.7347 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.2479 57.8107 7.5
+      vertex 77.5468 56.9631 7.5
+      vertex 77.6612 56.8557 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.2822 57.131 7.5
+      vertex 77.7506 58.1263 7.5
+      vertex 77.4762 58.235 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.0092 57.9842 7.5
+      vertex 77.4198 57.0554 7.5
+      vertex 77.5468 56.9631 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.7506 58.1263 7.5
+      vertex 77.2822 57.131 7.5
+      vertex 77.4198 57.0554 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.1363 57.1888 7.5
+      vertex 77.4762 58.235 7.5
+      vertex 77.1903 58.3084 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.4762 58.235 7.5
+      vertex 77.1363 57.1888 7.5
+      vertex 77.2822 57.131 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.1903 58.3084 7.5
+      vertex 76.9842 57.2279 7.5
+      vertex 77.1363 57.1888 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.8976 58.3454 7.5
+      vertex 76.9842 57.2279 7.5
+      vertex 77.1903 58.3084 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.8976 58.3454 7.5
+      vertex 76.8285 57.2475 7.5
+      vertex 76.9842 57.2279 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.8976 58.3454 7.5
+      vertex 76.6715 57.2475 7.5
+      vertex 76.8285 57.2475 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 76.6024 58.3454 7.5
+      vertex 76.6715 57.2475 7.5
+      vertex 76.8976 58.3454 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.6024 58.3454 7.5
+      vertex 76.5158 57.2279 7.5
+      vertex 76.6715 57.2475 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 76.3097 58.3084 7.5
+      vertex 76.5158 57.2279 7.5
+      vertex 76.6024 58.3454 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.5158 57.2279 7.5
+      vertex 76.3097 58.3084 7.5
+      vertex 76.3637 57.1888 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 76.0238 58.235 7.5
+      vertex 76.3637 57.1888 7.5
+      vertex 76.3097 58.3084 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.3637 57.1888 7.5
+      vertex 76.0238 58.235 7.5
+      vertex 76.2178 57.131 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 75.7494 58.1263 7.5
+      vertex 76.2178 57.131 7.5
+      vertex 76.0238 58.235 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.2178 57.131 7.5
+      vertex 75.7494 58.1263 7.5
+      vertex 76.0802 57.0554 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 75.4908 57.9842 7.5
+      vertex 76.0802 57.0554 7.5
+      vertex 75.7494 58.1263 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.0802 57.0554 7.5
+      vertex 75.4908 57.9842 7.5
+      vertex 75.9532 56.9631 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 75.2521 57.8107 7.5
+      vertex 75.9532 56.9631 7.5
+      vertex 75.4908 57.9842 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.9532 56.9631 7.5
+      vertex 75.2521 57.8107 7.5
+      vertex 75.8388 56.8557 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 75.0369 57.6087 7.5
+      vertex 75.8388 56.8557 7.5
+      vertex 75.2521 57.8107 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.8388 56.8557 7.5
+      vertex 75.0369 57.6087 7.5
+      vertex 75.7387 56.7347 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 74.8488 57.3813 7.5
+      vertex 75.7387 56.7347 7.5
+      vertex 75.0369 57.6087 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 74.6907 57.1321 7.5
+      vertex 75.6546 56.6022 7.5
+      vertex 74.8488 57.3813 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.7387 56.7347 7.5
+      vertex 74.8488 57.3813 7.5
+      vertex 75.6546 56.6022 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 77.7613 55.2653 7.5
+      vertex 78.6512 54.6187 7.5
+      vertex 77.8454 55.3978 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.6512 54.6187 7.5
+      vertex 77.7613 55.2653 7.5
+      vertex 78.4631 54.3913 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 77.6612 55.1443 7.5
+      vertex 78.4631 54.3913 7.5
+      vertex 77.7613 55.2653 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.4631 54.3913 7.5
+      vertex 77.6612 55.1443 7.5
+      vertex 78.2479 54.1893 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.2479 54.1893 7.5
+      vertex 78.0043 54.0909 7.5
+      vertex 78.0767 54.0649 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 77.5468 55.0369 7.5
+      vertex 78.2479 54.1893 7.5
+      vertex 77.6612 55.1443 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.2479 54.1893 7.5
+      vertex 77.8082 54.1479 7.5
+      vertex 78.0043 54.0909 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.2479 54.1893 7.5
+      vertex 77.5468 55.0369 7.5
+      vertex 77.8082 54.1479 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.8082 54.1479 7.5
+      vertex 77.5468 55.0369 7.5
+      vertex 77.609 54.1924 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 77.4198 54.9446 7.5
+      vertex 77.609 54.1924 7.5
+      vertex 77.5468 55.0369 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.4198 54.9446 7.5
+      vertex 77.4073 54.2244 7.5
+      vertex 77.609 54.1924 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 77.2822 54.869 7.5
+      vertex 77.4073 54.2244 7.5
+      vertex 77.4198 54.9446 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.2822 54.869 7.5
+      vertex 77.2041 54.2436 7.5
+      vertex 77.4073 54.2244 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 77.1363 54.8112 7.5
+      vertex 77.2041 54.2436 7.5
+      vertex 77.2822 54.869 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 76.9842 54.7721 7.5
+      vertex 77.2041 54.2436 7.5
+      vertex 77.1363 54.8112 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.2041 54.2436 7.5
+      vertex 76.9842 54.7721 7.5
+      vertex 77 54.25 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 76.8285 54.7525 7.5
+      vertex 77 54.25 7.5
+      vertex 76.9842 54.7721 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.8285 54.7525 7.5
+      vertex 76.7959 54.2436 7.5
+      vertex 77 54.25 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 76.6715 54.7525 7.5
+      vertex 76.7959 54.2436 7.5
+      vertex 76.8285 54.7525 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.6715 54.7525 7.5
+      vertex 76.5927 54.2244 7.5
+      vertex 76.7959 54.2436 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.5158 54.7721 7.5
+      vertex 76.5927 54.2244 7.5
+      vertex 76.6715 54.7525 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.5158 54.7721 7.5
+      vertex 76.391 54.1924 7.5
+      vertex 76.5927 54.2244 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.3637 54.8112 7.5
+      vertex 76.391 54.1924 7.5
+      vertex 76.5158 54.7721 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.1918 54.1479 7.5
+      vertex 76.3637 54.8112 7.5
+      vertex 76.2178 54.869 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.3637 54.8112 7.5
+      vertex 76.1918 54.1479 7.5
+      vertex 76.391 54.1924 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.9957 54.0909 7.5
+      vertex 76.2178 54.869 7.5
+      vertex 76.0802 54.9446 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.2178 54.869 7.5
+      vertex 75.9957 54.0909 7.5
+      vertex 76.1918 54.1479 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.8036 54.0218 7.5
+      vertex 76.0802 54.9446 7.5
+      vertex 75.9532 55.0369 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.2521 54.1893 7.5
+      vertex 75.9532 55.0369 7.5
+      vertex 75.8388 55.1443 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.0802 54.9446 7.5
+      vertex 75.8036 54.0218 7.5
+      vertex 75.9957 54.0909 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.0369 54.3913 7.5
+      vertex 75.8388 55.1443 7.5
+      vertex 75.7387 55.2653 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.8488 54.6187 7.5
+      vertex 75.7387 55.2653 7.5
+      vertex 75.6546 55.3978 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.9532 55.0369 7.5
+      vertex 75.2521 54.1893 7.5
+      vertex 75.8036 54.0218 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.6907 54.8679 7.5
+      vertex 75.6546 55.3978 7.5
+      vertex 75.5878 55.5398 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.565 55.1349 7.5
+      vertex 75.5878 55.5398 7.5
+      vertex 75.5393 55.6891 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.4738 55.4156 7.5
+      vertex 75.5393 55.6891 7.5
+      vertex 75.5099 55.8433 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.4185 55.7055 7.5
+      vertex 75.5099 55.8433 7.5
+      vertex 75.5 56 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.8036 54.0218 7.5
+      vertex 75.4908 54.0158 7.5
+      vertex 75.6225 53.9434 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.6546 56.6022 7.5
+      vertex 74.6907 57.1321 7.5
+      vertex 75.5878 56.4602 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 74.565 56.8651 7.5
+      vertex 75.5878 56.4602 7.5
+      vertex 74.6907 57.1321 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.8036 54.0218 7.5
+      vertex 75.2521 54.1893 7.5
+      vertex 75.4908 54.0158 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.5878 56.4602 7.5
+      vertex 74.565 56.8651 7.5
+      vertex 75.5393 56.3109 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.8388 55.1443 7.5
+      vertex 75.0369 54.3913 7.5
+      vertex 75.2521 54.1893 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 74.4738 56.5844 7.5
+      vertex 75.5393 56.3109 7.5
+      vertex 74.565 56.8651 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.7387 55.2653 7.5
+      vertex 74.8488 54.6187 7.5
+      vertex 75.0369 54.3913 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.5393 56.3109 7.5
+      vertex 74.4738 56.5844 7.5
+      vertex 75.5099 56.1567 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.6546 55.3978 7.5
+      vertex 74.6907 54.8679 7.5
+      vertex 74.8488 54.6187 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 74.4185 56.2945 7.5
+      vertex 75.5099 56.1567 7.5
+      vertex 74.4738 56.5844 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.5878 55.5398 7.5
+      vertex 74.565 55.1349 7.5
+      vertex 74.6907 54.8679 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.5099 56.1567 7.5
+      vertex 74.4185 56.2945 7.5
+      vertex 75.5 56 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.5393 55.6891 7.5
+      vertex 74.4738 55.4156 7.5
+      vertex 74.565 55.1349 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.4 56 7.5
+      vertex 75.5 56 7.5
+      vertex 74.4185 56.2945 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.5099 55.8433 7.5
+      vertex 74.4185 55.7055 7.5
+      vertex 74.4738 55.4156 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.5 56 7.5
+      vertex 74.4 56 7.5
+      vertex 74.4185 55.7055 7.5
+    endloop
+  endfacet
+  facet normal -0.998033 0.0626948 0
+    outer loop
+      vertex 74.4 56 3
+      vertex 74.4185 56.2945 7.5
+      vertex 74.4185 56.2945 3
+    endloop
+  endfacet
+  facet normal -0.998033 0.0626948 0
+    outer loop
+      vertex 74.4185 56.2945 7.5
+      vertex 74.4 56 3
+      vertex 74.4 56 7.5
+    endloop
+  endfacet
+  facet normal 0.48158 0.876402 -0
+    outer loop
+      vertex 78.0092 57.9842 3
+      vertex 77.7506 58.1263 7.5
+      vertex 78.0092 57.9842 7.5
+    endloop
+  endfacet
+  facet normal 0.48158 0.876402 0
+    outer loop
+      vertex 77.7506 58.1263 7.5
+      vertex 78.0092 57.9842 3
+      vertex 77.7506 58.1263 3
+    endloop
+  endfacet
+  facet normal -0.58795 0.808897 0
+    outer loop
+      vertex 75.4908 57.9842 3
+      vertex 75.2521 57.8107 7.5
+      vertex 75.4908 57.9842 7.5
+    endloop
+  endfacet
+  facet normal -0.58795 0.808897 0
+    outer loop
+      vertex 75.2521 57.8107 7.5
+      vertex 75.4908 57.9842 3
+      vertex 75.2521 57.8107 3
+    endloop
+  endfacet
+  facet normal -0.58795 -0.808897 0
+    outer loop
+      vertex 75.2521 54.1893 3
+      vertex 75.4908 54.0158 7.5
+      vertex 75.2521 54.1893 7.5
+    endloop
+  endfacet
+  facet normal -0.58795 -0.808897 -0
+    outer loop
+      vertex 75.4908 54.0158 7.5
+      vertex 75.2521 54.1893 3
+      vertex 75.4908 54.0158 3
+    endloop
+  endfacet
+  facet normal -0.770549 -0.63738 0
+    outer loop
+      vertex 75.0369 54.3913 3
+      vertex 74.8488 54.6187 7.5
+      vertex 74.8488 54.6187 3
+    endloop
+  endfacet
+  facet normal -0.770549 -0.63738 0
+    outer loop
+      vertex 74.8488 54.6187 7.5
+      vertex 75.0369 54.3913 3
+      vertex 75.0369 54.3913 7.5
+    endloop
+  endfacet
+  facet normal 0.982288 -0.187377 0
+    outer loop
+      vertex 79.0262 55.4156 7.5
+      vertex 79.0815 55.7055 3
+      vertex 79.0815 55.7055 7.5
+    endloop
+  endfacet
+  facet normal 0.982288 -0.187377 0
+    outer loop
+      vertex 79.0815 55.7055 3
+      vertex 79.0262 55.4156 7.5
+      vertex 79.0262 55.4156 3
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 76.8976 58.3454 3
+      vertex 76.6024 58.3454 7.5
+      vertex 76.8976 58.3454 7.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 76.6024 58.3454 7.5
+      vertex 76.8976 58.3454 3
+      vertex 76.6024 58.3454 3
+    endloop
+  endfacet
+  facet normal 0.8444 -0.535713 0
+    outer loop
+      vertex 78.6512 54.6187 7.5
+      vertex 78.8093 54.8679 3
+      vertex 78.8093 54.8679 7.5
+    endloop
+  endfacet
+  facet normal 0.8444 -0.535713 0
+    outer loop
+      vertex 78.8093 54.8679 3
+      vertex 78.6512 54.6187 7.5
+      vertex 78.6512 54.6187 3
+    endloop
+  endfacet
+  facet normal 0.90475 -0.425944 0
+    outer loop
+      vertex 78.8093 54.8679 7.5
+      vertex 78.935 55.1349 3
+      vertex 78.935 55.1349 7.5
+    endloop
+  endfacet
+  facet normal 0.90475 -0.425944 0
+    outer loop
+      vertex 78.935 55.1349 3
+      vertex 78.8093 54.8679 7.5
+      vertex 78.8093 54.8679 3
+    endloop
+  endfacet
+  facet normal 0.684392 0.729114 -0
+    outer loop
+      vertex 78.4631 57.6087 3
+      vertex 78.2479 57.8107 7.5
+      vertex 78.4631 57.6087 7.5
+    endloop
+  endfacet
+  facet normal 0.684392 0.729114 0
+    outer loop
+      vertex 78.2479 57.8107 7.5
+      vertex 78.4631 57.6087 3
+      vertex 78.2479 57.8107 3
+    endloop
+  endfacet
+  facet normal -0.125411 0.992105 0
+    outer loop
+      vertex 76.6024 58.3454 3
+      vertex 76.3097 58.3084 7.5
+      vertex 76.6024 58.3454 7.5
+    endloop
+  endfacet
+  facet normal -0.125411 0.992105 0
+    outer loop
+      vertex 76.3097 58.3084 7.5
+      vertex 76.6024 58.3454 3
+      vertex 76.3097 58.3084 3
+    endloop
+  endfacet
+  facet normal 0.125411 0.992105 -0
+    outer loop
+      vertex 77.1903 58.3084 3
+      vertex 76.8976 58.3454 7.5
+      vertex 77.1903 58.3084 7.5
+    endloop
+  endfacet
+  facet normal 0.125411 0.992105 0
+    outer loop
+      vertex 76.8976 58.3454 7.5
+      vertex 77.1903 58.3084 3
+      vertex 76.8976 58.3454 3
+    endloop
+  endfacet
+  facet normal 0.248669 0.968589 -0
+    outer loop
+      vertex 77.4762 58.235 3
+      vertex 77.1903 58.3084 7.5
+      vertex 77.4762 58.235 7.5
+    endloop
+  endfacet
+  facet normal 0.248669 0.968589 0
+    outer loop
+      vertex 77.1903 58.3084 7.5
+      vertex 77.4762 58.235 3
+      vertex 77.1903 58.3084 3
+    endloop
+  endfacet
+  facet normal -0.982288 0.187377 0
+    outer loop
+      vertex 74.4185 56.2945 3
+      vertex 74.4738 56.5844 7.5
+      vertex 74.4738 56.5844 3
+    endloop
+  endfacet
+  facet normal -0.982288 0.187377 0
+    outer loop
+      vertex 74.4738 56.5844 7.5
+      vertex 74.4185 56.2945 3
+      vertex 74.4185 56.2945 7.5
+    endloop
+  endfacet
+  facet normal 0.770549 0.63738 0
+    outer loop
+      vertex 78.6512 57.3813 7.5
+      vertex 78.4631 57.6087 3
+      vertex 78.4631 57.6087 7.5
+    endloop
+  endfacet
+  facet normal 0.770549 0.63738 0
+    outer loop
+      vertex 78.4631 57.6087 3
+      vertex 78.6512 57.3813 7.5
+      vertex 78.6512 57.3813 3
+    endloop
+  endfacet
+  facet normal -0.951061 0.309002 0
+    outer loop
+      vertex 74.4738 56.5844 3
+      vertex 74.565 56.8651 7.5
+      vertex 74.565 56.8651 3
+    endloop
+  endfacet
+  facet normal -0.951061 0.309002 0
+    outer loop
+      vertex 74.565 56.8651 7.5
+      vertex 74.4738 56.5844 3
+      vertex 74.4738 56.5844 7.5
+    endloop
+  endfacet
+  facet normal -0.8444 -0.535713 0
+    outer loop
+      vertex 74.8488 54.6187 3
+      vertex 74.6907 54.8679 7.5
+      vertex 74.6907 54.8679 3
+    endloop
+  endfacet
+  facet normal -0.8444 -0.535713 0
+    outer loop
+      vertex 74.6907 54.8679 7.5
+      vertex 74.8488 54.6187 3
+      vertex 74.8488 54.6187 7.5
+    endloop
+  endfacet
+  facet normal -0.90475 -0.425944 0
+    outer loop
+      vertex 74.6907 54.8679 3
+      vertex 74.565 55.1349 7.5
+      vertex 74.565 55.1349 3
+    endloop
+  endfacet
+  facet normal -0.90475 -0.425944 0
+    outer loop
+      vertex 74.565 55.1349 7.5
+      vertex 74.6907 54.8679 3
+      vertex 74.6907 54.8679 7.5
+    endloop
+  endfacet
+  facet normal -0.770549 0.63738 0
+    outer loop
+      vertex 74.8488 57.3813 3
+      vertex 75.0369 57.6087 7.5
+      vertex 75.0369 57.6087 3
+    endloop
+  endfacet
+  facet normal -0.770549 0.63738 0
+    outer loop
+      vertex 75.0369 57.6087 7.5
+      vertex 74.8488 57.3813 3
+      vertex 74.8488 57.3813 7.5
+    endloop
+  endfacet
+  facet normal -0.587834 0.808981 0
+    outer loop
+      vertex 61.9233 85.9351 3
+      vertex 61.7521 85.8107 7.5
+      vertex 61.9233 85.9351 7.5
+    endloop
+  endfacet
+  facet normal -0.587834 0.808981 0
+    outer loop
+      vertex 61.7521 85.8107 7.5
+      vertex 61.9233 85.9351 3
+      vertex 61.7521 85.8107 3
+    endloop
+  endfacet
+  facet normal 0.982288 0.187377 0
+    outer loop
+      vertex 65.5815 84.2945 7.5
+      vertex 65.5262 84.5844 3
+      vertex 65.5262 84.5844 7.5
+    endloop
+  endfacet
+  facet normal 0.982288 0.187377 0
+    outer loop
+      vertex 65.5262 84.5844 3
+      vertex 65.5815 84.2945 7.5
+      vertex 65.5815 84.2945 3
+    endloop
+  endfacet
+  facet normal 0.998033 0.0626948 0
+    outer loop
+      vertex 65.6 84 7.5
+      vertex 65.5815 84.2945 3
+      vertex 65.5815 84.2945 7.5
+    endloop
+  endfacet
+  facet normal 0.998033 0.0626948 0
+    outer loop
+      vertex 65.5815 84.2945 3
+      vertex 65.6 84 7.5
+      vertex 65.6 84 3
+    endloop
+  endfacet
+  facet normal 0.951061 0.309002 0
+    outer loop
+      vertex 65.5262 84.5844 7.5
+      vertex 65.435 84.8651 3
+      vertex 65.435 84.8651 7.5
+    endloop
+  endfacet
+  facet normal 0.951061 0.309002 0
+    outer loop
+      vertex 65.435 84.8651 3
+      vertex 65.5262 84.5844 7.5
+      vertex 65.5262 84.5844 3
+    endloop
+  endfacet
+  facet normal 0.951061 -0.309002 0
+    outer loop
+      vertex 65.435 83.1349 7.5
+      vertex 65.5262 83.4156 3
+      vertex 65.5262 83.4156 7.5
+    endloop
+  endfacet
+  facet normal 0.951061 -0.309002 0
+    outer loop
+      vertex 65.5262 83.4156 3
+      vertex 65.435 83.1349 7.5
+      vertex 65.435 83.1349 3
+    endloop
+  endfacet
+  facet normal 0.8444 0.535713 0
+    outer loop
+      vertex 65.3093 85.1321 7.5
+      vertex 65.1512 85.3813 3
+      vertex 65.1512 85.3813 7.5
+    endloop
+  endfacet
+  facet normal 0.8444 0.535713 0
+    outer loop
+      vertex 65.1512 85.3813 3
+      vertex 65.3093 85.1321 7.5
+      vertex 65.3093 85.1321 3
+    endloop
+  endfacet
+  facet normal 0.48158 -0.876402 0
+    outer loop
+      vertex 64.2506 81.8737 3
+      vertex 64.5092 82.0158 7.5
+      vertex 64.2506 81.8737 7.5
+    endloop
+  endfacet
+  facet normal 0.48158 -0.876402 0
+    outer loop
+      vertex 64.5092 82.0158 7.5
+      vertex 64.2506 81.8737 3
+      vertex 64.5092 82.0158 3
+    endloop
+  endfacet
+  facet normal 0.248669 -0.968589 0
+    outer loop
+      vertex 63.6903 81.6916 3
+      vertex 63.9762 81.765 7.5
+      vertex 63.6903 81.6916 7.5
+    endloop
+  endfacet
+  facet normal 0.248669 -0.968589 0
+    outer loop
+      vertex 63.9762 81.765 7.5
+      vertex 63.6903 81.6916 3
+      vertex 63.9762 81.765 3
+    endloop
+  endfacet
+  facet normal 0.684392 0.729114 -0
+    outer loop
+      vertex 64.9631 85.6087 3
+      vertex 64.7479 85.8107 7.5
+      vertex 64.9631 85.6087 7.5
+    endloop
+  endfacet
+  facet normal 0.684392 0.729114 0
+    outer loop
+      vertex 64.7479 85.8107 7.5
+      vertex 64.9631 85.6087 3
+      vertex 64.7479 85.8107 3
+    endloop
+  endfacet
+  facet normal 0.90475 0.425944 0
+    outer loop
+      vertex 65.435 84.8651 7.5
+      vertex 65.3093 85.1321 3
+      vertex 65.3093 85.1321 7.5
+    endloop
+  endfacet
+  facet normal 0.90475 0.425944 0
+    outer loop
+      vertex 65.3093 85.1321 3
+      vertex 65.435 84.8651 7.5
+      vertex 65.435 84.8651 3
+    endloop
+  endfacet
+  facet normal 0.8444 -0.535713 0
+    outer loop
+      vertex 65.1512 82.6187 7.5
+      vertex 65.3093 82.8679 3
+      vertex 65.3093 82.8679 7.5
+    endloop
+  endfacet
+  facet normal 0.8444 -0.535713 0
+    outer loop
+      vertex 65.3093 82.8679 3
+      vertex 65.1512 82.6187 7.5
+      vertex 65.1512 82.6187 3
+    endloop
+  endfacet
+  facet normal -0.982288 -0.187377 0
+    outer loop
+      vertex 60.9738 83.4156 3
+      vertex 60.9185 83.7055 7.5
+      vertex 60.9185 83.7055 3
+    endloop
+  endfacet
+  facet normal -0.982288 -0.187377 0
+    outer loop
+      vertex 60.9185 83.7055 7.5
+      vertex 60.9738 83.4156 3
+      vertex 60.9738 83.4156 7.5
+    endloop
+  endfacet
+  facet normal 0.90475 -0.425944 0
+    outer loop
+      vertex 65.3093 82.8679 7.5
+      vertex 65.435 83.1349 3
+      vertex 65.435 83.1349 7.5
+    endloop
+  endfacet
+  facet normal 0.90475 -0.425944 0
+    outer loop
+      vertex 65.435 83.1349 3
+      vertex 65.3093 82.8679 7.5
+      vertex 65.3093 82.8679 3
+    endloop
+  endfacet
+  facet normal 0.770549 0.63738 0
+    outer loop
+      vertex 65.1512 85.3813 7.5
+      vertex 64.9631 85.6087 3
+      vertex 64.9631 85.6087 7.5
+    endloop
+  endfacet
+  facet normal 0.770549 0.63738 0
+    outer loop
+      vertex 64.9631 85.6087 3
+      vertex 65.1512 85.3813 7.5
+      vertex 65.1512 85.3813 3
+    endloop
+  endfacet
+  facet normal -0.48158 -0.876402 0
+    outer loop
+      vertex 61.9908 82.0158 3
+      vertex 62.2494 81.8737 7.5
+      vertex 61.9908 82.0158 7.5
+    endloop
+  endfacet
+  facet normal -0.48158 -0.876402 -0
+    outer loop
+      vertex 62.2494 81.8737 7.5
+      vertex 61.9908 82.0158 3
+      vertex 62.2494 81.8737 3
+    endloop
+  endfacet
+  facet normal -0.90475 -0.425944 0
+    outer loop
+      vertex 61.1907 82.8679 3
+      vertex 61.065 83.1349 7.5
+      vertex 61.065 83.1349 3
+    endloop
+  endfacet
+  facet normal -0.90475 -0.425944 0
+    outer loop
+      vertex 61.065 83.1349 7.5
+      vertex 61.1907 82.8679 3
+      vertex 61.1907 82.8679 7.5
+    endloop
+  endfacet
+  facet normal 0.368293 -0.92971 0
+    outer loop
+      vertex 63.9762 81.765 3
+      vertex 64.2506 81.8737 7.5
+      vertex 63.9762 81.765 7.5
+    endloop
+  endfacet
+  facet normal 0.368293 -0.92971 0
+    outer loop
+      vertex 64.2506 81.8737 7.5
+      vertex 63.9762 81.765 3
+      vertex 64.2506 81.8737 3
+    endloop
+  endfacet
+  facet normal -0.770549 0.63738 0
+    outer loop
+      vertex 61.3488 85.3813 3
+      vertex 61.5369 85.6087 7.5
+      vertex 61.5369 85.6087 3
+    endloop
+  endfacet
+  facet normal -0.770549 0.63738 0
+    outer loop
+      vertex 61.5369 85.6087 7.5
+      vertex 61.3488 85.3813 3
+      vertex 61.3488 85.3813 7.5
+    endloop
+  endfacet
+  facet normal 0.125411 -0.992105 0
+    outer loop
+      vertex 63.3976 81.6546 3
+      vertex 63.6903 81.6916 7.5
+      vertex 63.3976 81.6546 7.5
+    endloop
+  endfacet
+  facet normal 0.125411 -0.992105 0
+    outer loop
+      vertex 63.6903 81.6916 7.5
+      vertex 63.3976 81.6546 3
+      vertex 63.6903 81.6916 3
+    endloop
+  endfacet
+  facet normal -0.951061 -0.309002 0
+    outer loop
+      vertex 61.065 83.1349 3
+      vertex 60.9738 83.4156 7.5
+      vertex 60.9738 83.4156 3
+    endloop
+  endfacet
+  facet normal -0.951061 -0.309002 0
+    outer loop
+      vertex 60.9738 83.4156 7.5
+      vertex 61.065 83.1349 3
+      vertex 61.065 83.1349 7.5
+    endloop
+  endfacet
+  facet normal -0.982288 0.187377 0
+    outer loop
+      vertex 60.9185 84.2945 3
+      vertex 60.9738 84.5844 7.5
+      vertex 60.9738 84.5844 3
+    endloop
+  endfacet
+  facet normal -0.982288 0.187377 0
+    outer loop
+      vertex 60.9738 84.5844 7.5
+      vertex 60.9185 84.2945 3
+      vertex 60.9185 84.2945 7.5
+    endloop
+  endfacet
+  facet normal 0.998033 -0.0626948 0
+    outer loop
+      vertex 65.5815 83.7055 7.5
+      vertex 65.6 84 3
+      vertex 65.6 84 7.5
+    endloop
+  endfacet
+  facet normal 0.998033 -0.0626948 0
+    outer loop
+      vertex 65.6 84 3
+      vertex 65.5815 83.7055 7.5
+      vertex 65.5815 83.7055 3
+    endloop
+  endfacet
+  facet normal -0.684392 -0.729114 0
+    outer loop
+      vertex 61.5369 82.3913 3
+      vertex 61.7521 82.1893 7.5
+      vertex 61.5369 82.3913 7.5
+    endloop
+  endfacet
+  facet normal -0.684392 -0.729114 -0
+    outer loop
+      vertex 61.7521 82.1893 7.5
+      vertex 61.5369 82.3913 3
+      vertex 61.7521 82.1893 3
+    endloop
+  endfacet
+  facet normal -0.998033 -0.0626948 0
+    outer loop
+      vertex 60.9185 83.7055 3
+      vertex 60.9 84 7.5
+      vertex 60.9 84 3
+    endloop
+  endfacet
+  facet normal -0.998033 -0.0626948 0
+    outer loop
+      vertex 60.9 84 7.5
+      vertex 60.9185 83.7055 3
+      vertex 60.9185 83.7055 7.5
+    endloop
+  endfacet
+  facet normal 0.58795 -0.808897 0
+    outer loop
+      vertex 64.5092 82.0158 3
+      vertex 64.7479 82.1893 7.5
+      vertex 64.5092 82.0158 7.5
+    endloop
+  endfacet
+  facet normal 0.58795 -0.808897 0
+    outer loop
+      vertex 64.7479 82.1893 7.5
+      vertex 64.5092 82.0158 3
+      vertex 64.7479 82.1893 3
+    endloop
+  endfacet
+  facet normal -0.125411 -0.992105 0
+    outer loop
+      vertex 62.8097 81.6916 3
+      vertex 63.1024 81.6546 7.5
+      vertex 62.8097 81.6916 7.5
+    endloop
+  endfacet
+  facet normal -0.125411 -0.992105 -0
+    outer loop
+      vertex 63.1024 81.6546 7.5
+      vertex 62.8097 81.6916 3
+      vertex 63.1024 81.6546 3
+    endloop
+  endfacet
+  facet normal 0.684392 -0.729114 0
+    outer loop
+      vertex 64.7479 82.1893 3
+      vertex 64.9631 82.3913 7.5
+      vertex 64.7479 82.1893 7.5
+    endloop
+  endfacet
+  facet normal 0.684392 -0.729114 0
+    outer loop
+      vertex 64.9631 82.3913 7.5
+      vertex 64.7479 82.1893 3
+      vertex 64.9631 82.3913 3
+    endloop
+  endfacet
+  facet normal 0.58795 0.808897 -0
+    outer loop
+      vertex 64.7479 85.8107 3
+      vertex 64.5092 85.9842 7.5
+      vertex 64.7479 85.8107 7.5
+    endloop
+  endfacet
+  facet normal 0.58795 0.808897 0
+    outer loop
+      vertex 64.5092 85.9842 7.5
+      vertex 64.7479 85.8107 3
+      vertex 64.5092 85.9842 3
+    endloop
+  endfacet
+  facet normal 0.770549 -0.63738 0
+    outer loop
+      vertex 64.9631 82.3913 7.5
+      vertex 65.1512 82.6187 3
+      vertex 65.1512 82.6187 7.5
+    endloop
+  endfacet
+  facet normal 0.770549 -0.63738 0
+    outer loop
+      vertex 65.1512 82.6187 3
+      vertex 64.9631 82.3913 7.5
+      vertex 64.9631 82.3913 3
+    endloop
+  endfacet
+  facet normal 0.48174 0.876314 -0
+    outer loop
+      vertex 64.5092 85.9842 3
+      vertex 64.3775 86.0566 7.5
+      vertex 64.5092 85.9842 7.5
+    endloop
+  endfacet
+  facet normal 0.48174 0.876314 0
+    outer loop
+      vertex 64.3775 86.0566 7.5
+      vertex 64.5092 85.9842 3
+      vertex 64.3775 86.0566 3
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 63.1024 81.6546 3
+      vertex 63.3976 81.6546 7.5
+      vertex 63.1024 81.6546 7.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 63.3976 81.6546 7.5
+      vertex 63.1024 81.6546 3
+      vertex 63.3976 81.6546 3
+    endloop
+  endfacet
+  facet normal -0.951061 0.309002 0
+    outer loop
+      vertex 60.9738 84.5844 3
+      vertex 61.065 84.8651 7.5
+      vertex 61.065 84.8651 3
+    endloop
+  endfacet
+  facet normal -0.951061 0.309002 0
+    outer loop
+      vertex 61.065 84.8651 7.5
+      vertex 60.9738 84.5844 3
+      vertex 60.9738 84.5844 7.5
+    endloop
+  endfacet
+  facet normal -0.90475 0.425944 0
+    outer loop
+      vertex 61.065 84.8651 3
+      vertex 61.1907 85.1321 7.5
+      vertex 61.1907 85.1321 3
+    endloop
+  endfacet
+  facet normal -0.90475 0.425944 0
+    outer loop
+      vertex 61.1907 85.1321 7.5
+      vertex 61.065 84.8651 3
+      vertex 61.065 84.8651 7.5
+    endloop
+  endfacet
+  facet normal -0.8444 -0.535713 0
+    outer loop
+      vertex 61.3488 82.6187 3
+      vertex 61.1907 82.8679 7.5
+      vertex 61.1907 82.8679 3
+    endloop
+  endfacet
+  facet normal -0.8444 -0.535713 0
+    outer loop
+      vertex 61.1907 82.8679 7.5
+      vertex 61.3488 82.6187 3
+      vertex 61.3488 82.6187 7.5
+    endloop
+  endfacet
+  facet normal -0.368293 -0.92971 0
+    outer loop
+      vertex 62.2494 81.8737 3
+      vertex 62.5238 81.765 7.5
+      vertex 62.2494 81.8737 7.5
+    endloop
+  endfacet
+  facet normal -0.368293 -0.92971 -0
+    outer loop
+      vertex 62.5238 81.765 7.5
+      vertex 62.2494 81.8737 3
+      vertex 62.5238 81.765 3
+    endloop
+  endfacet
+  facet normal -0.248669 -0.968589 0
+    outer loop
+      vertex 62.5238 81.765 3
+      vertex 62.8097 81.6916 7.5
+      vertex 62.5238 81.765 7.5
+    endloop
+  endfacet
+  facet normal -0.248669 -0.968589 -0
+    outer loop
+      vertex 62.8097 81.6916 7.5
+      vertex 62.5238 81.765 3
+      vertex 62.8097 81.6916 3
+    endloop
+  endfacet
+  facet normal -0.58795 -0.808897 0
+    outer loop
+      vertex 61.7521 82.1893 3
+      vertex 61.9908 82.0158 7.5
+      vertex 61.7521 82.1893 7.5
+    endloop
+  endfacet
+  facet normal -0.58795 -0.808897 -0
+    outer loop
+      vertex 61.9908 82.0158 7.5
+      vertex 61.7521 82.1893 3
+      vertex 61.9908 82.0158 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.5 84 7.5
+      vertex 65.6 84 7.5
+      vertex 65.5815 84.2945 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.4901 84.1567 7.5
+      vertex 65.5815 84.2945 7.5
+      vertex 65.5262 84.5844 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.6 84 7.5
+      vertex 64.5 84 7.5
+      vertex 65.5815 83.7055 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.4607 84.3109 7.5
+      vertex 65.5262 84.5844 7.5
+      vertex 65.435 84.8651 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.4901 83.8433 7.5
+      vertex 65.5815 83.7055 7.5
+      vertex 64.5 84 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.4122 84.4602 7.5
+      vertex 65.435 84.8651 7.5
+      vertex 65.3093 85.1321 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.5815 83.7055 7.5
+      vertex 64.4901 83.8433 7.5
+      vertex 65.5262 83.4156 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.3454 84.6022 7.5
+      vertex 65.3093 85.1321 7.5
+      vertex 65.1512 85.3813 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.4607 83.6891 7.5
+      vertex 65.5262 83.4156 7.5
+      vertex 64.4901 83.8433 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.2613 84.7347 7.5
+      vertex 65.1512 85.3813 7.5
+      vertex 64.9631 85.6087 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.5262 83.4156 7.5
+      vertex 64.4607 83.6891 7.5
+      vertex 65.435 83.1349 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.1612 84.8557 7.5
+      vertex 64.9631 85.6087 7.5
+      vertex 64.7479 85.8107 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.4122 83.5398 7.5
+      vertex 65.435 83.1349 7.5
+      vertex 64.4607 83.6891 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.1964 85.9782 7.5
+      vertex 64.7479 85.8107 7.5
+      vertex 64.5092 85.9842 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.435 83.1349 7.5
+      vertex 64.4122 83.5398 7.5
+      vertex 65.3093 82.8679 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.3454 83.3978 7.5
+      vertex 65.3093 82.8679 7.5
+      vertex 64.4122 83.5398 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.5815 84.2945 7.5
+      vertex 64.4901 84.1567 7.5
+      vertex 64.5 84 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.5262 84.5844 7.5
+      vertex 64.4607 84.3109 7.5
+      vertex 64.4901 84.1567 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.435 84.8651 7.5
+      vertex 64.4122 84.4602 7.5
+      vertex 64.4607 84.3109 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.1964 85.9782 7.5
+      vertex 64.5092 85.9842 7.5
+      vertex 64.3775 86.0566 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.3093 85.1321 7.5
+      vertex 64.3454 84.6022 7.5
+      vertex 64.4122 84.4602 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.1512 85.3813 7.5
+      vertex 64.2613 84.7347 7.5
+      vertex 64.3454 84.6022 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.7479 85.8107 7.5
+      vertex 64.1964 85.9782 7.5
+      vertex 64.0468 84.9631 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.9631 85.6087 7.5
+      vertex 64.1612 84.8557 7.5
+      vertex 64.2613 84.7347 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.7479 85.8107 7.5
+      vertex 64.0468 84.9631 7.5
+      vertex 64.1612 84.8557 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.9198 85.0554 7.5
+      vertex 64.1964 85.9782 7.5
+      vertex 64.0043 85.9091 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.1964 85.9782 7.5
+      vertex 63.9198 85.0554 7.5
+      vertex 64.0468 84.9631 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.7822 85.131 7.5
+      vertex 64.0043 85.9091 7.5
+      vertex 63.8082 85.8521 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.0043 85.9091 7.5
+      vertex 63.7822 85.131 7.5
+      vertex 63.9198 85.0554 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.8082 85.8521 7.5
+      vertex 63.6363 85.1888 7.5
+      vertex 63.7822 85.131 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.609 85.8076 7.5
+      vertex 63.6363 85.1888 7.5
+      vertex 63.8082 85.8521 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.609 85.8076 7.5
+      vertex 63.4842 85.2279 7.5
+      vertex 63.6363 85.1888 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.4073 85.7756 7.5
+      vertex 63.4842 85.2279 7.5
+      vertex 63.609 85.8076 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.4073 85.7756 7.5
+      vertex 63.3285 85.2475 7.5
+      vertex 63.4842 85.2279 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.2041 85.7564 7.5
+      vertex 63.3285 85.2475 7.5
+      vertex 63.4073 85.7756 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.2041 85.7564 7.5
+      vertex 63.1715 85.2475 7.5
+      vertex 63.3285 85.2475 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63 85.75 7.5
+      vertex 63.1715 85.2475 7.5
+      vertex 63.2041 85.7564 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.1715 85.2475 7.5
+      vertex 63 85.75 7.5
+      vertex 63.0158 85.2279 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.7959 85.7564 7.5
+      vertex 63.0158 85.2279 7.5
+      vertex 63 85.75 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.0158 85.2279 7.5
+      vertex 62.7959 85.7564 7.5
+      vertex 62.8637 85.1888 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.7959 85.7564 7.5
+      vertex 62.7178 85.131 7.5
+      vertex 62.8637 85.1888 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.5927 85.7756 7.5
+      vertex 62.7178 85.131 7.5
+      vertex 62.7959 85.7564 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.5927 85.7756 7.5
+      vertex 62.5802 85.0554 7.5
+      vertex 62.7178 85.131 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.391 85.8076 7.5
+      vertex 62.5802 85.0554 7.5
+      vertex 62.5927 85.7756 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.5802 85.0554 7.5
+      vertex 62.391 85.8076 7.5
+      vertex 62.4532 84.9631 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.1918 85.8521 7.5
+      vertex 62.4532 84.9631 7.5
+      vertex 62.391 85.8076 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.4532 84.9631 7.5
+      vertex 62.1918 85.8521 7.5
+      vertex 62.3388 84.8557 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 61.5369 85.6087 7.5
+      vertex 62.3388 84.8557 7.5
+      vertex 62.1918 85.8521 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.3388 84.8557 7.5
+      vertex 61.5369 85.6087 7.5
+      vertex 62.2387 84.7347 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 61.3488 85.3813 7.5
+      vertex 62.2387 84.7347 7.5
+      vertex 61.5369 85.6087 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.2387 84.7347 7.5
+      vertex 61.3488 85.3813 7.5
+      vertex 62.1546 84.6022 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 61.1907 85.1321 7.5
+      vertex 62.1546 84.6022 7.5
+      vertex 61.3488 85.3813 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.1546 84.6022 7.5
+      vertex 61.1907 85.1321 7.5
+      vertex 62.0878 84.4602 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.5369 85.6087 7.5
+      vertex 62.1918 85.8521 7.5
+      vertex 61.9957 85.9091 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.3093 82.8679 7.5
+      vertex 64.3454 83.3978 7.5
+      vertex 65.1512 82.6187 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.2613 83.2653 7.5
+      vertex 65.1512 82.6187 7.5
+      vertex 64.3454 83.3978 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.1512 82.6187 7.5
+      vertex 64.2613 83.2653 7.5
+      vertex 64.9631 82.3913 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.1612 83.1443 7.5
+      vertex 64.9631 82.3913 7.5
+      vertex 64.2613 83.2653 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.9631 82.3913 7.5
+      vertex 64.1612 83.1443 7.5
+      vertex 64.7479 82.1893 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.0468 83.0369 7.5
+      vertex 64.7479 82.1893 7.5
+      vertex 64.1612 83.1443 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.7479 82.1893 7.5
+      vertex 64.0468 83.0369 7.5
+      vertex 64.5092 82.0158 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.9198 82.9446 7.5
+      vertex 64.5092 82.0158 7.5
+      vertex 64.0468 83.0369 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.5092 82.0158 7.5
+      vertex 63.9198 82.9446 7.5
+      vertex 64.2506 81.8737 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.7822 82.869 7.5
+      vertex 64.2506 81.8737 7.5
+      vertex 63.9198 82.9446 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.2506 81.8737 7.5
+      vertex 63.7822 82.869 7.5
+      vertex 63.9762 81.765 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.6363 82.8112 7.5
+      vertex 63.9762 81.765 7.5
+      vertex 63.7822 82.869 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.9762 81.765 7.5
+      vertex 63.6363 82.8112 7.5
+      vertex 63.6903 81.6916 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.4842 82.7721 7.5
+      vertex 63.6903 81.6916 7.5
+      vertex 63.6363 82.8112 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.4842 82.7721 7.5
+      vertex 63.3976 81.6546 7.5
+      vertex 63.6903 81.6916 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.3285 82.7525 7.5
+      vertex 63.3976 81.6546 7.5
+      vertex 63.4842 82.7721 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.1715 82.7525 7.5
+      vertex 63.3976 81.6546 7.5
+      vertex 63.3285 82.7525 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.1715 82.7525 7.5
+      vertex 63.1024 81.6546 7.5
+      vertex 63.3976 81.6546 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.0158 82.7721 7.5
+      vertex 63.1024 81.6546 7.5
+      vertex 63.1715 82.7525 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.8097 81.6916 7.5
+      vertex 63.0158 82.7721 7.5
+      vertex 62.8637 82.8112 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.0158 82.7721 7.5
+      vertex 62.8097 81.6916 7.5
+      vertex 63.1024 81.6546 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.5238 81.765 7.5
+      vertex 62.8637 82.8112 7.5
+      vertex 62.7178 82.869 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.2494 81.8737 7.5
+      vertex 62.7178 82.869 7.5
+      vertex 62.5802 82.9446 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.8637 82.8112 7.5
+      vertex 62.5238 81.765 7.5
+      vertex 62.8097 81.6916 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.9908 82.0158 7.5
+      vertex 62.5802 82.9446 7.5
+      vertex 62.4532 83.0369 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.7521 82.1893 7.5
+      vertex 62.4532 83.0369 7.5
+      vertex 62.3388 83.1443 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.7178 82.869 7.5
+      vertex 62.2494 81.8737 7.5
+      vertex 62.5238 81.765 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.5369 82.3913 7.5
+      vertex 62.3388 83.1443 7.5
+      vertex 62.2387 83.2653 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.3488 82.6187 7.5
+      vertex 62.2387 83.2653 7.5
+      vertex 62.1546 83.3978 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.1907 82.8679 7.5
+      vertex 62.1546 83.3978 7.5
+      vertex 62.0878 83.5398 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.065 83.1349 7.5
+      vertex 62.0878 83.5398 7.5
+      vertex 62.0393 83.6891 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9738 83.4156 7.5
+      vertex 62.0393 83.6891 7.5
+      vertex 62.0099 83.8433 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.5802 82.9446 7.5
+      vertex 61.9908 82.0158 7.5
+      vertex 62.2494 81.8737 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9185 83.7055 7.5
+      vertex 62.0099 83.8433 7.5
+      vertex 62 84 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 61.065 84.8651 7.5
+      vertex 62.0878 84.4602 7.5
+      vertex 61.1907 85.1321 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.7521 85.8107 7.5
+      vertex 61.9957 85.9091 7.5
+      vertex 61.9233 85.9351 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.9957 85.9091 7.5
+      vertex 61.7521 85.8107 7.5
+      vertex 61.5369 85.6087 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.4532 83.0369 7.5
+      vertex 61.7521 82.1893 7.5
+      vertex 61.9908 82.0158 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.0878 84.4602 7.5
+      vertex 61.065 84.8651 7.5
+      vertex 62.0393 84.3109 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.3388 83.1443 7.5
+      vertex 61.5369 82.3913 7.5
+      vertex 61.7521 82.1893 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.9738 84.5844 7.5
+      vertex 62.0393 84.3109 7.5
+      vertex 61.065 84.8651 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.2387 83.2653 7.5
+      vertex 61.3488 82.6187 7.5
+      vertex 61.5369 82.3913 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.0393 84.3109 7.5
+      vertex 60.9738 84.5844 7.5
+      vertex 62.0099 84.1567 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.1546 83.3978 7.5
+      vertex 61.1907 82.8679 7.5
+      vertex 61.3488 82.6187 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.9185 84.2945 7.5
+      vertex 62.0099 84.1567 7.5
+      vertex 60.9738 84.5844 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.0878 83.5398 7.5
+      vertex 61.065 83.1349 7.5
+      vertex 61.1907 82.8679 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.0099 84.1567 7.5
+      vertex 60.9185 84.2945 7.5
+      vertex 62 84 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.0393 83.6891 7.5
+      vertex 60.9738 83.4156 7.5
+      vertex 61.065 83.1349 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 7.5
+      vertex 62 84 7.5
+      vertex 60.9185 84.2945 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.0099 83.8433 7.5
+      vertex 60.9185 83.7055 7.5
+      vertex 60.9738 83.4156 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62 84 7.5
+      vertex 60.9 84 7.5
+      vertex 60.9185 83.7055 7.5
+    endloop
+  endfacet
+  facet normal -0.684392 0.729114 0
+    outer loop
+      vertex 61.7521 85.8107 3
+      vertex 61.5369 85.6087 7.5
+      vertex 61.7521 85.8107 7.5
+    endloop
+  endfacet
+  facet normal -0.684392 0.729114 0
+    outer loop
+      vertex 61.5369 85.6087 7.5
+      vertex 61.7521 85.8107 3
+      vertex 61.5369 85.6087 3
+    endloop
+  endfacet
+  facet normal 0.982288 -0.187377 0
+    outer loop
+      vertex 65.5262 83.4156 7.5
+      vertex 65.5815 83.7055 3
+      vertex 65.5815 83.7055 7.5
+    endloop
+  endfacet
+  facet normal 0.982288 -0.187377 0
+    outer loop
+      vertex 65.5815 83.7055 3
+      vertex 65.5262 83.4156 7.5
+      vertex 65.5262 83.4156 3
+    endloop
+  endfacet
+  facet normal -0.770549 -0.63738 0
+    outer loop
+      vertex 61.5369 82.3913 3
+      vertex 61.3488 82.6187 7.5
+      vertex 61.3488 82.6187 3
+    endloop
+  endfacet
+  facet normal -0.770549 -0.63738 0
+    outer loop
+      vertex 61.3488 82.6187 7.5
+      vertex 61.5369 82.3913 3
+      vertex 61.5369 82.3913 7.5
+    endloop
+  endfacet
+  facet normal -0.8444 0.535713 0
+    outer loop
+      vertex 61.1907 85.1321 3
+      vertex 61.3488 85.3813 7.5
+      vertex 61.3488 85.3813 3
+    endloop
+  endfacet
+  facet normal -0.8444 0.535713 0
+    outer loop
+      vertex 61.3488 85.3813 7.5
+      vertex 61.1907 85.1321 3
+      vertex 61.1907 85.1321 7.5
+    endloop
+  endfacet
+  facet normal -0.998033 0.0626948 0
+    outer loop
+      vertex 60.9 84 3
+      vertex 60.9185 84.2945 7.5
+      vertex 60.9185 84.2945 3
+    endloop
+  endfacet
+  facet normal -0.998033 0.0626948 0
+    outer loop
+      vertex 60.9185 84.2945 7.5
+      vertex 60.9 84 3
+      vertex 60.9 84 7.5
+    endloop
+  endfacet
+  facet normal -0.8444 0.535713 0
+    outer loop
+      vertex 61.1907 57.1321 3
+      vertex 61.3488 57.3813 7.5
+      vertex 61.3488 57.3813 3
+    endloop
+  endfacet
+  facet normal -0.8444 0.535713 0
+    outer loop
+      vertex 61.3488 57.3813 7.5
+      vertex 61.1907 57.1321 3
+      vertex 61.1907 57.1321 7.5
+    endloop
+  endfacet
+  facet normal -0.684392 -0.729114 0
+    outer loop
+      vertex 61.5369 54.3913 3
+      vertex 61.7521 54.1893 7.5
+      vertex 61.5369 54.3913 7.5
+    endloop
+  endfacet
+  facet normal -0.684392 -0.729114 -0
+    outer loop
+      vertex 61.7521 54.1893 7.5
+      vertex 61.5369 54.3913 3
+      vertex 61.7521 54.1893 3
+    endloop
+  endfacet
+  facet normal 0.982288 0.187377 0
+    outer loop
+      vertex 65.5815 56.2945 7.5
+      vertex 65.5262 56.5844 3
+      vertex 65.5262 56.5844 7.5
+    endloop
+  endfacet
+  facet normal 0.982288 0.187377 0
+    outer loop
+      vertex 65.5262 56.5844 3
+      vertex 65.5815 56.2945 7.5
+      vertex 65.5815 56.2945 3
+    endloop
+  endfacet
+  facet normal 0.998033 0.0626948 0
+    outer loop
+      vertex 65.6 56 7.5
+      vertex 65.5815 56.2945 3
+      vertex 65.5815 56.2945 7.5
+    endloop
+  endfacet
+  facet normal 0.998033 0.0626948 0
+    outer loop
+      vertex 65.5815 56.2945 3
+      vertex 65.6 56 7.5
+      vertex 65.6 56 3
+    endloop
+  endfacet
+  facet normal 0.951061 0.309002 0
+    outer loop
+      vertex 65.5262 56.5844 7.5
+      vertex 65.435 56.8651 3
+      vertex 65.435 56.8651 7.5
+    endloop
+  endfacet
+  facet normal 0.951061 0.309002 0
+    outer loop
+      vertex 65.435 56.8651 3
+      vertex 65.5262 56.5844 7.5
+      vertex 65.5262 56.5844 3
+    endloop
+  endfacet
+  facet normal 0.48158 -0.876402 0
+    outer loop
+      vertex 64.2506 53.8737 3
+      vertex 64.5092 54.0158 7.5
+      vertex 64.2506 53.8737 7.5
+    endloop
+  endfacet
+  facet normal 0.48158 -0.876402 0
+    outer loop
+      vertex 64.5092 54.0158 7.5
+      vertex 64.2506 53.8737 3
+      vertex 64.5092 54.0158 3
+    endloop
+  endfacet
+  facet normal -0.998033 -0.0626948 0
+    outer loop
+      vertex 60.9185 55.7055 3
+      vertex 60.9 56 7.5
+      vertex 60.9 56 3
+    endloop
+  endfacet
+  facet normal -0.998033 -0.0626948 0
+    outer loop
+      vertex 60.9 56 7.5
+      vertex 60.9185 55.7055 3
+      vertex 60.9185 55.7055 7.5
+    endloop
+  endfacet
+  facet normal 0.248669 -0.968589 0
+    outer loop
+      vertex 63.6903 53.6916 3
+      vertex 63.9762 53.765 7.5
+      vertex 63.6903 53.6916 7.5
+    endloop
+  endfacet
+  facet normal 0.248669 -0.968589 0
+    outer loop
+      vertex 63.9762 53.765 7.5
+      vertex 63.6903 53.6916 3
+      vertex 63.9762 53.765 3
+    endloop
+  endfacet
+  facet normal 0.125411 -0.992105 0
+    outer loop
+      vertex 63.3976 53.6546 3
+      vertex 63.6903 53.6916 7.5
+      vertex 63.3976 53.6546 7.5
+    endloop
+  endfacet
+  facet normal 0.125411 -0.992105 0
+    outer loop
+      vertex 63.6903 53.6916 7.5
+      vertex 63.3976 53.6546 3
+      vertex 63.6903 53.6916 3
+    endloop
+  endfacet
+  facet normal -0.684392 0.729114 0
+    outer loop
+      vertex 61.7521 57.8107 3
+      vertex 61.5369 57.6087 7.5
+      vertex 61.7521 57.8107 7.5
+    endloop
+  endfacet
+  facet normal -0.684392 0.729114 0
+    outer loop
+      vertex 61.5369 57.6087 7.5
+      vertex 61.7521 57.8107 3
+      vertex 61.5369 57.6087 3
+    endloop
+  endfacet
+  facet normal 0.770549 -0.63738 0
+    outer loop
+      vertex 64.9631 54.3913 7.5
+      vertex 65.1512 54.6187 3
+      vertex 65.1512 54.6187 7.5
+    endloop
+  endfacet
+  facet normal 0.770549 -0.63738 0
+    outer loop
+      vertex 65.1512 54.6187 3
+      vertex 64.9631 54.3913 7.5
+      vertex 64.9631 54.3913 3
+    endloop
+  endfacet
+  facet normal 0.368293 -0.92971 0
+    outer loop
+      vertex 63.9762 53.765 3
+      vertex 64.2506 53.8737 7.5
+      vertex 63.9762 53.765 7.5
+    endloop
+  endfacet
+  facet normal 0.368293 -0.92971 0
+    outer loop
+      vertex 64.2506 53.8737 7.5
+      vertex 63.9762 53.765 3
+      vertex 64.2506 53.8737 3
+    endloop
+  endfacet
+  facet normal 0.8444 0.535713 0
+    outer loop
+      vertex 65.3093 57.1321 7.5
+      vertex 65.1512 57.3813 3
+      vertex 65.1512 57.3813 7.5
+    endloop
+  endfacet
+  facet normal 0.8444 0.535713 0
+    outer loop
+      vertex 65.1512 57.3813 3
+      vertex 65.3093 57.1321 7.5
+      vertex 65.3093 57.1321 3
+    endloop
+  endfacet
+  facet normal 0.90475 0.425944 0
+    outer loop
+      vertex 65.435 56.8651 7.5
+      vertex 65.3093 57.1321 3
+      vertex 65.3093 57.1321 7.5
+    endloop
+  endfacet
+  facet normal 0.90475 0.425944 0
+    outer loop
+      vertex 65.3093 57.1321 3
+      vertex 65.435 56.8651 7.5
+      vertex 65.435 56.8651 3
+    endloop
+  endfacet
+  facet normal 0.951061 -0.309002 0
+    outer loop
+      vertex 65.435 55.1349 7.5
+      vertex 65.5262 55.4156 3
+      vertex 65.5262 55.4156 7.5
+    endloop
+  endfacet
+  facet normal 0.951061 -0.309002 0
+    outer loop
+      vertex 65.5262 55.4156 3
+      vertex 65.435 55.1349 7.5
+      vertex 65.435 55.1349 3
+    endloop
+  endfacet
+  facet normal 0.368293 0.92971 -0
+    outer loop
+      vertex 64.2506 58.1263 3
+      vertex 63.9762 58.235 7.5
+      vertex 64.2506 58.1263 7.5
+    endloop
+  endfacet
+  facet normal 0.368293 0.92971 0
+    outer loop
+      vertex 63.9762 58.235 7.5
+      vertex 64.2506 58.1263 3
+      vertex 63.9762 58.235 3
+    endloop
+  endfacet
+  facet normal -0.982288 -0.187377 0
+    outer loop
+      vertex 60.9738 55.4156 3
+      vertex 60.9185 55.7055 7.5
+      vertex 60.9185 55.7055 3
+    endloop
+  endfacet
+  facet normal -0.982288 -0.187377 0
+    outer loop
+      vertex 60.9185 55.7055 7.5
+      vertex 60.9738 55.4156 3
+      vertex 60.9738 55.4156 7.5
+    endloop
+  endfacet
+  facet normal -0.248669 0.968589 0
+    outer loop
+      vertex 62.8097 58.3084 3
+      vertex 62.5238 58.235 7.5
+      vertex 62.8097 58.3084 7.5
+    endloop
+  endfacet
+  facet normal -0.248669 0.968589 0
+    outer loop
+      vertex 62.5238 58.235 7.5
+      vertex 62.8097 58.3084 3
+      vertex 62.5238 58.235 3
+    endloop
+  endfacet
+  facet normal -0.248669 -0.968589 0
+    outer loop
+      vertex 62.5238 53.765 3
+      vertex 62.8097 53.6916 7.5
+      vertex 62.5238 53.765 7.5
+    endloop
+  endfacet
+  facet normal -0.248669 -0.968589 -0
+    outer loop
+      vertex 62.8097 53.6916 7.5
+      vertex 62.5238 53.765 3
+      vertex 62.8097 53.6916 3
+    endloop
+  endfacet
+  facet normal -0.951061 -0.309002 0
+    outer loop
+      vertex 61.065 55.1349 3
+      vertex 60.9738 55.4156 7.5
+      vertex 60.9738 55.4156 3
+    endloop
+  endfacet
+  facet normal -0.951061 -0.309002 0
+    outer loop
+      vertex 60.9738 55.4156 7.5
+      vertex 61.065 55.1349 3
+      vertex 61.065 55.1349 7.5
+    endloop
+  endfacet
+  facet normal -0.90475 0.425944 0
+    outer loop
+      vertex 61.065 56.8651 3
+      vertex 61.1907 57.1321 7.5
+      vertex 61.1907 57.1321 3
+    endloop
+  endfacet
+  facet normal -0.90475 0.425944 0
+    outer loop
+      vertex 61.1907 57.1321 7.5
+      vertex 61.065 56.8651 3
+      vertex 61.065 56.8651 7.5
+    endloop
+  endfacet
+  facet normal 0.58795 -0.808897 0
+    outer loop
+      vertex 64.5092 54.0158 3
+      vertex 64.7479 54.1893 7.5
+      vertex 64.5092 54.0158 7.5
+    endloop
+  endfacet
+  facet normal 0.58795 -0.808897 0
+    outer loop
+      vertex 64.7479 54.1893 7.5
+      vertex 64.5092 54.0158 3
+      vertex 64.7479 54.1893 3
+    endloop
+  endfacet
+  facet normal 0.684392 -0.729114 0
+    outer loop
+      vertex 64.7479 54.1893 3
+      vertex 64.9631 54.3913 7.5
+      vertex 64.7479 54.1893 7.5
+    endloop
+  endfacet
+  facet normal 0.684392 -0.729114 0
+    outer loop
+      vertex 64.9631 54.3913 7.5
+      vertex 64.7479 54.1893 3
+      vertex 64.9631 54.3913 3
+    endloop
+  endfacet
+  facet normal 0.58795 0.808897 -0
+    outer loop
+      vertex 64.7479 57.8107 3
+      vertex 64.5092 57.9842 7.5
+      vertex 64.7479 57.8107 7.5
+    endloop
+  endfacet
+  facet normal 0.58795 0.808897 0
+    outer loop
+      vertex 64.5092 57.9842 7.5
+      vertex 64.7479 57.8107 3
+      vertex 64.5092 57.9842 3
+    endloop
+  endfacet
+  facet normal -0.368293 0.92971 0
+    outer loop
+      vertex 62.5238 58.235 3
+      vertex 62.2494 58.1263 7.5
+      vertex 62.5238 58.235 7.5
+    endloop
+  endfacet
+  facet normal -0.368293 0.92971 0
+    outer loop
+      vertex 62.2494 58.1263 7.5
+      vertex 62.5238 58.235 3
+      vertex 62.2494 58.1263 3
+    endloop
+  endfacet
+  facet normal 0.998033 -0.0626948 0
+    outer loop
+      vertex 65.5815 55.7055 7.5
+      vertex 65.6 56 3
+      vertex 65.6 56 7.5
+    endloop
+  endfacet
+  facet normal 0.998033 -0.0626948 0
+    outer loop
+      vertex 65.6 56 3
+      vertex 65.5815 55.7055 7.5
+      vertex 65.5815 55.7055 3
+    endloop
+  endfacet
+  facet normal -0.90475 -0.425944 0
+    outer loop
+      vertex 61.1907 54.8679 3
+      vertex 61.065 55.1349 7.5
+      vertex 61.065 55.1349 3
+    endloop
+  endfacet
+  facet normal -0.90475 -0.425944 0
+    outer loop
+      vertex 61.065 55.1349 7.5
+      vertex 61.1907 54.8679 3
+      vertex 61.1907 54.8679 7.5
+    endloop
+  endfacet
+  facet normal -0.48158 0.876402 0
+    outer loop
+      vertex 62.2494 58.1263 3
+      vertex 61.9908 57.9842 7.5
+      vertex 62.2494 58.1263 7.5
+    endloop
+  endfacet
+  facet normal -0.48158 0.876402 0
+    outer loop
+      vertex 61.9908 57.9842 7.5
+      vertex 62.2494 58.1263 3
+      vertex 61.9908 57.9842 3
+    endloop
+  endfacet
+  facet normal -0.125411 -0.992105 0
+    outer loop
+      vertex 62.8097 53.6916 3
+      vertex 63.1024 53.6546 7.5
+      vertex 62.8097 53.6916 7.5
+    endloop
+  endfacet
+  facet normal -0.125411 -0.992105 -0
+    outer loop
+      vertex 63.1024 53.6546 7.5
+      vertex 62.8097 53.6916 3
+      vertex 63.1024 53.6546 3
+    endloop
+  endfacet
+  facet normal -0.48158 -0.876402 0
+    outer loop
+      vertex 61.9908 54.0158 3
+      vertex 62.2494 53.8737 7.5
+      vertex 61.9908 54.0158 7.5
+    endloop
+  endfacet
+  facet normal -0.48158 -0.876402 -0
+    outer loop
+      vertex 62.2494 53.8737 7.5
+      vertex 61.9908 54.0158 3
+      vertex 62.2494 53.8737 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.5 56 7.5
+      vertex 65.6 56 7.5
+      vertex 65.5815 56.2945 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.4901 56.1567 7.5
+      vertex 65.5815 56.2945 7.5
+      vertex 65.5262 56.5844 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.6 56 7.5
+      vertex 64.5 56 7.5
+      vertex 65.5815 55.7055 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.4607 56.3109 7.5
+      vertex 65.5262 56.5844 7.5
+      vertex 65.435 56.8651 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.4901 55.8433 7.5
+      vertex 65.5815 55.7055 7.5
+      vertex 64.5 56 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.4122 56.4602 7.5
+      vertex 65.435 56.8651 7.5
+      vertex 65.3093 57.1321 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.5815 55.7055 7.5
+      vertex 64.4901 55.8433 7.5
+      vertex 65.5262 55.4156 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.3454 56.6022 7.5
+      vertex 65.3093 57.1321 7.5
+      vertex 65.1512 57.3813 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.4607 55.6891 7.5
+      vertex 65.5262 55.4156 7.5
+      vertex 64.4901 55.8433 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.2613 56.7347 7.5
+      vertex 65.1512 57.3813 7.5
+      vertex 64.9631 57.6087 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.5262 55.4156 7.5
+      vertex 64.4607 55.6891 7.5
+      vertex 65.435 55.1349 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.1612 56.8557 7.5
+      vertex 64.9631 57.6087 7.5
+      vertex 64.7479 57.8107 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.4122 55.5398 7.5
+      vertex 65.435 55.1349 7.5
+      vertex 64.4607 55.6891 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.0468 56.9631 7.5
+      vertex 64.7479 57.8107 7.5
+      vertex 64.5092 57.9842 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.435 55.1349 7.5
+      vertex 64.4122 55.5398 7.5
+      vertex 65.3093 54.8679 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.3454 55.3978 7.5
+      vertex 65.3093 54.8679 7.5
+      vertex 64.4122 55.5398 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.5815 56.2945 7.5
+      vertex 64.4901 56.1567 7.5
+      vertex 64.5 56 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.5262 56.5844 7.5
+      vertex 64.4607 56.3109 7.5
+      vertex 64.4901 56.1567 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.435 56.8651 7.5
+      vertex 64.4122 56.4602 7.5
+      vertex 64.4607 56.3109 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.3093 57.1321 7.5
+      vertex 64.3454 56.6022 7.5
+      vertex 64.4122 56.4602 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.1512 57.3813 7.5
+      vertex 64.2613 56.7347 7.5
+      vertex 64.3454 56.6022 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.9198 57.0554 7.5
+      vertex 64.5092 57.9842 7.5
+      vertex 64.2506 58.1263 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.9631 57.6087 7.5
+      vertex 64.1612 56.8557 7.5
+      vertex 64.2613 56.7347 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.7479 57.8107 7.5
+      vertex 64.0468 56.9631 7.5
+      vertex 64.1612 56.8557 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.7822 57.131 7.5
+      vertex 64.2506 58.1263 7.5
+      vertex 63.9762 58.235 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.5092 57.9842 7.5
+      vertex 63.9198 57.0554 7.5
+      vertex 64.0468 56.9631 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.2506 58.1263 7.5
+      vertex 63.7822 57.131 7.5
+      vertex 63.9198 57.0554 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.6363 57.1888 7.5
+      vertex 63.9762 58.235 7.5
+      vertex 63.6903 58.3084 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.9762 58.235 7.5
+      vertex 63.6363 57.1888 7.5
+      vertex 63.7822 57.131 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.6903 58.3084 7.5
+      vertex 63.4842 57.2279 7.5
+      vertex 63.6363 57.1888 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.3976 58.3454 7.5
+      vertex 63.4842 57.2279 7.5
+      vertex 63.6903 58.3084 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.3976 58.3454 7.5
+      vertex 63.3285 57.2475 7.5
+      vertex 63.4842 57.2279 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.3976 58.3454 7.5
+      vertex 63.1715 57.2475 7.5
+      vertex 63.3285 57.2475 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.1024 58.3454 7.5
+      vertex 63.1715 57.2475 7.5
+      vertex 63.3976 58.3454 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.1024 58.3454 7.5
+      vertex 63.0158 57.2279 7.5
+      vertex 63.1715 57.2475 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 62.8097 58.3084 7.5
+      vertex 63.0158 57.2279 7.5
+      vertex 63.1024 58.3454 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.0158 57.2279 7.5
+      vertex 62.8097 58.3084 7.5
+      vertex 62.8637 57.1888 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 62.5238 58.235 7.5
+      vertex 62.8637 57.1888 7.5
+      vertex 62.8097 58.3084 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.8637 57.1888 7.5
+      vertex 62.5238 58.235 7.5
+      vertex 62.7178 57.131 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 62.2494 58.1263 7.5
+      vertex 62.7178 57.131 7.5
+      vertex 62.5238 58.235 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.7178 57.131 7.5
+      vertex 62.2494 58.1263 7.5
+      vertex 62.5802 57.0554 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 61.9908 57.9842 7.5
+      vertex 62.5802 57.0554 7.5
+      vertex 62.2494 58.1263 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.5802 57.0554 7.5
+      vertex 61.9908 57.9842 7.5
+      vertex 62.4532 56.9631 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 61.7521 57.8107 7.5
+      vertex 62.4532 56.9631 7.5
+      vertex 61.9908 57.9842 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.4532 56.9631 7.5
+      vertex 61.7521 57.8107 7.5
+      vertex 62.3388 56.8557 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 61.5369 57.6087 7.5
+      vertex 62.3388 56.8557 7.5
+      vertex 61.7521 57.8107 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.3388 56.8557 7.5
+      vertex 61.5369 57.6087 7.5
+      vertex 62.2387 56.7347 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 61.3488 57.3813 7.5
+      vertex 62.2387 56.7347 7.5
+      vertex 61.5369 57.6087 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 61.1907 57.1321 7.5
+      vertex 62.1546 56.6022 7.5
+      vertex 61.3488 57.3813 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.2387 56.7347 7.5
+      vertex 61.3488 57.3813 7.5
+      vertex 62.1546 56.6022 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.3093 54.8679 7.5
+      vertex 64.3454 55.3978 7.5
+      vertex 65.1512 54.6187 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.2613 55.2653 7.5
+      vertex 65.1512 54.6187 7.5
+      vertex 64.3454 55.3978 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.1512 54.6187 7.5
+      vertex 64.2613 55.2653 7.5
+      vertex 64.9631 54.3913 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.1612 55.1443 7.5
+      vertex 64.9631 54.3913 7.5
+      vertex 64.2613 55.2653 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.9631 54.3913 7.5
+      vertex 64.1612 55.1443 7.5
+      vertex 64.7479 54.1893 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.0468 55.0369 7.5
+      vertex 64.7479 54.1893 7.5
+      vertex 64.1612 55.1443 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.7479 54.1893 7.5
+      vertex 64.0468 55.0369 7.5
+      vertex 64.5092 54.0158 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.9198 54.9446 7.5
+      vertex 64.5092 54.0158 7.5
+      vertex 64.0468 55.0369 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.5092 54.0158 7.5
+      vertex 63.9198 54.9446 7.5
+      vertex 64.2506 53.8737 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.7822 54.869 7.5
+      vertex 64.2506 53.8737 7.5
+      vertex 63.9198 54.9446 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.2506 53.8737 7.5
+      vertex 63.7822 54.869 7.5
+      vertex 63.9762 53.765 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.6363 54.8112 7.5
+      vertex 63.9762 53.765 7.5
+      vertex 63.7822 54.869 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.9762 53.765 7.5
+      vertex 63.6363 54.8112 7.5
+      vertex 63.6903 53.6916 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.4842 54.7721 7.5
+      vertex 63.6903 53.6916 7.5
+      vertex 63.6363 54.8112 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.4842 54.7721 7.5
+      vertex 63.3976 53.6546 7.5
+      vertex 63.6903 53.6916 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.3285 54.7525 7.5
+      vertex 63.3976 53.6546 7.5
+      vertex 63.4842 54.7721 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.1715 54.7525 7.5
+      vertex 63.3976 53.6546 7.5
+      vertex 63.3285 54.7525 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.1715 54.7525 7.5
+      vertex 63.1024 53.6546 7.5
+      vertex 63.3976 53.6546 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.0158 54.7721 7.5
+      vertex 63.1024 53.6546 7.5
+      vertex 63.1715 54.7525 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.8097 53.6916 7.5
+      vertex 63.0158 54.7721 7.5
+      vertex 62.8637 54.8112 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.0158 54.7721 7.5
+      vertex 62.8097 53.6916 7.5
+      vertex 63.1024 53.6546 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.5238 53.765 7.5
+      vertex 62.8637 54.8112 7.5
+      vertex 62.7178 54.869 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.2494 53.8737 7.5
+      vertex 62.7178 54.869 7.5
+      vertex 62.5802 54.9446 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.8637 54.8112 7.5
+      vertex 62.5238 53.765 7.5
+      vertex 62.8097 53.6916 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.9908 54.0158 7.5
+      vertex 62.5802 54.9446 7.5
+      vertex 62.4532 55.0369 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.7521 54.1893 7.5
+      vertex 62.4532 55.0369 7.5
+      vertex 62.3388 55.1443 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.7178 54.869 7.5
+      vertex 62.2494 53.8737 7.5
+      vertex 62.5238 53.765 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.5369 54.3913 7.5
+      vertex 62.3388 55.1443 7.5
+      vertex 62.2387 55.2653 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.3488 54.6187 7.5
+      vertex 62.2387 55.2653 7.5
+      vertex 62.1546 55.3978 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.1907 54.8679 7.5
+      vertex 62.1546 55.3978 7.5
+      vertex 62.0878 55.5398 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.065 55.1349 7.5
+      vertex 62.0878 55.5398 7.5
+      vertex 62.0393 55.6891 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9738 55.4156 7.5
+      vertex 62.0393 55.6891 7.5
+      vertex 62.0099 55.8433 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.5802 54.9446 7.5
+      vertex 61.9908 54.0158 7.5
+      vertex 62.2494 53.8737 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9185 55.7055 7.5
+      vertex 62.0099 55.8433 7.5
+      vertex 62 56 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.1546 56.6022 7.5
+      vertex 61.1907 57.1321 7.5
+      vertex 62.0878 56.4602 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 61.065 56.8651 7.5
+      vertex 62.0878 56.4602 7.5
+      vertex 61.1907 57.1321 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.4532 55.0369 7.5
+      vertex 61.7521 54.1893 7.5
+      vertex 61.9908 54.0158 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.0878 56.4602 7.5
+      vertex 61.065 56.8651 7.5
+      vertex 62.0393 56.3109 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.3388 55.1443 7.5
+      vertex 61.5369 54.3913 7.5
+      vertex 61.7521 54.1893 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.9738 56.5844 7.5
+      vertex 62.0393 56.3109 7.5
+      vertex 61.065 56.8651 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.2387 55.2653 7.5
+      vertex 61.3488 54.6187 7.5
+      vertex 61.5369 54.3913 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.0393 56.3109 7.5
+      vertex 60.9738 56.5844 7.5
+      vertex 62.0099 56.1567 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.1546 55.3978 7.5
+      vertex 61.1907 54.8679 7.5
+      vertex 61.3488 54.6187 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.9185 56.2945 7.5
+      vertex 62.0099 56.1567 7.5
+      vertex 60.9738 56.5844 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.0878 55.5398 7.5
+      vertex 61.065 55.1349 7.5
+      vertex 61.1907 54.8679 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.0099 56.1567 7.5
+      vertex 60.9185 56.2945 7.5
+      vertex 62 56 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.0393 55.6891 7.5
+      vertex 60.9738 55.4156 7.5
+      vertex 61.065 55.1349 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 56 7.5
+      vertex 62 56 7.5
+      vertex 60.9185 56.2945 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.0099 55.8433 7.5
+      vertex 60.9185 55.7055 7.5
+      vertex 60.9738 55.4156 7.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62 56 7.5
+      vertex 60.9 56 7.5
+      vertex 60.9185 55.7055 7.5
+    endloop
+  endfacet
+  facet normal -0.998033 0.0626948 0
+    outer loop
+      vertex 60.9 56 3
+      vertex 60.9185 56.2945 7.5
+      vertex 60.9185 56.2945 3
+    endloop
+  endfacet
+  facet normal -0.998033 0.0626948 0
+    outer loop
+      vertex 60.9185 56.2945 7.5
+      vertex 60.9 56 3
+      vertex 60.9 56 7.5
+    endloop
+  endfacet
+  facet normal 0.48158 0.876402 -0
+    outer loop
+      vertex 64.5092 57.9842 3
+      vertex 64.2506 58.1263 7.5
+      vertex 64.5092 57.9842 7.5
+    endloop
+  endfacet
+  facet normal 0.48158 0.876402 0
+    outer loop
+      vertex 64.2506 58.1263 7.5
+      vertex 64.5092 57.9842 3
+      vertex 64.2506 58.1263 3
+    endloop
+  endfacet
+  facet normal -0.58795 0.808897 0
+    outer loop
+      vertex 61.9908 57.9842 3
+      vertex 61.7521 57.8107 7.5
+      vertex 61.9908 57.9842 7.5
+    endloop
+  endfacet
+  facet normal -0.58795 0.808897 0
+    outer loop
+      vertex 61.7521 57.8107 7.5
+      vertex 61.9908 57.9842 3
+      vertex 61.7521 57.8107 3
+    endloop
+  endfacet
+  facet normal -0.58795 -0.808897 0
+    outer loop
+      vertex 61.7521 54.1893 3
+      vertex 61.9908 54.0158 7.5
+      vertex 61.7521 54.1893 7.5
+    endloop
+  endfacet
+  facet normal -0.58795 -0.808897 -0
+    outer loop
+      vertex 61.9908 54.0158 7.5
+      vertex 61.7521 54.1893 3
+      vertex 61.9908 54.0158 3
+    endloop
+  endfacet
+  facet normal -0.770549 -0.63738 0
+    outer loop
+      vertex 61.5369 54.3913 3
+      vertex 61.3488 54.6187 7.5
+      vertex 61.3488 54.6187 3
+    endloop
+  endfacet
+  facet normal -0.770549 -0.63738 0
+    outer loop
+      vertex 61.3488 54.6187 7.5
+      vertex 61.5369 54.3913 3
+      vertex 61.5369 54.3913 7.5
+    endloop
+  endfacet
+  facet normal 0.982288 -0.187377 0
+    outer loop
+      vertex 65.5262 55.4156 7.5
+      vertex 65.5815 55.7055 3
+      vertex 65.5815 55.7055 7.5
+    endloop
+  endfacet
+  facet normal 0.982288 -0.187377 0
+    outer loop
+      vertex 65.5815 55.7055 3
+      vertex 65.5262 55.4156 7.5
+      vertex 65.5262 55.4156 3
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 63.1024 53.6546 3
+      vertex 63.3976 53.6546 7.5
+      vertex 63.1024 53.6546 7.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 63.3976 53.6546 7.5
+      vertex 63.1024 53.6546 3
+      vertex 63.3976 53.6546 3
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 63.3976 58.3454 3
+      vertex 63.1024 58.3454 7.5
+      vertex 63.3976 58.3454 7.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 63.1024 58.3454 7.5
+      vertex 63.3976 58.3454 3
+      vertex 63.1024 58.3454 3
+    endloop
+  endfacet
+  facet normal -0.368293 -0.92971 0
+    outer loop
+      vertex 62.2494 53.8737 3
+      vertex 62.5238 53.765 7.5
+      vertex 62.2494 53.8737 7.5
+    endloop
+  endfacet
+  facet normal -0.368293 -0.92971 -0
+    outer loop
+      vertex 62.5238 53.765 7.5
+      vertex 62.2494 53.8737 3
+      vertex 62.5238 53.765 3
+    endloop
+  endfacet
+  facet normal 0.8444 -0.535713 0
+    outer loop
+      vertex 65.1512 54.6187 7.5
+      vertex 65.3093 54.8679 3
+      vertex 65.3093 54.8679 7.5
+    endloop
+  endfacet
+  facet normal 0.8444 -0.535713 0
+    outer loop
+      vertex 65.3093 54.8679 3
+      vertex 65.1512 54.6187 7.5
+      vertex 65.1512 54.6187 3
+    endloop
+  endfacet
+  facet normal 0.90475 -0.425944 0
+    outer loop
+      vertex 65.3093 54.8679 7.5
+      vertex 65.435 55.1349 3
+      vertex 65.435 55.1349 7.5
+    endloop
+  endfacet
+  facet normal 0.90475 -0.425944 0
+    outer loop
+      vertex 65.435 55.1349 3
+      vertex 65.3093 54.8679 7.5
+      vertex 65.3093 54.8679 3
+    endloop
+  endfacet
+  facet normal -0.125411 0.992105 0
+    outer loop
+      vertex 63.1024 58.3454 3
+      vertex 62.8097 58.3084 7.5
+      vertex 63.1024 58.3454 7.5
+    endloop
+  endfacet
+  facet normal -0.125411 0.992105 0
+    outer loop
+      vertex 62.8097 58.3084 7.5
+      vertex 63.1024 58.3454 3
+      vertex 62.8097 58.3084 3
+    endloop
+  endfacet
+  facet normal 0.125411 0.992105 -0
+    outer loop
+      vertex 63.6903 58.3084 3
+      vertex 63.3976 58.3454 7.5
+      vertex 63.6903 58.3084 7.5
+    endloop
+  endfacet
+  facet normal 0.125411 0.992105 0
+    outer loop
+      vertex 63.3976 58.3454 7.5
+      vertex 63.6903 58.3084 3
+      vertex 63.3976 58.3454 3
+    endloop
+  endfacet
+  facet normal 0.248669 0.968589 -0
+    outer loop
+      vertex 63.9762 58.235 3
+      vertex 63.6903 58.3084 7.5
+      vertex 63.9762 58.235 7.5
+    endloop
+  endfacet
+  facet normal 0.248669 0.968589 0
+    outer loop
+      vertex 63.6903 58.3084 7.5
+      vertex 63.9762 58.235 3
+      vertex 63.6903 58.3084 3
+    endloop
+  endfacet
+  facet normal -0.982288 0.187377 0
+    outer loop
+      vertex 60.9185 56.2945 3
+      vertex 60.9738 56.5844 7.5
+      vertex 60.9738 56.5844 3
+    endloop
+  endfacet
+  facet normal -0.982288 0.187377 0
+    outer loop
+      vertex 60.9738 56.5844 7.5
+      vertex 60.9185 56.2945 3
+      vertex 60.9185 56.2945 7.5
+    endloop
+  endfacet
+  facet normal 0.684392 0.729114 -0
+    outer loop
+      vertex 64.9631 57.6087 3
+      vertex 64.7479 57.8107 7.5
+      vertex 64.9631 57.6087 7.5
+    endloop
+  endfacet
+  facet normal 0.684392 0.729114 0
+    outer loop
+      vertex 64.7479 57.8107 7.5
+      vertex 64.9631 57.6087 3
+      vertex 64.7479 57.8107 3
+    endloop
+  endfacet
+  facet normal 0.770549 0.63738 0
+    outer loop
+      vertex 65.1512 57.3813 7.5
+      vertex 64.9631 57.6087 3
+      vertex 64.9631 57.6087 7.5
+    endloop
+  endfacet
+  facet normal 0.770549 0.63738 0
+    outer loop
+      vertex 64.9631 57.6087 3
+      vertex 65.1512 57.3813 7.5
+      vertex 65.1512 57.3813 3
+    endloop
+  endfacet
+  facet normal -0.951061 0.309002 0
+    outer loop
+      vertex 60.9738 56.5844 3
+      vertex 61.065 56.8651 7.5
+      vertex 61.065 56.8651 3
+    endloop
+  endfacet
+  facet normal -0.951061 0.309002 0
+    outer loop
+      vertex 61.065 56.8651 7.5
+      vertex 60.9738 56.5844 3
+      vertex 60.9738 56.5844 7.5
+    endloop
+  endfacet
+  facet normal -0.8444 -0.535713 0
+    outer loop
+      vertex 61.3488 54.6187 3
+      vertex 61.1907 54.8679 7.5
+      vertex 61.1907 54.8679 3
+    endloop
+  endfacet
+  facet normal -0.8444 -0.535713 0
+    outer loop
+      vertex 61.1907 54.8679 7.5
+      vertex 61.3488 54.6187 3
+      vertex 61.3488 54.6187 7.5
+    endloop
+  endfacet
+  facet normal -0.770549 0.63738 0
+    outer loop
+      vertex 61.3488 57.3813 3
+      vertex 61.5369 57.6087 7.5
+      vertex 61.5369 57.6087 3
+    endloop
+  endfacet
+  facet normal -0.770549 0.63738 0
+    outer loop
+      vertex 61.5369 57.6087 7.5
+      vertex 61.3488 57.3813 3
+      vertex 61.3488 57.3813 7.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 140 12 40
+      vertex 140 0 40
+      vertex 140 12 3
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 140 128 3
+      vertex 140 140 40
+      vertex 140 128 40
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 140 140 40
+      vertex 140 128 3
+      vertex 140 140 0
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 140 12 3
+      vertex 140 140 0
+      vertex 140 128 3
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 140 12 3
+      vertex 140 0 0
+      vertex 140 140 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 140 0 0
+      vertex 140 12 3
+      vertex 140 0 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 56 3
+      vertex 60.7436 56.2041 3
+      vertex 60.75 56 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 60.7244 56.4073 3
+      vertex 60.7436 56.2041 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 60.6924 56.609 3
+      vertex 60.7244 56.4073 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 60.6479 56.8082 3
+      vertex 60.6924 56.609 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9738 84.5844 3
+      vertex 60.3707 87.0897 3
+      vertex 60.9185 84.2945 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 60.5909 57.0043 3
+      vertex 60.6479 56.8082 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 60.5218 57.1964 3
+      vertex 60.5909 57.0043 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.2559 87.2586 3
+      vertex 60.9185 84.2945 3
+      vertex 60.3707 87.0897 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 60.4407 57.3838 3
+      vertex 60.5218 57.1964 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.152 87.4343 3
+      vertex 60.9185 84.2945 3
+      vertex 60.2559 87.2586 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 60.348 57.5657 3
+      vertex 60.4407 57.3838 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9185 84.2945 3
+      vertex 60.152 87.4343 3
+      vertex 60.9 84 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 60.2441 57.7414 3
+      vertex 60.348 57.5657 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.0593 87.6162 3
+      vertex 60.9 84 3
+      vertex 60.152 87.4343 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 60.1293 57.9103 3
+      vertex 60.2441 57.7414 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.9782 87.8036 3
+      vertex 60.9 84 3
+      vertex 60.0593 87.6162 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 60.0042 58.0716 3
+      vertex 60.1293 57.9103 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.9091 87.9957 3
+      vertex 60.9 84 3
+      vertex 59.9782 87.8036 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8707 57.9103 3
+      vertex 60.9 84 3
+      vertex 59.9091 87.9957 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 59.8691 58.2248 3
+      vertex 60.0042 58.0716 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8707 57.9103 3
+      vertex 59.9091 87.9957 3
+      vertex 59.8521 88.1918 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.7559 57.7414 3
+      vertex 59.8521 88.1918 3
+      vertex 59.8076 88.391 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.652 57.5657 3
+      vertex 59.8076 88.391 3
+      vertex 59.7756 88.5927 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 128 3
+      vertex 59.7756 88.5927 3
+      vertex 59.7564 88.7959 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 128 3
+      vertex 59.7564 88.7959 3
+      vertex 59.75 89 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 59.7248 58.3691 3
+      vertex 59.8691 58.2248 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.8036 85.9782 3
+      vertex 61.7521 85.8107 3
+      vertex 61.9233 85.9351 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.6162 86.0593 3
+      vertex 61.7521 85.8107 3
+      vertex 61.8036 85.9782 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.6162 86.0593 3
+      vertex 61.5369 85.6087 3
+      vertex 61.7521 85.8107 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.4343 86.152 3
+      vertex 61.5369 85.6087 3
+      vertex 61.6162 86.0593 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.2586 86.2559 3
+      vertex 61.5369 85.6087 3
+      vertex 61.4343 86.152 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.5369 85.6087 3
+      vertex 61.2586 86.2559 3
+      vertex 61.3488 85.3813 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.0897 86.3707 3
+      vertex 61.3488 85.3813 3
+      vertex 61.2586 86.2559 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.3488 85.3813 3
+      vertex 61.0897 86.3707 3
+      vertex 61.1907 85.1321 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9284 86.4958 3
+      vertex 61.1907 85.1321 3
+      vertex 61.0897 86.3707 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.7752 86.6309 3
+      vertex 61.1907 85.1321 3
+      vertex 60.9284 86.4958 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.1907 85.1321 3
+      vertex 60.7752 86.6309 3
+      vertex 61.065 84.8651 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.6309 86.7752 3
+      vertex 61.065 84.8651 3
+      vertex 60.7752 86.6309 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.065 84.8651 3
+      vertex 60.6309 86.7752 3
+      vertex 60.9738 84.5844 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.7436 56.2041 3
+      vertex 60.9 56 3
+      vertex 60.9185 56.2945 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.4958 86.9284 3
+      vertex 60.9738 84.5844 3
+      vertex 60.6309 86.7752 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.3707 87.0897 3
+      vertex 60.9738 84.5844 3
+      vertex 60.4958 86.9284 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.7436 55.7959 3
+      vertex 60.9 56 3
+      vertex 60.75 56 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.7244 55.5927 3
+      vertex 60.9 56 3
+      vertex 60.7436 55.7959 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.6924 55.391 3
+      vertex 60.9 56 3
+      vertex 60.7244 55.5927 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.6479 55.1918 3
+      vertex 60.9 56 3
+      vertex 60.6924 55.391 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 56 3
+      vertex 60.6479 55.1918 3
+      vertex 60.7985 42.3626 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.5909 54.9957 3
+      vertex 60.7985 42.3626 3
+      vertex 60.6479 55.1918 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.5218 54.8036 3
+      vertex 60.7985 42.3626 3
+      vertex 60.5909 54.9957 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.4407 54.6162 3
+      vertex 60.7985 42.3626 3
+      vertex 60.5218 54.8036 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.348 54.4343 3
+      vertex 60.7985 42.3626 3
+      vertex 60.4407 54.6162 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.2441 54.2586 3
+      vertex 60.7985 42.3626 3
+      vertex 60.348 54.4343 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.1293 54.0897 3
+      vertex 60.7985 42.3626 3
+      vertex 60.2441 54.2586 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.0042 53.9284 3
+      vertex 60.7985 42.3626 3
+      vertex 60.1293 54.0897 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.4185 56.2945 3
+      vertex 65.5815 56.2945 3
+      vertex 65.6 56 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 66.146 62.9895 3
+      vertex 65.5262 56.5844 3
+      vertex 65.5815 56.2945 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 66.146 62.9895 3
+      vertex 65.435 56.8651 3
+      vertex 65.5262 56.5844 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 66.146 62.9895 3
+      vertex 65.3093 57.1321 3
+      vertex 65.435 56.8651 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.6903 58.3084 3
+      vertex 65.7134 63.2454 3
+      vertex 65.2977 63.5279 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 66.146 62.9895 3
+      vertex 65.1512 57.3813 3
+      vertex 65.3093 57.1321 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 66.146 62.9895 3
+      vertex 64.9631 57.6087 3
+      vertex 65.1512 57.3813 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.3976 58.3454 3
+      vertex 65.2977 63.5279 3
+      vertex 64.9006 63.8359 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 66.146 62.9895 3
+      vertex 64.7479 57.8107 3
+      vertex 64.9631 57.6087 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.1024 58.3454 3
+      vertex 64.9006 63.8359 3
+      vertex 64.5236 64.1683 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 66.146 62.9895 3
+      vertex 64.5092 57.9842 3
+      vertex 64.7479 57.8107 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 66.146 62.9895 3
+      vertex 64.2506 58.1263 3
+      vertex 64.5092 57.9842 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.8097 58.3084 3
+      vertex 64.5236 64.1683 3
+      vertex 64.1683 64.5236 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 66.146 62.9895 3
+      vertex 63.9762 58.235 3
+      vertex 64.2506 58.1263 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.5238 58.235 3
+      vertex 64.1683 64.5236 3
+      vertex 63.8359 64.9006 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.7134 63.2454 3
+      vertex 63.6903 58.3084 3
+      vertex 63.9762 58.235 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.2494 58.1263 3
+      vertex 63.8359 64.9006 3
+      vertex 63.5279 65.2977 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.2977 63.5279 3
+      vertex 63.3976 58.3454 3
+      vertex 63.6903 58.3084 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.9908 57.9842 3
+      vertex 63.5279 65.2977 3
+      vertex 63.2454 65.7134 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.9006 63.8359 3
+      vertex 63.1024 58.3454 3
+      vertex 63.3976 58.3454 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.7521 57.8107 3
+      vertex 63.2454 65.7134 3
+      vertex 62.9895 66.146 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.5236 64.1683 3
+      vertex 62.8097 58.3084 3
+      vertex 63.1024 58.3454 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.5369 57.6087 3
+      vertex 62.9895 66.146 3
+      vertex 62.7614 66.5938 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.3488 57.3813 3
+      vertex 62.7614 66.5938 3
+      vertex 62.5618 67.055 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.1683 64.5236 3
+      vertex 62.5238 58.235 3
+      vertex 62.8097 58.3084 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.3488 57.3813 3
+      vertex 62.5618 67.055 3
+      vertex 62.3915 67.5279 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.1907 57.1321 3
+      vertex 62.3915 67.5279 3
+      vertex 62.2513 68.0105 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.8359 64.9006 3
+      vertex 62.2494 58.1263 3
+      vertex 62.5238 58.235 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.7436 56.2041 3
+      vertex 62.2513 68.0105 3
+      vertex 62.1417 68.5009 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.7436 56.2041 3
+      vertex 62.1417 68.5009 3
+      vertex 62.0631 68.9973 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.7436 56.2041 3
+      vertex 62.0631 68.9973 3
+      vertex 62.0158 69.4977 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.7436 56.2041 3
+      vertex 62.0158 69.4977 3
+      vertex 62 70 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.5279 65.2977 3
+      vertex 61.9908 57.9842 3
+      vertex 62.2494 58.1263 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.065 83.1349 3
+      vertex 62.2513 71.9895 3
+      vertex 61.1907 82.8679 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.2513 71.9895 3
+      vertex 61.065 83.1349 3
+      vertex 62.1417 71.4991 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.2454 65.7134 3
+      vertex 61.7521 57.8107 3
+      vertex 61.9908 57.9842 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.1417 71.4991 3
+      vertex 61.065 83.1349 3
+      vertex 62.0631 71.0027 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.9895 66.146 3
+      vertex 61.5369 57.6087 3
+      vertex 61.7521 57.8107 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9738 83.4156 3
+      vertex 62.0631 71.0027 3
+      vertex 61.065 83.1349 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.7614 66.5938 3
+      vertex 61.3488 57.3813 3
+      vertex 61.5369 57.6087 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.0631 71.0027 3
+      vertex 60.9738 83.4156 3
+      vertex 62.0158 70.5023 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.3915 67.5279 3
+      vertex 61.1907 57.1321 3
+      vertex 61.3488 57.3813 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.0158 70.5023 3
+      vertex 60.9738 83.4156 3
+      vertex 62 70 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.2513 68.0105 3
+      vertex 61.065 56.8651 3
+      vertex 61.1907 57.1321 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9185 83.7055 3
+      vertex 62 70 3
+      vertex 60.9738 83.4156 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.2513 68.0105 3
+      vertex 60.7436 56.2041 3
+      vertex 61.065 56.8651 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.7436 56.2041 3
+      vertex 62 70 3
+      vertex 60.9185 83.7055 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.7436 56.2041 3
+      vertex 60.9738 56.5844 3
+      vertex 61.065 56.8651 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.7436 56.2041 3
+      vertex 60.9185 83.7055 3
+      vertex 60.9 84 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.7436 56.2041 3
+      vertex 60.9185 56.2945 3
+      vertex 60.9738 56.5844 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.4185 84.2945 3
+      vertex 65.5815 84.2945 3
+      vertex 65.6 84 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.7441 87.2586 3
+      vertex 65.5262 84.5844 3
+      vertex 65.5815 84.2945 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.3093 85.1321 3
+      vertex 65.6293 87.0897 3
+      vertex 65.5042 86.9284 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.7441 87.2586 3
+      vertex 65.435 84.8651 3
+      vertex 65.5262 84.5844 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.3093 85.1321 3
+      vertex 65.5042 86.9284 3
+      vertex 65.3691 86.7752 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.6293 87.0897 3
+      vertex 65.3093 85.1321 3
+      vertex 65.435 84.8651 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.1512 85.3813 3
+      vertex 65.3691 86.7752 3
+      vertex 65.2248 86.6309 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.3691 86.7752 3
+      vertex 65.1512 85.3813 3
+      vertex 65.3093 85.1321 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 65.0716 86.4958 3
+      vertex 65.1512 85.3813 3
+      vertex 65.2248 86.6309 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.0716 86.4958 3
+      vertex 64.9631 85.6087 3
+      vertex 65.1512 85.3813 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.9103 86.3707 3
+      vertex 64.9631 85.6087 3
+      vertex 65.0716 86.4958 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.9103 86.3707 3
+      vertex 64.7479 85.8107 3
+      vertex 64.9631 85.6087 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.7414 86.2559 3
+      vertex 64.7479 85.8107 3
+      vertex 64.9103 86.3707 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.5657 86.152 3
+      vertex 64.7479 85.8107 3
+      vertex 64.7414 86.2559 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.5657 86.152 3
+      vertex 64.5092 85.9842 3
+      vertex 64.7479 85.8107 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.3838 86.0593 3
+      vertex 64.5092 85.9842 3
+      vertex 64.5657 86.152 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.5092 85.9842 3
+      vertex 64.3838 86.0593 3
+      vertex 64.3775 86.0566 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 68.2199 90.6683 3
+      vertex 66.2436 89.2041 3
+      vertex 66.25 89 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 67.0643 90.965 3
+      vertex 66.2244 89.4073 3
+      vertex 66.2436 89.2041 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 67.0643 90.965 3
+      vertex 66.1924 89.609 3
+      vertex 66.2244 89.4073 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 67.0643 90.965 3
+      vertex 66.1479 89.8082 3
+      vertex 66.1924 89.609 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 67.0643 90.965 3
+      vertex 66.0909 90.0043 3
+      vertex 66.1479 89.8082 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 67.0643 90.965 3
+      vertex 66.0218 90.1964 3
+      vertex 66.0909 90.0043 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.7441 90.7414 3
+      vertex 66.5028 91.1671 3
+      vertex 65.9551 91.4041 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 66.5028 91.1671 3
+      vertex 65.9407 90.3838 3
+      vertex 66.0218 90.1964 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 66.5028 91.1671 3
+      vertex 65.848 90.5657 3
+      vertex 65.9407 90.3838 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 66.5028 91.1671 3
+      vertex 65.7441 90.7414 3
+      vertex 65.848 90.5657 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.9551 91.4041 3
+      vertex 65.6293 90.9103 3
+      vertex 65.7441 90.7414 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.9551 91.4041 3
+      vertex 65.5042 91.0716 3
+      vertex 65.6293 90.9103 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.3691 91.2248 3
+      vertex 65.9551 91.4041 3
+      vertex 65.4233 91.6751 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.9551 91.4041 3
+      vertex 65.3691 91.2248 3
+      vertex 65.5042 91.0716 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.4233 91.6751 3
+      vertex 65.2248 91.3691 3
+      vertex 65.3691 91.2248 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.4233 91.6751 3
+      vertex 65.0716 91.5042 3
+      vertex 65.2248 91.3691 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.4233 91.6751 3
+      vertex 64.9103 91.6293 3
+      vertex 65.0716 91.5042 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.9096 91.9789 3
+      vertex 64.9103 91.6293 3
+      vertex 65.4233 91.6751 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.9096 91.9789 3
+      vertex 64.7414 91.7441 3
+      vertex 64.9103 91.6293 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.9096 91.9789 3
+      vertex 64.5657 91.848 3
+      vertex 64.7414 91.7441 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.416 92.3143 3
+      vertex 64.5657 91.848 3
+      vertex 64.9096 91.9789 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.416 92.3143 3
+      vertex 64.3838 91.9407 3
+      vertex 64.5657 91.848 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.416 92.3143 3
+      vertex 64.1964 92.0218 3
+      vertex 64.3838 91.9407 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.416 92.3143 3
+      vertex 64.0043 92.0909 3
+      vertex 64.1964 92.0218 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.9445 92.6801 3
+      vertex 64.0043 92.0909 3
+      vertex 64.416 92.3143 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.9445 92.6801 3
+      vertex 63.8082 92.1479 3
+      vertex 64.0043 92.0909 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.9445 92.6801 3
+      vertex 63.609 92.1924 3
+      vertex 63.8082 92.1479 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.4073 92.2244 3
+      vertex 63.9445 92.6801 3
+      vertex 63.4968 93.0748 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.9445 92.6801 3
+      vertex 63.4073 92.2244 3
+      vertex 63.609 92.1924 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.4968 93.0748 3
+      vertex 63.2041 92.2436 3
+      vertex 63.4073 92.2244 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63 92.25 3
+      vertex 63.4968 93.0748 3
+      vertex 63.0748 93.4968 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.4968 93.0748 3
+      vertex 63 92.25 3
+      vertex 63.2041 92.2436 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.0748 93.4968 3
+      vertex 62.7959 92.2436 3
+      vertex 63 92.25 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.391 92.1924 3
+      vertex 63.0748 93.4968 3
+      vertex 62.6801 93.9445 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.0748 93.4968 3
+      vertex 62.5927 92.2244 3
+      vertex 62.7959 92.2436 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.0748 93.4968 3
+      vertex 62.391 92.1924 3
+      vertex 62.5927 92.2244 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.9957 92.0909 3
+      vertex 62.6801 93.9445 3
+      vertex 62.3143 94.416 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.6801 93.9445 3
+      vertex 62.1918 92.1479 3
+      vertex 62.391 92.1924 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.6801 93.9445 3
+      vertex 61.9957 92.0909 3
+      vertex 62.1918 92.1479 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.4343 91.848 3
+      vertex 62.3143 94.416 3
+      vertex 61.9789 94.9096 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.3143 94.416 3
+      vertex 61.8036 92.0218 3
+      vertex 61.9957 92.0909 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.0897 91.6293 3
+      vertex 61.9789 94.9096 3
+      vertex 61.6751 95.4233 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.3143 94.416 3
+      vertex 61.6162 91.9407 3
+      vertex 61.8036 92.0218 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.3143 94.416 3
+      vertex 61.4343 91.848 3
+      vertex 61.6162 91.9407 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.7752 91.3691 3
+      vertex 61.6751 95.4233 3
+      vertex 61.4041 95.9551 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.9789 94.9096 3
+      vertex 61.2586 91.7441 3
+      vertex 61.4343 91.848 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.4958 91.0716 3
+      vertex 61.4041 95.9551 3
+      vertex 61.1671 96.5028 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.9789 94.9096 3
+      vertex 61.0897 91.6293 3
+      vertex 61.2586 91.7441 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.3707 90.9103 3
+      vertex 61.1671 96.5028 3
+      vertex 60.965 97.0643 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.6751 95.4233 3
+      vertex 60.9284 91.5042 3
+      vertex 61.0897 91.6293 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.152 90.5657 3
+      vertex 60.965 97.0643 3
+      vertex 60.7985 97.6374 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.6751 95.4233 3
+      vertex 60.7752 91.3691 3
+      vertex 60.9284 91.5042 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.0593 90.3838 3
+      vertex 60.7985 97.6374 3
+      vertex 60.6683 98.2199 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.4041 95.9551 3
+      vertex 60.6309 91.2248 3
+      vertex 60.7752 91.3691 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.9091 90.0043 3
+      vertex 60.6683 98.2199 3
+      vertex 60.5749 98.8093 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.8521 89.8082 3
+      vertex 60.5749 98.8093 3
+      vertex 60.5187 99.4035 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 128 3
+      vertex 60.5187 99.4035 3
+      vertex 60.5 100 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.4041 95.9551 3
+      vertex 60.4958 91.0716 3
+      vertex 60.6309 91.2248 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 79.0262 83.4156 3
+      vertex 85.5 77.75 3
+      vertex 79.0815 83.7055 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 77.75 3
+      vertex 79.0815 56.2945 3
+      vertex 79.1 56 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 78.935 83.1349 3
+      vertex 85.5 77.75 3
+      vertex 79.0262 83.4156 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.9842 69.4977 3
+      vertex 85.5 77.75 3
+      vertex 78 70 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 78.8093 82.8679 3
+      vertex 85.5 77.75 3
+      vertex 78.935 83.1349 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 77.75 3
+      vertex 79.0262 56.5844 3
+      vertex 79.0815 56.2945 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 78.6512 82.6187 3
+      vertex 85.5 77.75 3
+      vertex 78.8093 82.8679 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.9369 68.9973 3
+      vertex 85.5 77.75 3
+      vertex 77.9842 69.4977 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 78.4631 82.3913 3
+      vertex 85.5 77.75 3
+      vertex 78.6512 82.6187 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.8583 68.5009 3
+      vertex 85.5 77.75 3
+      vertex 77.9369 68.9973 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 78.2479 82.1893 3
+      vertex 85.5 77.75 3
+      vertex 78.4631 82.3913 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 77.75 3
+      vertex 78.935 56.8651 3
+      vertex 79.0262 56.5844 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 78.0092 82.0158 3
+      vertex 85.5 77.75 3
+      vertex 78.2479 82.1893 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.7487 68.0105 3
+      vertex 85.5 77.75 3
+      vertex 77.8583 68.5009 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.4721 74.7023 3
+      vertex 85.5 77.75 3
+      vertex 78.0092 82.0158 3
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 78.8093 57.1321 3
+      vertex 85.5 77.75 3
+      vertex 77.7487 68.0105 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 77.75 3
+      vertex 78.8093 57.1321 3
+      vertex 78.935 56.8651 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 77.75 3
+      vertex 77.9842 70.5023 3
+      vertex 78 70 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 77.75 3
+      vertex 77.9369 71.0027 3
+      vertex 77.9842 70.5023 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 77.75 3
+      vertex 77.8583 71.4991 3
+      vertex 77.9369 71.0027 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.4721 74.7023 3
+      vertex 78.0092 82.0158 3
+      vertex 77.7506 81.8737 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 77.75 3
+      vertex 77.7487 71.9895 3
+      vertex 77.8583 71.4991 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 77.75 3
+      vertex 77.6085 72.4721 3
+      vertex 77.7487 71.9895 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.1641 75.0994 3
+      vertex 77.7506 81.8737 3
+      vertex 77.4762 81.765 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 77.75 3
+      vertex 77.4382 72.945 3
+      vertex 77.6085 72.4721 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 77.75 3
+      vertex 77.2386 73.4062 3
+      vertex 77.4382 72.945 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.8317 75.4764 3
+      vertex 77.4762 81.765 3
+      vertex 77.1903 81.6916 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 77.75 3
+      vertex 77.0105 73.854 3
+      vertex 77.2386 73.4062 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.4764 75.8317 3
+      vertex 77.1903 81.6916 3
+      vertex 76.8976 81.6546 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 77.75 3
+      vertex 76.7546 74.2866 3
+      vertex 77.0105 73.854 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.0994 76.1641 3
+      vertex 76.8976 81.6546 3
+      vertex 76.6024 81.6546 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 77.75 3
+      vertex 76.4721 74.7023 3
+      vertex 76.7546 74.2866 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.7023 76.4721 3
+      vertex 76.6024 81.6546 3
+      vertex 76.3097 81.6916 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.7506 81.8737 3
+      vertex 76.1641 75.0994 3
+      vertex 76.4721 74.7023 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.2866 76.7546 3
+      vertex 76.3097 81.6916 3
+      vertex 76.0238 81.765 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.4762 81.765 3
+      vertex 75.8317 75.4764 3
+      vertex 76.1641 75.0994 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 73.854 77.0105 3
+      vertex 76.0238 81.765 3
+      vertex 75.7494 81.8737 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 73.4062 77.2386 3
+      vertex 75.7494 81.8737 3
+      vertex 75.4908 82.0158 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.1903 81.6916 3
+      vertex 75.4764 75.8317 3
+      vertex 75.8317 75.4764 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 72.945 77.4382 3
+      vertex 75.4908 82.0158 3
+      vertex 75.2521 82.1893 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.8976 81.6546 3
+      vertex 75.0994 76.1641 3
+      vertex 75.4764 75.8317 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 72.4721 77.6085 3
+      vertex 75.2521 82.1893 3
+      vertex 75.0369 82.3913 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 71.9895 77.7487 3
+      vertex 75.0369 82.3913 3
+      vertex 74.8488 82.6187 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.6024 81.6546 3
+      vertex 74.7023 76.4721 3
+      vertex 75.0994 76.1641 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 71.4991 77.8583 3
+      vertex 74.8488 82.6187 3
+      vertex 74.6907 82.8679 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 71.0027 77.9369 3
+      vertex 74.6907 82.8679 3
+      vertex 74.565 83.1349 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 70.5023 77.9842 3
+      vertex 74.565 83.1349 3
+      vertex 74.4738 83.4156 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.5262 83.4156 3
+      vertex 74.4738 83.4156 3
+      vertex 74.4185 83.7055 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.5815 83.7055 3
+      vertex 74.4185 83.7055 3
+      vertex 74.4 84 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.3097 81.6916 3
+      vertex 74.2866 76.7546 3
+      vertex 74.7023 76.4721 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 77.75 3
+      vertex 79.0815 84.2945 3
+      vertex 79.1 84 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 89.0888 98.1443 3
+      vertex 78.5959 95.9551 3
+      vertex 89.2032 98.0369 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 89.3302 97.9446 3
+      vertex 79.0262 84.5844 3
+      vertex 79.0815 84.2945 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 89.3302 97.9446 3
+      vertex 78.935 84.8651 3
+      vertex 79.0262 84.5844 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.3249 95.4233 3
+      vertex 89.2032 98.0369 3
+      vertex 78.5959 95.9551 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 89.3302 97.9446 3
+      vertex 78.8093 85.1321 3
+      vertex 78.935 84.8651 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 89.2032 98.0369 3
+      vertex 78.3249 95.4233 3
+      vertex 89.3302 97.9446 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.0211 94.9096 3
+      vertex 89.3302 97.9446 3
+      vertex 78.3249 95.4233 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 89.3302 97.9446 3
+      vertex 78.6512 85.3813 3
+      vertex 78.8093 85.1321 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 89.3302 97.9446 3
+      vertex 78.0211 94.9096 3
+      vertex 78.6512 85.3813 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.6512 85.3813 3
+      vertex 78.0211 94.9096 3
+      vertex 78.4631 85.6087 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 77.6857 94.416 3
+      vertex 78.4631 85.6087 3
+      vertex 78.0211 94.9096 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.4631 85.6087 3
+      vertex 77.6857 94.416 3
+      vertex 78.2479 85.8107 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 77.3199 93.9445 3
+      vertex 78.2479 85.8107 3
+      vertex 77.6857 94.416 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.2479 85.8107 3
+      vertex 77.3199 93.9445 3
+      vertex 78.0092 85.9842 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 76.9252 93.4968 3
+      vertex 78.0092 85.9842 3
+      vertex 77.3199 93.9445 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.0092 85.9842 3
+      vertex 76.9252 93.4968 3
+      vertex 77.7506 86.1263 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 76.5032 93.0748 3
+      vertex 77.7506 86.1263 3
+      vertex 76.9252 93.4968 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.7506 86.1263 3
+      vertex 76.5032 93.0748 3
+      vertex 77.4762 86.235 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 76.0555 92.6801 3
+      vertex 77.4762 86.235 3
+      vertex 76.5032 93.0748 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.4762 86.235 3
+      vertex 76.0555 92.6801 3
+      vertex 77.1903 86.3084 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 75.584 92.3143 3
+      vertex 77.1903 86.3084 3
+      vertex 76.0555 92.6801 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.1903 86.3084 3
+      vertex 75.584 92.3143 3
+      vertex 76.8976 86.3454 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 75.0904 91.9789 3
+      vertex 76.8976 86.3454 3
+      vertex 75.584 92.3143 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.8976 86.3454 3
+      vertex 75.0904 91.9789 3
+      vertex 76.6024 86.3454 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 74.5767 91.6751 3
+      vertex 76.6024 86.3454 3
+      vertex 75.0904 91.9789 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.6024 86.3454 3
+      vertex 74.5767 91.6751 3
+      vertex 76.3097 86.3084 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 74.0449 91.4041 3
+      vertex 76.3097 86.3084 3
+      vertex 74.5767 91.6751 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.3097 86.3084 3
+      vertex 74.0449 91.4041 3
+      vertex 76.0238 86.235 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.0238 86.235 3
+      vertex 74.0449 91.4041 3
+      vertex 75.7494 86.1263 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 73.4972 91.1671 3
+      vertex 75.7494 86.1263 3
+      vertex 74.0449 91.4041 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.7494 86.1263 3
+      vertex 73.4972 91.1671 3
+      vertex 75.4908 85.9842 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 72.9357 90.965 3
+      vertex 75.4908 85.9842 3
+      vertex 73.4972 91.1671 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.4908 85.9842 3
+      vertex 72.9357 90.965 3
+      vertex 75.2521 85.8107 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 72.3626 90.7985 3
+      vertex 75.2521 85.8107 3
+      vertex 72.9357 90.965 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.2521 85.8107 3
+      vertex 72.3626 90.7985 3
+      vertex 75.0369 85.6087 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 71.7801 90.6683 3
+      vertex 75.0369 85.6087 3
+      vertex 72.3626 90.7985 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.0369 85.6087 3
+      vertex 71.7801 90.6683 3
+      vertex 74.8488 85.3813 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 71.1907 90.5749 3
+      vertex 74.8488 85.3813 3
+      vertex 71.7801 90.6683 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.8488 85.3813 3
+      vertex 71.1907 90.5749 3
+      vertex 74.6907 85.1321 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.0238 81.765 3
+      vertex 73.854 77.0105 3
+      vertex 74.2866 76.7546 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 70.5965 90.5187 3
+      vertex 74.6907 85.1321 3
+      vertex 71.1907 90.5749 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.7494 81.8737 3
+      vertex 73.4062 77.2386 3
+      vertex 73.854 77.0105 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.4908 82.0158 3
+      vertex 72.945 77.4382 3
+      vertex 73.4062 77.2386 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.6907 85.1321 3
+      vertex 70.5965 90.5187 3
+      vertex 74.565 84.8651 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.2521 82.1893 3
+      vertex 72.4721 77.6085 3
+      vertex 72.945 77.4382 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 70 90.5 3
+      vertex 74.565 84.8651 3
+      vertex 70.5965 90.5187 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.0369 82.3913 3
+      vertex 71.9895 77.7487 3
+      vertex 72.4721 77.6085 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.565 84.8651 3
+      vertex 70 90.5 3
+      vertex 74.4738 84.5844 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.8488 82.6187 3
+      vertex 71.4991 77.8583 3
+      vertex 71.9895 77.7487 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 66.0218 87.8036 3
+      vertex 74.4738 84.5844 3
+      vertex 70 90.5 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.6907 82.8679 3
+      vertex 71.0027 77.9369 3
+      vertex 71.4991 77.8583 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 65.9407 87.6162 3
+      vertex 74.4738 84.5844 3
+      vertex 66.0218 87.8036 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.5815 83.7055 3
+      vertex 74.4 84 3
+      vertex 65.6 84 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.5815 84.2945 3
+      vertex 74.4185 84.2945 3
+      vertex 74.4738 84.5844 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.565 83.1349 3
+      vertex 70.5023 77.9842 3
+      vertex 71.0027 77.9369 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.4185 83.7055 3
+      vertex 65.5815 83.7055 3
+      vertex 65.5262 83.4156 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 66.0909 87.9957 3
+      vertex 70 90.5 3
+      vertex 69.4035 90.5187 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.4738 83.4156 3
+      vertex 70 78 3
+      vertex 70.5023 77.9842 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 66.1924 88.391 3
+      vertex 69.4035 90.5187 3
+      vertex 68.8093 90.5749 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.4738 83.4156 3
+      vertex 65.5262 83.4156 3
+      vertex 70 78 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 66.2436 88.7959 3
+      vertex 68.8093 90.5749 3
+      vertex 68.2199 90.6683 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 70 78 3
+      vertex 65.5262 83.4156 3
+      vertex 69.4977 77.9842 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 66.2436 89.2041 3
+      vertex 68.2199 90.6683 3
+      vertex 67.6374 90.7985 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 65.435 83.1349 3
+      vertex 69.4977 77.9842 3
+      vertex 65.5262 83.4156 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 66.2436 89.2041 3
+      vertex 67.6374 90.7985 3
+      vertex 67.0643 90.965 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 69.4035 90.5187 3
+      vertex 66.1479 88.1918 3
+      vertex 66.0909 87.9957 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 69.4977 77.9842 3
+      vertex 65.435 83.1349 3
+      vertex 68.9973 77.9369 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 66.0218 90.1964 3
+      vertex 67.0643 90.965 3
+      vertex 66.5028 91.1671 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 68.2199 90.6683 3
+      vertex 66.25 89 3
+      vertex 66.2436 88.7959 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 68.8093 90.5749 3
+      vertex 66.2436 88.7959 3
+      vertex 66.2244 88.5927 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 68.8093 90.5749 3
+      vertex 66.2244 88.5927 3
+      vertex 66.1924 88.391 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 69.4035 90.5187 3
+      vertex 66.1924 88.391 3
+      vertex 66.1479 88.1918 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 65.3093 82.8679 3
+      vertex 68.9973 77.9369 3
+      vertex 65.435 83.1349 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 68.9973 77.9369 3
+      vertex 65.3093 82.8679 3
+      vertex 68.5009 77.8583 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 70 90.5 3
+      vertex 66.0909 87.9957 3
+      vertex 66.0218 87.8036 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.5815 84.2945 3
+      vertex 74.4738 84.5844 3
+      vertex 65.9407 87.6162 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.4185 84.2945 3
+      vertex 65.6 84 3
+      vertex 74.4 84 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.5815 84.2945 3
+      vertex 65.9407 87.6162 3
+      vertex 65.848 87.4343 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.5815 84.2945 3
+      vertex 65.848 87.4343 3
+      vertex 65.7441 87.2586 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 65.1512 82.6187 3
+      vertex 68.5009 77.8583 3
+      vertex 65.3093 82.8679 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.435 84.8651 3
+      vertex 65.7441 87.2586 3
+      vertex 65.6293 87.0897 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 68.5009 77.8583 3
+      vertex 65.1512 82.6187 3
+      vertex 68.0105 77.7487 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.9631 82.3913 3
+      vertex 68.0105 77.7487 3
+      vertex 65.1512 82.6187 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 68.0105 77.7487 3
+      vertex 64.9631 82.3913 3
+      vertex 67.5279 77.6085 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.7479 82.1893 3
+      vertex 67.5279 77.6085 3
+      vertex 64.9631 82.3913 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 67.5279 77.6085 3
+      vertex 64.7479 82.1893 3
+      vertex 67.055 77.4382 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.5092 82.0158 3
+      vertex 67.055 77.4382 3
+      vertex 64.7479 82.1893 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 67.055 77.4382 3
+      vertex 64.5092 82.0158 3
+      vertex 66.5938 77.2386 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.2506 81.8737 3
+      vertex 66.5938 77.2386 3
+      vertex 64.5092 82.0158 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 66.5938 77.2386 3
+      vertex 64.2506 81.8737 3
+      vertex 66.146 77.0105 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.9762 81.765 3
+      vertex 66.146 77.0105 3
+      vertex 64.2506 81.8737 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 66.146 77.0105 3
+      vertex 63.9762 81.765 3
+      vertex 65.7134 76.7546 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.6903 81.6916 3
+      vertex 65.7134 76.7546 3
+      vertex 63.9762 81.765 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.7134 76.7546 3
+      vertex 63.6903 81.6916 3
+      vertex 65.2977 76.4721 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.3976 81.6546 3
+      vertex 65.2977 76.4721 3
+      vertex 63.6903 81.6916 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.2977 76.4721 3
+      vertex 63.3976 81.6546 3
+      vertex 64.9006 76.1641 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.1024 81.6546 3
+      vertex 64.9006 76.1641 3
+      vertex 63.3976 81.6546 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.9006 76.1641 3
+      vertex 63.1024 81.6546 3
+      vertex 64.5236 75.8317 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.8097 81.6916 3
+      vertex 64.5236 75.8317 3
+      vertex 63.1024 81.6546 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.5236 75.8317 3
+      vertex 62.8097 81.6916 3
+      vertex 64.1683 75.4764 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.5238 81.765 3
+      vertex 64.1683 75.4764 3
+      vertex 62.8097 81.6916 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.1683 75.4764 3
+      vertex 62.5238 81.765 3
+      vertex 63.8359 75.0994 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.2494 81.8737 3
+      vertex 63.8359 75.0994 3
+      vertex 62.5238 81.765 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.8359 75.0994 3
+      vertex 62.2494 81.8737 3
+      vertex 63.5279 74.7023 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.9908 82.0158 3
+      vertex 63.5279 74.7023 3
+      vertex 62.2494 81.8737 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.5279 74.7023 3
+      vertex 61.9908 82.0158 3
+      vertex 63.2454 74.2866 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.7521 82.1893 3
+      vertex 63.2454 74.2866 3
+      vertex 61.9908 82.0158 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.2454 74.2866 3
+      vertex 61.7521 82.1893 3
+      vertex 62.9895 73.854 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.5369 82.3913 3
+      vertex 62.9895 73.854 3
+      vertex 61.7521 82.1893 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.9895 73.854 3
+      vertex 61.5369 82.3913 3
+      vertex 62.7614 73.4062 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.3488 82.6187 3
+      vertex 62.7614 73.4062 3
+      vertex 61.5369 82.3913 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.7614 73.4062 3
+      vertex 61.3488 82.6187 3
+      vertex 62.5618 72.945 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.5618 72.945 3
+      vertex 61.3488 82.6187 3
+      vertex 62.3915 72.4721 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.1907 82.8679 3
+      vertex 62.3915 72.4721 3
+      vertex 61.3488 82.6187 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.3915 72.4721 3
+      vertex 61.1907 82.8679 3
+      vertex 62.2513 71.9895 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 88.7599 40.8433 3
+      vertex 79.4813 40.5965 3
+      vertex 79.5 40 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 88.9046 41.6022 3
+      vertex 79.4251 41.1907 3
+      vertex 79.4813 40.5965 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.5959 44.0449 3
+      vertex 79.5042 48.9284 3
+      vertex 79.3691 48.7752 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 88.9046 41.6022 3
+      vertex 79.3317 41.7801 3
+      vertex 79.4251 41.1907 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.5959 44.0449 3
+      vertex 79.3691 48.7752 3
+      vertex 79.2248 48.6309 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 88.9046 41.6022 3
+      vertex 79.2015 42.3626 3
+      vertex 79.3317 41.7801 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.3249 44.5767 3
+      vertex 79.2248 48.6309 3
+      vertex 79.0716 48.4958 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 88.9046 41.6022 3
+      vertex 79.035 42.9357 3
+      vertex 79.2015 42.3626 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.3249 44.5767 3
+      vertex 79.0716 48.4958 3
+      vertex 78.9103 48.3707 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 88.9887 41.7347 3
+      vertex 79.035 42.9357 3
+      vertex 88.9046 41.6022 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.0211 45.0904 3
+      vertex 78.9103 48.3707 3
+      vertex 78.7414 48.2559 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.5042 48.9284 3
+      vertex 78.5959 44.0449 3
+      vertex 78.8329 43.4972 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.0211 45.0904 3
+      vertex 78.7414 48.2559 3
+      vertex 78.5657 48.152 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.6857 45.584 3
+      vertex 78.5657 48.152 3
+      vertex 78.3838 48.0593 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.2248 48.6309 3
+      vertex 78.3249 44.5767 3
+      vertex 78.5959 44.0449 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.6857 45.584 3
+      vertex 78.3838 48.0593 3
+      vertex 78.1964 47.9782 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.9103 48.3707 3
+      vertex 78.0211 45.0904 3
+      vertex 78.3249 44.5767 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.6857 45.584 3
+      vertex 78.1964 47.9782 3
+      vertex 78.0043 47.9091 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.3199 46.0555 3
+      vertex 78.0043 47.9091 3
+      vertex 77.8082 47.8521 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.5657 48.152 3
+      vertex 77.6857 45.584 3
+      vertex 78.0211 45.0904 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.3199 46.0555 3
+      vertex 77.8082 47.8521 3
+      vertex 77.609 47.8076 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.9252 46.5032 3
+      vertex 77.609 47.8076 3
+      vertex 77.4073 47.7756 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.0043 47.9091 3
+      vertex 77.3199 46.0555 3
+      vertex 77.6857 45.584 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.9252 46.5032 3
+      vertex 77.4073 47.7756 3
+      vertex 77.2041 47.7564 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.9252 46.5032 3
+      vertex 77.2041 47.7564 3
+      vertex 77 47.75 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.609 47.8076 3
+      vertex 76.9252 46.5032 3
+      vertex 77.3199 46.0555 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.5032 46.9252 3
+      vertex 77 47.75 3
+      vertex 76.7959 47.7564 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.5032 46.9252 3
+      vertex 76.7959 47.7564 3
+      vertex 76.5927 47.7756 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77 47.75 3
+      vertex 76.5032 46.9252 3
+      vertex 76.9252 46.5032 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.0555 47.3199 3
+      vertex 76.5927 47.7756 3
+      vertex 76.391 47.8076 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.0555 47.3199 3
+      vertex 76.391 47.8076 3
+      vertex 76.1918 47.8521 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.5927 47.7756 3
+      vertex 76.0555 47.3199 3
+      vertex 76.5032 46.9252 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.9957 47.9091 3
+      vertex 76.0555 47.3199 3
+      vertex 76.1918 47.8521 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.584 47.6857 3
+      vertex 75.9957 47.9091 3
+      vertex 75.8036 47.9782 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.584 47.6857 3
+      vertex 75.8036 47.9782 3
+      vertex 75.6162 48.0593 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.9957 47.9091 3
+      vertex 75.584 47.6857 3
+      vertex 76.0555 47.3199 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.4343 48.152 3
+      vertex 75.584 47.6857 3
+      vertex 75.6162 48.0593 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.0904 48.0211 3
+      vertex 75.4343 48.152 3
+      vertex 75.2586 48.2559 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.4343 48.152 3
+      vertex 75.0904 48.0211 3
+      vertex 75.584 47.6857 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.0897 48.3707 3
+      vertex 75.0904 48.0211 3
+      vertex 75.2586 48.2559 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.5767 48.3249 3
+      vertex 75.0897 48.3707 3
+      vertex 74.9284 48.4958 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.5767 48.3249 3
+      vertex 74.9284 48.4958 3
+      vertex 74.7752 48.6309 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.5767 48.3249 3
+      vertex 74.7752 48.6309 3
+      vertex 74.6309 48.7752 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.0897 48.3707 3
+      vertex 74.5767 48.3249 3
+      vertex 75.0904 48.0211 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.0449 48.5959 3
+      vertex 74.6309 48.7752 3
+      vertex 74.4958 48.9284 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.0449 48.5959 3
+      vertex 74.4958 48.9284 3
+      vertex 74.3707 49.0897 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.0449 48.5959 3
+      vertex 74.3707 49.0897 3
+      vertex 74.2559 49.2586 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 73.4972 48.8329 3
+      vertex 74.2559 49.2586 3
+      vertex 74.152 49.4343 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 73.4972 48.8329 3
+      vertex 74.152 49.4343 3
+      vertex 74.0593 49.6162 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.6309 48.7752 3
+      vertex 74.0449 48.5959 3
+      vertex 74.5767 48.3249 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 73.4972 48.8329 3
+      vertex 74.0593 49.6162 3
+      vertex 73.9782 49.8036 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 72.9357 49.035 3
+      vertex 73.9782 49.8036 3
+      vertex 73.9091 49.9957 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 72.9357 49.035 3
+      vertex 73.9091 49.9957 3
+      vertex 73.8521 50.1918 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 72.3626 49.2015 3
+      vertex 73.8521 50.1918 3
+      vertex 73.8076 50.391 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 72.3626 49.2015 3
+      vertex 73.8076 50.391 3
+      vertex 73.7756 50.5927 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.2559 49.2586 3
+      vertex 73.4972 48.8329 3
+      vertex 74.0449 48.5959 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 72.3626 49.2015 3
+      vertex 73.7756 50.5927 3
+      vertex 73.7564 50.7959 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 71.7801 49.3317 3
+      vertex 73.7564 50.7959 3
+      vertex 73.75 51 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.8329 96.5028 3
+      vertex 88.9887 98.2653 3
+      vertex 79.035 97.0643 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 88.9887 98.2653 3
+      vertex 78.8329 96.5028 3
+      vertex 89.0888 98.1443 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 79.0815 83.7055 3
+      vertex 85.5 77.75 3
+      vertex 79.1 84 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.5959 95.9551 3
+      vertex 89.0888 98.1443 3
+      vertex 78.8329 96.5028 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 77.75 3
+      vertex 79.1 56 3
+      vertex 79.5042 53.0716 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 89.9215 97.7525 3
+      vertex 79.0815 84.2945 3
+      vertex 85.5 77.75 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 79.0815 55.7055 3
+      vertex 79.5042 53.0716 3
+      vertex 79.1 56 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 79.0262 55.4156 3
+      vertex 79.5042 53.0716 3
+      vertex 79.0815 55.7055 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.5042 53.0716 3
+      vertex 79.0262 55.4156 3
+      vertex 79.3691 53.2248 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 78.935 55.1349 3
+      vertex 79.3691 53.2248 3
+      vertex 79.0262 55.4156 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.3691 53.2248 3
+      vertex 78.935 55.1349 3
+      vertex 79.2248 53.3691 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 78.8093 54.8679 3
+      vertex 79.2248 53.3691 3
+      vertex 78.935 55.1349 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.2248 53.3691 3
+      vertex 78.8093 54.8679 3
+      vertex 79.0716 53.5042 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.0716 53.5042 3
+      vertex 78.8093 54.8679 3
+      vertex 78.9103 53.6293 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 78.6512 54.6187 3
+      vertex 78.9103 53.6293 3
+      vertex 78.8093 54.8679 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.9103 53.6293 3
+      vertex 78.6512 54.6187 3
+      vertex 78.7414 53.7441 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 78.4631 54.3913 3
+      vertex 78.7414 53.7441 3
+      vertex 78.6512 54.6187 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.7414 53.7441 3
+      vertex 78.4631 54.3913 3
+      vertex 78.5657 53.848 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.4631 54.3913 3
+      vertex 78.3838 53.9407 3
+      vertex 78.5657 53.848 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 78.2479 54.1893 3
+      vertex 78.3838 53.9407 3
+      vertex 78.4631 54.3913 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.2479 54.1893 3
+      vertex 78.1964 54.0218 3
+      vertex 78.3838 53.9407 3
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 78.1964 54.0218 3
+      vertex 78.2479 54.1893 3
+      vertex 78.0767 54.0649 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 77.6085 67.5279 3
+      vertex 78.8093 57.1321 3
+      vertex 77.7487 68.0105 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.8093 57.1321 3
+      vertex 77.6085 67.5279 3
+      vertex 78.6512 57.3813 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 77.4382 67.055 3
+      vertex 78.6512 57.3813 3
+      vertex 77.6085 67.5279 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 77.2386 66.5938 3
+      vertex 78.6512 57.3813 3
+      vertex 77.4382 67.055 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.6512 57.3813 3
+      vertex 77.2386 66.5938 3
+      vertex 78.4631 57.6087 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 77.0105 66.146 3
+      vertex 78.4631 57.6087 3
+      vertex 77.2386 66.5938 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.4631 57.6087 3
+      vertex 77.0105 66.146 3
+      vertex 78.2479 57.8107 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 76.7546 65.7134 3
+      vertex 78.2479 57.8107 3
+      vertex 77.0105 66.146 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.2479 57.8107 3
+      vertex 76.7546 65.7134 3
+      vertex 78.0092 57.9842 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 76.4721 65.2977 3
+      vertex 78.0092 57.9842 3
+      vertex 76.7546 65.7134 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.0092 57.9842 3
+      vertex 76.4721 65.2977 3
+      vertex 77.7506 58.1263 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 76.1641 64.9006 3
+      vertex 77.7506 58.1263 3
+      vertex 76.4721 65.2977 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.7506 58.1263 3
+      vertex 76.1641 64.9006 3
+      vertex 77.4762 58.235 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 75.8317 64.5236 3
+      vertex 77.4762 58.235 3
+      vertex 76.1641 64.9006 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.4762 58.235 3
+      vertex 75.8317 64.5236 3
+      vertex 77.1903 58.3084 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 75.4764 64.1683 3
+      vertex 77.1903 58.3084 3
+      vertex 75.8317 64.5236 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.1903 58.3084 3
+      vertex 75.4764 64.1683 3
+      vertex 76.8976 58.3454 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 75.0994 63.8359 3
+      vertex 76.8976 58.3454 3
+      vertex 75.4764 64.1683 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.8976 58.3454 3
+      vertex 75.0994 63.8359 3
+      vertex 76.6024 58.3454 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 74.7023 63.5279 3
+      vertex 76.6024 58.3454 3
+      vertex 75.0994 63.8359 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.6024 58.3454 3
+      vertex 74.7023 63.5279 3
+      vertex 76.3097 58.3084 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 74.2866 63.2454 3
+      vertex 76.3097 58.3084 3
+      vertex 74.7023 63.5279 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.3097 58.3084 3
+      vertex 74.2866 63.2454 3
+      vertex 76.0238 58.235 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 73.854 62.9895 3
+      vertex 76.0238 58.235 3
+      vertex 74.2866 63.2454 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.0238 58.235 3
+      vertex 73.854 62.9895 3
+      vertex 75.7494 58.1263 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 73.4062 62.7614 3
+      vertex 75.7494 58.1263 3
+      vertex 73.854 62.9895 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.7494 58.1263 3
+      vertex 73.4062 62.7614 3
+      vertex 75.4908 57.9842 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 72.945 62.5618 3
+      vertex 75.4908 57.9842 3
+      vertex 73.4062 62.7614 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.4908 57.9842 3
+      vertex 72.945 62.5618 3
+      vertex 75.2521 57.8107 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 72.4721 62.3915 3
+      vertex 75.2521 57.8107 3
+      vertex 72.945 62.5618 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.2521 57.8107 3
+      vertex 72.4721 62.3915 3
+      vertex 75.0369 57.6087 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 71.9895 62.2513 3
+      vertex 75.0369 57.6087 3
+      vertex 72.4721 62.3915 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.0369 57.6087 3
+      vertex 71.9895 62.2513 3
+      vertex 74.8488 57.3813 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 71.4991 62.1417 3
+      vertex 74.8488 57.3813 3
+      vertex 71.9895 62.2513 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.8488 57.3813 3
+      vertex 71.4991 62.1417 3
+      vertex 74.6907 57.1321 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 71.0027 62.0631 3
+      vertex 74.6907 57.1321 3
+      vertex 71.4991 62.1417 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.6907 57.1321 3
+      vertex 71.0027 62.0631 3
+      vertex 74.565 56.8651 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 70.5023 62.0158 3
+      vertex 74.565 56.8651 3
+      vertex 71.0027 62.0631 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.565 56.8651 3
+      vertex 70.5023 62.0158 3
+      vertex 74.4738 56.5844 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 70 62 3
+      vertex 74.4738 56.5844 3
+      vertex 70.5023 62.0158 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.5815 56.2945 3
+      vertex 74.4738 56.5844 3
+      vertex 70 62 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.5815 56.2945 3
+      vertex 74.4185 56.2945 3
+      vertex 74.4738 56.5844 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.5815 55.7055 3
+      vertex 74.4 56 3
+      vertex 65.6 56 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.4 56 3
+      vertex 74.2559 52.7414 3
+      vertex 74.3707 52.9103 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.5262 55.4156 3
+      vertex 74.4 56 3
+      vertex 65.5815 55.7055 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.4 56 3
+      vertex 74.152 52.5657 3
+      vertex 74.2559 52.7414 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.4 56 3
+      vertex 65.5262 55.4156 3
+      vertex 74.152 52.5657 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.152 52.5657 3
+      vertex 65.5262 55.4156 3
+      vertex 74.0593 52.3838 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 73.9782 49.8036 3
+      vertex 72.9357 49.035 3
+      vertex 73.4972 48.8329 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.0593 52.3838 3
+      vertex 65.5262 55.4156 3
+      vertex 73.9782 52.1964 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 73.8521 50.1918 3
+      vertex 72.3626 49.2015 3
+      vertex 72.9357 49.035 3
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 70 49.5 3
+      vertex 73.9782 52.1964 3
+      vertex 65.5262 55.4156 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 73.7564 50.7959 3
+      vertex 71.7801 49.3317 3
+      vertex 72.3626 49.2015 3
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 70.5965 49.4813 3
+      vertex 73.9091 52.0043 3
+      vertex 70 49.5 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 73.7564 51.2041 3
+      vertex 71.7801 49.3317 3
+      vertex 73.75 51 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 73.9091 52.0043 3
+      vertex 70.5965 49.4813 3
+      vertex 73.8521 51.8082 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 73.8521 51.8082 3
+      vertex 70.5965 49.4813 3
+      vertex 73.8076 51.609 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 73.9782 52.1964 3
+      vertex 70 49.5 3
+      vertex 73.9091 52.0043 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.4185 56.2945 3
+      vertex 65.6 56 3
+      vertex 74.4 56 3
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 71.1907 49.4251 3
+      vertex 73.8076 51.609 3
+      vertex 70.5965 49.4813 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.5815 56.2945 3
+      vertex 70 62 3
+      vertex 69.4977 62.0158 3
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 71.7801 49.3317 3
+      vertex 73.7564 51.2041 3
+      vertex 71.1907 49.4251 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.5815 56.2945 3
+      vertex 69.4977 62.0158 3
+      vertex 68.9973 62.0631 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 73.8076 51.609 3
+      vertex 71.1907 49.4251 3
+      vertex 73.7756 51.4073 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.5815 56.2945 3
+      vertex 68.9973 62.0631 3
+      vertex 68.5009 62.1417 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 73.7756 51.4073 3
+      vertex 71.1907 49.4251 3
+      vertex 73.7564 51.2041 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.5815 56.2945 3
+      vertex 68.5009 62.1417 3
+      vertex 68.0105 62.2513 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 65.435 55.1349 3
+      vertex 70 49.5 3
+      vertex 65.5262 55.4156 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.5815 56.2945 3
+      vertex 68.0105 62.2513 3
+      vertex 67.5279 62.3915 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 70 49.5 3
+      vertex 65.435 55.1349 3
+      vertex 69.4035 49.4813 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.5815 56.2945 3
+      vertex 67.5279 62.3915 3
+      vertex 67.055 62.5618 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.5815 56.2945 3
+      vertex 67.055 62.5618 3
+      vertex 66.5938 62.7614 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 65.3093 54.8679 3
+      vertex 69.4035 49.4813 3
+      vertex 65.435 55.1349 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.5815 56.2945 3
+      vertex 66.5938 62.7614 3
+      vertex 66.146 62.9895 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 69.4035 49.4813 3
+      vertex 65.3093 54.8679 3
+      vertex 68.8093 49.4251 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.9762 58.235 3
+      vertex 66.146 62.9895 3
+      vertex 65.7134 63.2454 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 65.1512 54.6187 3
+      vertex 68.8093 49.4251 3
+      vertex 65.3093 54.8679 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 68.8093 49.4251 3
+      vertex 65.1512 54.6187 3
+      vertex 68.2199 49.3317 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.9631 54.3913 3
+      vertex 68.2199 49.3317 3
+      vertex 65.1512 54.6187 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 68.2199 49.3317 3
+      vertex 64.9631 54.3913 3
+      vertex 67.6374 49.2015 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.7479 54.1893 3
+      vertex 67.6374 49.2015 3
+      vertex 64.9631 54.3913 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 67.6374 49.2015 3
+      vertex 64.7479 54.1893 3
+      vertex 67.0643 49.035 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.5092 54.0158 3
+      vertex 67.0643 49.035 3
+      vertex 64.7479 54.1893 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 67.0643 49.035 3
+      vertex 64.5092 54.0158 3
+      vertex 66.5028 48.8329 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.2506 53.8737 3
+      vertex 66.5028 48.8329 3
+      vertex 64.5092 54.0158 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 66.5028 48.8329 3
+      vertex 64.2506 53.8737 3
+      vertex 65.9551 48.5959 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.9762 53.765 3
+      vertex 65.9551 48.5959 3
+      vertex 64.2506 53.8737 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.6903 53.6916 3
+      vertex 65.9551 48.5959 3
+      vertex 63.9762 53.765 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.9551 48.5959 3
+      vertex 63.6903 53.6916 3
+      vertex 65.4233 48.3249 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.3976 53.6546 3
+      vertex 65.4233 48.3249 3
+      vertex 63.6903 53.6916 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.4233 48.3249 3
+      vertex 63.3976 53.6546 3
+      vertex 64.9096 48.0211 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.1024 53.6546 3
+      vertex 64.9096 48.0211 3
+      vertex 63.3976 53.6546 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.9096 48.0211 3
+      vertex 63.1024 53.6546 3
+      vertex 64.416 47.6857 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.8097 53.6916 3
+      vertex 64.416 47.6857 3
+      vertex 63.1024 53.6546 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.416 47.6857 3
+      vertex 62.8097 53.6916 3
+      vertex 63.9445 47.3199 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.5238 53.765 3
+      vertex 63.9445 47.3199 3
+      vertex 62.8097 53.6916 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.9445 47.3199 3
+      vertex 62.5238 53.765 3
+      vertex 63.4968 46.9252 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.2494 53.8737 3
+      vertex 63.4968 46.9252 3
+      vertex 62.5238 53.765 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.4968 46.9252 3
+      vertex 62.2494 53.8737 3
+      vertex 63.0748 46.5032 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.9908 54.0158 3
+      vertex 63.0748 46.5032 3
+      vertex 62.2494 53.8737 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.0748 46.5032 3
+      vertex 61.9908 54.0158 3
+      vertex 62.6801 46.0555 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.7521 54.1893 3
+      vertex 62.6801 46.0555 3
+      vertex 61.9908 54.0158 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.6801 46.0555 3
+      vertex 61.7521 54.1893 3
+      vertex 62.3143 45.584 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.5369 54.3913 3
+      vertex 62.3143 45.584 3
+      vertex 61.7521 54.1893 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.3143 45.584 3
+      vertex 61.5369 54.3913 3
+      vertex 61.9789 45.0904 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.3488 54.6187 3
+      vertex 61.9789 45.0904 3
+      vertex 61.5369 54.3913 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.9789 45.0904 3
+      vertex 61.3488 54.6187 3
+      vertex 61.6751 44.5767 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.1907 54.8679 3
+      vertex 61.6751 44.5767 3
+      vertex 61.3488 54.6187 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.6751 44.5767 3
+      vertex 61.1907 54.8679 3
+      vertex 61.4041 44.0449 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.1907 54.8679 3
+      vertex 61.1671 43.4972 3
+      vertex 61.4041 44.0449 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.065 55.1349 3
+      vertex 61.1671 43.4972 3
+      vertex 61.1907 54.8679 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.965 42.9357 3
+      vertex 61.065 55.1349 3
+      vertex 60.9738 55.4156 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.065 55.1349 3
+      vertex 60.965 42.9357 3
+      vertex 61.1671 43.4972 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.7985 42.3626 3
+      vertex 60.9738 55.4156 3
+      vertex 60.9185 55.7055 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.7985 42.3626 3
+      vertex 60.9185 55.7055 3
+      vertex 60.9 56 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9738 55.4156 3
+      vertex 60.7985 42.3626 3
+      vertex 60.965 42.9357 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.4908 54.0158 3
+      vertex 75.6162 53.9407 3
+      vertex 75.6225 53.9434 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.4908 54.0158 3
+      vertex 75.4343 53.848 3
+      vertex 75.6162 53.9407 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.2521 54.1893 3
+      vertex 75.4343 53.848 3
+      vertex 75.4908 54.0158 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.4343 53.848 3
+      vertex 75.2521 54.1893 3
+      vertex 75.2586 53.7441 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.2521 54.1893 3
+      vertex 75.0897 53.6293 3
+      vertex 75.2586 53.7441 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.0369 54.3913 3
+      vertex 75.0897 53.6293 3
+      vertex 75.2521 54.1893 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.0369 54.3913 3
+      vertex 74.9284 53.5042 3
+      vertex 75.0897 53.6293 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.8488 54.6187 3
+      vertex 74.9284 53.5042 3
+      vertex 75.0369 54.3913 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.8488 54.6187 3
+      vertex 74.7752 53.3691 3
+      vertex 74.9284 53.5042 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.6309 53.2248 3
+      vertex 74.8488 54.6187 3
+      vertex 74.6907 54.8679 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.8488 54.6187 3
+      vertex 74.6309 53.2248 3
+      vertex 74.7752 53.3691 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.3707 52.9103 3
+      vertex 74.6907 54.8679 3
+      vertex 74.565 55.1349 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.6907 54.8679 3
+      vertex 74.4958 53.0716 3
+      vertex 74.6309 53.2248 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.3707 52.9103 3
+      vertex 74.565 55.1349 3
+      vertex 74.4738 55.4156 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.3707 52.9103 3
+      vertex 74.4738 55.4156 3
+      vertex 74.4185 55.7055 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.3707 52.9103 3
+      vertex 74.4185 55.7055 3
+      vertex 74.4 56 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 74.6907 54.8679 3
+      vertex 74.3707 52.9103 3
+      vertex 74.4958 53.0716 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 111.76 41.1567 3
+      vertex 91.2401 41.1567 3
+      vertex 91.25 41 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 112.089 41.8557 3
+      vertex 91.2107 41.3109 3
+      vertex 91.2401 41.1567 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 112.089 41.8557 3
+      vertex 91.1622 41.4602 3
+      vertex 91.2107 41.3109 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 112.089 41.8557 3
+      vertex 91.0954 41.6022 3
+      vertex 91.1622 41.4602 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 112.089 41.8557 3
+      vertex 91.0113 41.7347 3
+      vertex 91.0954 41.6022 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 112.089 41.8557 3
+      vertex 90.9112 41.8557 3
+      vertex 91.0113 41.7347 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 110.75 62.25 3
+      vertex 90.7968 41.9631 3
+      vertex 90.9112 41.8557 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 110.75 62.25 3
+      vertex 90.6698 42.0554 3
+      vertex 90.7968 41.9631 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 85.5 62.25 3
+      vertex 90.6698 42.0554 3
+      vertex 110.75 62.25 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 90.6698 42.0554 3
+      vertex 85.5 62.25 3
+      vertex 90.5322 42.131 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 90.5322 42.131 3
+      vertex 85.5 62.25 3
+      vertex 90.3863 42.1888 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 90.3863 42.1888 3
+      vertex 85.5 62.25 3
+      vertex 90.2342 42.2279 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 90.2342 42.2279 3
+      vertex 85.5 62.25 3
+      vertex 90.0785 42.2475 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 80.2244 51.4073 3
+      vertex 90.0785 42.2475 3
+      vertex 85.5 62.25 3
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 80.2436 51.2041 3
+      vertex 90.0785 42.2475 3
+      vertex 80.2244 51.4073 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 90.0785 42.2475 3
+      vertex 80.2436 51.2041 3
+      vertex 89.9215 42.2475 3
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 80.25 51 3
+      vertex 89.9215 42.2475 3
+      vertex 80.2436 51.2041 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 89.9215 42.2475 3
+      vertex 80.25 51 3
+      vertex 89.7658 42.2279 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 80.2436 50.7959 3
+      vertex 89.7658 42.2279 3
+      vertex 80.25 51 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 80.0218 49.8036 3
+      vertex 89.3302 42.0554 3
+      vertex 80.0909 49.9957 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 89.4678 42.131 3
+      vertex 80.0909 49.9957 3
+      vertex 89.3302 42.0554 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 80.0909 49.9957 3
+      vertex 89.4678 42.131 3
+      vertex 80.1479 50.1918 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 89.6137 42.1888 3
+      vertex 80.1479 50.1918 3
+      vertex 89.4678 42.131 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 80.1479 50.1918 3
+      vertex 89.6137 42.1888 3
+      vertex 80.1924 50.391 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 80.1924 50.391 3
+      vertex 89.6137 42.1888 3
+      vertex 80.2244 50.5927 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 80.2244 50.5927 3
+      vertex 89.7658 42.2279 3
+      vertex 80.2436 50.7959 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.0954 98.3978 3
+      vertex 111.905 98.3978 3
+      vertex 91.1622 98.5398 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 111.905 98.3978 3
+      vertex 91.0954 98.3978 3
+      vertex 111.989 98.2653 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.0113 98.2653 3
+      vertex 111.989 98.2653 3
+      vertex 91.0954 98.3978 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 111.989 98.2653 3
+      vertex 91.0113 98.2653 3
+      vertex 112.089 98.1443 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 90.9112 98.1443 3
+      vertex 112.089 98.1443 3
+      vertex 91.0113 98.2653 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 112.089 98.1443 3
+      vertex 90.9112 98.1443 3
+      vertex 110.75 77.75 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 90.7968 98.0369 3
+      vertex 110.75 77.75 3
+      vertex 90.9112 98.1443 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 90.6698 97.9446 3
+      vertex 110.75 77.75 3
+      vertex 90.7968 98.0369 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 77.75 3
+      vertex 90.6698 97.9446 3
+      vertex 90.5322 97.869 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 77.75 3
+      vertex 90.5322 97.869 3
+      vertex 90.3863 97.8112 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 77.75 3
+      vertex 90.3863 97.8112 3
+      vertex 90.2342 97.7721 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 77.75 3
+      vertex 90.2342 97.7721 3
+      vertex 90.0785 97.7525 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 77.75 3
+      vertex 90.0785 97.7525 3
+      vertex 89.9215 97.7525 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.0815 84.2945 3
+      vertex 89.9215 97.7525 3
+      vertex 89.7658 97.7721 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.0815 84.2945 3
+      vertex 89.7658 97.7721 3
+      vertex 89.6137 97.8112 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.0815 84.2945 3
+      vertex 89.6137 97.8112 3
+      vertex 89.4678 97.869 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.0815 84.2945 3
+      vertex 89.4678 97.869 3
+      vertex 89.3302 97.9446 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.035 97.0643 3
+      vertex 88.9046 98.3978 3
+      vertex 79.2015 97.6374 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.2015 97.6374 3
+      vertex 88.8378 98.5398 3
+      vertex 79.3317 98.2199 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 90.6698 97.9446 3
+      vertex 85.5 77.75 3
+      vertex 110.75 77.75 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 88.7893 98.6891 3
+      vertex 79.3317 98.2199 3
+      vertex 88.8378 98.5398 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.3317 98.2199 3
+      vertex 88.7893 98.6891 3
+      vertex 79.4251 98.8093 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 88.7599 98.8433 3
+      vertex 79.4251 98.8093 3
+      vertex 88.7893 98.6891 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.4251 98.8093 3
+      vertex 88.7599 98.8433 3
+      vertex 79.4813 99.4035 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 88.75 99 3
+      vertex 79.4813 99.4035 3
+      vertex 88.7599 98.8433 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 88.7599 99.1567 3
+      vertex 79.4813 99.4035 3
+      vertex 88.75 99 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 140 12 3
+      vertex 114.24 41.1567 3
+      vertex 114.25 41 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 120.5 65 3
+      vertex 114.211 41.3109 3
+      vertex 114.24 41.1567 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 120.5 65 3
+      vertex 114.162 41.4602 3
+      vertex 114.211 41.3109 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 120.5 65 3
+      vertex 114.095 41.6022 3
+      vertex 114.162 41.4602 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 120.5 65 3
+      vertex 114.011 41.7347 3
+      vertex 114.095 41.6022 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 120.5 65 3
+      vertex 113.911 41.8557 3
+      vertex 114.011 41.7347 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 120.5 65 3
+      vertex 113.797 41.9631 3
+      vertex 113.911 41.8557 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 120.5 65 3
+      vertex 113.67 42.0554 3
+      vertex 113.797 41.9631 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 120.5 65 3
+      vertex 113.532 42.131 3
+      vertex 113.67 42.0554 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 110.75 62.25 3
+      vertex 113.532 42.131 3
+      vertex 120.5 65 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 113.532 42.131 3
+      vertex 110.75 62.25 3
+      vertex 113.386 42.1888 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 113.386 42.1888 3
+      vertex 110.75 62.25 3
+      vertex 113.234 42.2279 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 113.234 42.2279 3
+      vertex 110.75 62.25 3
+      vertex 113.078 42.2475 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 113.078 42.2475 3
+      vertex 110.75 62.25 3
+      vertex 112.922 42.2475 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 112.922 42.2475 3
+      vertex 110.75 62.25 3
+      vertex 112.766 42.2279 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 112.766 42.2279 3
+      vertex 110.75 62.25 3
+      vertex 112.614 42.1888 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 112.614 42.1888 3
+      vertex 110.75 62.25 3
+      vertex 112.468 42.131 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 112.468 42.131 3
+      vertex 110.75 62.25 3
+      vertex 112.33 42.0554 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 112.33 42.0554 3
+      vertex 110.75 62.25 3
+      vertex 112.203 41.9631 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 112.203 41.9631 3
+      vertex 110.75 62.25 3
+      vertex 112.089 41.8557 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 90.9112 41.8557 3
+      vertex 112.089 41.8557 3
+      vertex 110.75 62.25 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.2401 41.1567 3
+      vertex 111.989 41.7347 3
+      vertex 112.089 41.8557 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.2401 41.1567 3
+      vertex 111.789 41.3109 3
+      vertex 111.838 41.4602 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.2401 41.1567 3
+      vertex 111.838 41.4602 3
+      vertex 111.905 41.6022 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.2401 41.1567 3
+      vertex 111.905 41.6022 3
+      vertex 111.989 41.7347 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 110.75 62.25 3
+      vertex 120.5 65 3
+      vertex 110.75 65 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 140 128 3
+      vertex 120.5 75 3
+      vertex 140 12 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 114.24 98.8433 3
+      vertex 140 128 3
+      vertex 114.25 99 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 140 128 3
+      vertex 114.24 99.1567 3
+      vertex 114.25 99 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 140 128 3
+      vertex 114.211 99.3109 3
+      vertex 114.24 99.1567 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 140 128 3
+      vertex 114.162 99.4602 3
+      vertex 114.211 99.3109 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 140 128 3
+      vertex 114.095 99.6022 3
+      vertex 114.162 99.4602 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 140 128 3
+      vertex 114.011 99.7347 3
+      vertex 114.095 99.6022 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 140 128 3
+      vertex 113.911 99.8557 3
+      vertex 114.011 99.7347 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 140 128 3
+      vertex 113.797 99.9631 3
+      vertex 113.911 99.8557 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 140 128 3
+      vertex 113.67 100.055 3
+      vertex 113.797 99.9631 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 140 128 3
+      vertex 113.532 100.131 3
+      vertex 113.67 100.055 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 140 128 3
+      vertex 113.386 100.189 3
+      vertex 113.532 100.131 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 140 128 3
+      vertex 113.234 100.228 3
+      vertex 113.386 100.189 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 140 128 3
+      vertex 113.078 100.248 3
+      vertex 113.234 100.228 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 140 128 3
+      vertex 112.922 100.248 3
+      vertex 113.078 100.248 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 140 128 3
+      vertex 112.766 100.228 3
+      vertex 112.922 100.248 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 140 128 3
+      vertex 112.614 100.189 3
+      vertex 112.766 100.228 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 90.3863 100.189 3
+      vertex 112.614 100.189 3
+      vertex 140 128 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 112.614 100.189 3
+      vertex 90.3863 100.189 3
+      vertex 112.468 100.131 3
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 90.5322 100.131 3
+      vertex 112.468 100.131 3
+      vertex 90.3863 100.189 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 112.468 100.131 3
+      vertex 90.5322 100.131 3
+      vertex 112.33 100.055 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 111.838 98.5398 3
+      vertex 91.1622 98.5398 3
+      vertex 111.905 98.3978 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 111.76 99.1567 3
+      vertex 91.25 99 3
+      vertex 111.75 99 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.2401 99.1567 3
+      vertex 111.76 99.1567 3
+      vertex 111.789 99.3109 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.2107 99.3109 3
+      vertex 111.789 99.3109 3
+      vertex 111.838 99.4602 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.1622 99.4602 3
+      vertex 111.838 99.4602 3
+      vertex 111.905 99.6022 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.0954 99.6022 3
+      vertex 111.905 99.6022 3
+      vertex 111.989 99.7347 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.0113 99.7347 3
+      vertex 111.989 99.7347 3
+      vertex 112.089 99.8557 3
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 90.6698 100.055 3
+      vertex 112.33 100.055 3
+      vertex 90.5322 100.131 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 111.76 99.1567 3
+      vertex 91.2401 99.1567 3
+      vertex 91.25 99 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 111.789 99.3109 3
+      vertex 91.2107 99.3109 3
+      vertex 91.2401 99.1567 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 111.838 99.4602 3
+      vertex 91.1622 99.4602 3
+      vertex 91.2107 99.3109 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 111.905 99.6022 3
+      vertex 91.0954 99.6022 3
+      vertex 91.1622 99.4602 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 111.989 99.7347 3
+      vertex 91.0113 99.7347 3
+      vertex 91.0954 99.6022 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 112.089 99.8557 3
+      vertex 90.9112 99.8557 3
+      vertex 91.0113 99.7347 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 112.089 99.8557 3
+      vertex 90.7968 99.9631 3
+      vertex 90.9112 99.8557 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 112.203 99.9631 3
+      vertex 90.7968 99.9631 3
+      vertex 112.089 99.8557 3
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 90.7968 99.9631 3
+      vertex 112.203 99.9631 3
+      vertex 90.6698 100.055 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 112.33 100.055 3
+      vertex 90.6698 100.055 3
+      vertex 112.203 99.9631 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 76.0555 107.32 3
+      vertex 90.3863 100.189 3
+      vertex 140 128 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 90.3863 100.189 3
+      vertex 76.0555 107.32 3
+      vertex 90.2342 100.228 3
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 76.5032 106.925 3
+      vertex 90.2342 100.228 3
+      vertex 76.0555 107.32 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 90.2342 100.228 3
+      vertex 76.5032 106.925 3
+      vertex 90.0785 100.248 3
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 76.9252 106.503 3
+      vertex 90.0785 100.248 3
+      vertex 76.5032 106.925 3
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 77.3199 106.056 3
+      vertex 90.0785 100.248 3
+      vertex 76.9252 106.503 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 90.0785 100.248 3
+      vertex 77.3199 106.056 3
+      vertex 89.9215 100.248 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 79.4813 99.4035 3
+      vertex 88.7599 99.1567 3
+      vertex 79.5 100 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.5042 53.0716 3
+      vertex 85.5 62.25 3
+      vertex 85.5 77.75 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 88.8378 98.5398 3
+      vertex 79.2015 97.6374 3
+      vertex 88.9046 98.3978 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 79.9407 49.6162 3
+      vertex 89.3302 42.0554 3
+      vertex 80.0218 49.8036 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 89.7658 42.2279 3
+      vertex 80.2244 50.5927 3
+      vertex 89.6137 42.1888 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 62.25 3
+      vertex 80.1924 51.609 3
+      vertex 80.2244 51.4073 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 62.25 3
+      vertex 80.1479 51.8082 3
+      vertex 80.1924 51.609 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 62.25 3
+      vertex 80.0909 52.0043 3
+      vertex 80.1479 51.8082 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 62.25 3
+      vertex 80.0218 52.1964 3
+      vertex 80.0909 52.0043 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 62.25 3
+      vertex 79.9407 52.3838 3
+      vertex 80.0218 52.1964 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 62.25 3
+      vertex 79.848 52.5657 3
+      vertex 79.9407 52.3838 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.5 100 3
+      vertex 88.7599 99.1567 3
+      vertex 88.7893 99.3109 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 62.25 3
+      vertex 79.7441 52.7414 3
+      vertex 79.848 52.5657 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 62.25 3
+      vertex 79.6293 52.9103 3
+      vertex 79.7441 52.7414 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 85.5 62.25 3
+      vertex 79.5042 53.0716 3
+      vertex 79.6293 52.9103 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 88.9046 98.3978 3
+      vertex 79.035 97.0643 3
+      vertex 88.9887 98.2653 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.4813 100.597 3
+      vertex 88.7893 99.3109 3
+      vertex 88.8378 99.4602 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.4251 101.191 3
+      vertex 88.8378 99.4602 3
+      vertex 88.9046 99.6022 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.3317 101.78 3
+      vertex 88.9046 99.6022 3
+      vertex 88.9887 99.7347 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.2015 102.363 3
+      vertex 88.9887 99.7347 3
+      vertex 89.0888 99.8557 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.2015 102.363 3
+      vertex 89.0888 99.8557 3
+      vertex 89.2032 99.9631 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.035 102.936 3
+      vertex 89.2032 99.9631 3
+      vertex 89.3302 100.055 3
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 77.6857 105.584 3
+      vertex 89.9215 100.248 3
+      vertex 77.3199 106.056 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 88.7893 99.3109 3
+      vertex 79.4813 100.597 3
+      vertex 79.5 100 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 88.8378 99.4602 3
+      vertex 79.4251 101.191 3
+      vertex 79.4813 100.597 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 88.9046 99.6022 3
+      vertex 79.3317 101.78 3
+      vertex 79.4251 101.191 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 88.9887 99.7347 3
+      vertex 79.2015 102.363 3
+      vertex 79.3317 101.78 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 89.2032 99.9631 3
+      vertex 79.035 102.936 3
+      vertex 79.2015 102.363 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 89.3302 100.055 3
+      vertex 78.8329 103.497 3
+      vertex 79.035 102.936 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 89.3302 100.055 3
+      vertex 78.5959 104.045 3
+      vertex 78.8329 103.497 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 89.4678 100.131 3
+      vertex 78.5959 104.045 3
+      vertex 89.3302 100.055 3
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 78.5959 104.045 3
+      vertex 89.4678 100.131 3
+      vertex 78.3249 104.577 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 89.6137 100.189 3
+      vertex 78.3249 104.577 3
+      vertex 89.4678 100.131 3
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 78.3249 104.577 3
+      vertex 89.6137 100.189 3
+      vertex 78.0211 105.09 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 89.7658 100.228 3
+      vertex 78.0211 105.09 3
+      vertex 89.6137 100.189 3
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 78.0211 105.09 3
+      vertex 89.7658 100.228 3
+      vertex 77.6857 105.584 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 89.9215 100.248 3
+      vertex 77.6857 105.584 3
+      vertex 89.7658 100.228 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 140 128 3
+      vertex 75.584 107.686 3
+      vertex 76.0555 107.32 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 140 128 3
+      vertex 75.0904 108.021 3
+      vertex 75.584 107.686 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 140 128 3
+      vertex 74.5767 108.325 3
+      vertex 75.0904 108.021 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 140 128 3
+      vertex 74.0449 108.596 3
+      vertex 74.5767 108.325 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 140 128 3
+      vertex 73.4972 108.833 3
+      vertex 74.0449 108.596 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 140 128 3
+      vertex 72.9357 109.035 3
+      vertex 73.4972 108.833 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 140 128 3
+      vertex 72.3626 109.202 3
+      vertex 72.9357 109.035 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 140 128 3
+      vertex 71.7801 109.332 3
+      vertex 72.3626 109.202 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 140 128 3
+      vertex 71.1907 109.425 3
+      vertex 71.7801 109.332 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 140 128 3
+      vertex 70.5965 109.481 3
+      vertex 71.1907 109.425 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 140 128 3
+      vertex 70 109.5 3
+      vertex 70.5965 109.481 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0 128 3
+      vertex 70 109.5 3
+      vertex 140 128 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 70 109.5 3
+      vertex 0 128 3
+      vertex 69.4035 109.481 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 69.4035 109.481 3
+      vertex 0 128 3
+      vertex 68.8093 109.425 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 68.8093 109.425 3
+      vertex 0 128 3
+      vertex 68.2199 109.332 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.1671 96.5028 3
+      vertex 60.3707 90.9103 3
+      vertex 60.4958 91.0716 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.965 97.0643 3
+      vertex 60.2559 90.7414 3
+      vertex 60.3707 90.9103 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.965 97.0643 3
+      vertex 60.152 90.5657 3
+      vertex 60.2559 90.7414 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 128 3
+      vertex 60.5 100 3
+      vertex 60.5187 100.597 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.7985 97.6374 3
+      vertex 60.0593 90.3838 3
+      vertex 60.152 90.5657 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.6683 98.2199 3
+      vertex 59.9782 90.1964 3
+      vertex 60.0593 90.3838 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.6683 98.2199 3
+      vertex 59.9091 90.0043 3
+      vertex 59.9782 90.1964 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.5749 98.8093 3
+      vertex 59.8521 89.8082 3
+      vertex 59.9091 90.0043 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.5187 99.4035 3
+      vertex 59.8076 89.609 3
+      vertex 59.8521 89.8082 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.5187 99.4035 3
+      vertex 0 128 3
+      vertex 59.8076 89.609 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.8076 89.609 3
+      vertex 0 128 3
+      vertex 59.7756 89.4073 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 59.5716 58.5042 3
+      vertex 59.7248 58.3691 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 59.4103 58.6293 3
+      vertex 59.5716 58.5042 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 59.2414 58.7441 3
+      vertex 59.4103 58.6293 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 59.0657 58.848 3
+      vertex 59.2414 58.7441 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 58.8838 58.9407 3
+      vertex 59.0657 58.848 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 58.6964 59.0218 3
+      vertex 58.8838 58.9407 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 128 3
+      vertex 59.75 89 3
+      vertex 59.7564 89.2041 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 58.5043 59.0909 3
+      vertex 58.6964 59.0218 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 58.3082 59.1479 3
+      vertex 58.5043 59.0909 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 58.109 59.1924 3
+      vertex 58.3082 59.1479 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 57.9073 59.2244 3
+      vertex 58.109 59.1924 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 57.7041 59.2436 3
+      vertex 57.9073 59.2244 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.7756 89.4073 3
+      vertex 0 128 3
+      vertex 59.7564 89.2041 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 57.5 59.25 3
+      vertex 57.7041 59.2436 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 57.2959 59.2436 3
+      vertex 57.5 59.25 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 57.0927 59.2244 3
+      vertex 57.2959 59.2436 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 56.891 59.1924 3
+      vertex 57.0927 59.2244 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 56.6918 59.1479 3
+      vertex 56.891 59.1924 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 56.4957 59.0909 3
+      vertex 56.6918 59.1479 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 128 3
+      vertex 60.5187 100.597 3
+      vertex 60.5749 101.191 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 56.3036 59.0218 3
+      vertex 56.4957 59.0909 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 56.1162 58.9407 3
+      vertex 56.3036 59.0218 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 55.9343 58.848 3
+      vertex 56.1162 58.9407 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 55.7586 58.7441 3
+      vertex 55.9343 58.848 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 55.5897 58.6293 3
+      vertex 55.7586 58.7441 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 55.4284 58.5042 3
+      vertex 55.5897 58.6293 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 55.2752 58.3691 3
+      vertex 55.4284 58.5042 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 55.1309 58.2248 3
+      vertex 55.2752 58.3691 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 54.9958 58.0716 3
+      vertex 55.1309 58.2248 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9 84 3
+      vertex 54.8707 57.9103 3
+      vertex 54.9958 58.0716 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.7756 88.5927 3
+      vertex 0 128 3
+      vertex 54.652 57.5657 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.8521 88.1918 3
+      vertex 54.7559 57.7414 3
+      vertex 54.8707 57.9103 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.8076 88.391 3
+      vertex 54.652 57.5657 3
+      vertex 54.7559 57.7414 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.652 57.5657 3
+      vertex 0 128 3
+      vertex 54.5593 57.3838 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.5593 57.3838 3
+      vertex 0 128 3
+      vertex 54.4782 57.1964 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.4782 57.1964 3
+      vertex 0 128 3
+      vertex 54.4091 57.0043 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.4091 57.0043 3
+      vertex 0 128 3
+      vertex 54.3521 56.8082 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 12 3
+      vertex 54.3521 56.8082 3
+      vertex 0 128 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.2756 56.4073 3
+      vertex 0 12 3
+      vertex 54.2564 56.2041 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.3076 56.609 3
+      vertex 0 12 3
+      vertex 54.2756 56.4073 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.3521 56.8082 3
+      vertex 0 12 3
+      vertex 54.3076 56.609 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.6683 101.78 3
+      vertex 0 128 3
+      vertex 60.5749 101.191 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.7985 102.363 3
+      vertex 0 128 3
+      vertex 60.6683 101.78 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.965 102.936 3
+      vertex 0 128 3
+      vertex 60.7985 102.363 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.1671 103.497 3
+      vertex 0 128 3
+      vertex 60.965 102.936 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.4041 104.045 3
+      vertex 0 128 3
+      vertex 61.1671 103.497 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.6751 104.577 3
+      vertex 0 128 3
+      vertex 61.4041 104.045 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.9789 105.09 3
+      vertex 0 128 3
+      vertex 61.6751 104.577 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.3143 105.584 3
+      vertex 0 128 3
+      vertex 61.9789 105.09 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.6801 106.056 3
+      vertex 0 128 3
+      vertex 62.3143 105.584 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.0748 106.503 3
+      vertex 0 128 3
+      vertex 62.6801 106.056 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.4968 106.925 3
+      vertex 0 128 3
+      vertex 63.0748 106.503 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.9445 107.32 3
+      vertex 0 128 3
+      vertex 63.4968 106.925 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.416 107.686 3
+      vertex 0 128 3
+      vertex 63.9445 107.32 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.9096 108.021 3
+      vertex 0 128 3
+      vertex 64.416 107.686 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.4233 108.325 3
+      vertex 0 128 3
+      vertex 64.9096 108.021 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.9551 108.596 3
+      vertex 0 128 3
+      vertex 65.4233 108.325 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 66.5028 108.833 3
+      vertex 0 128 3
+      vertex 65.9551 108.596 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 67.0643 109.035 3
+      vertex 0 128 3
+      vertex 66.5028 108.833 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 67.6374 109.202 3
+      vertex 0 128 3
+      vertex 67.0643 109.035 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 68.2199 109.332 3
+      vertex 0 128 3
+      vertex 67.6374 109.202 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 120.5 65 3
+      vertex 140 12 3
+      vertex 120.5 75 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 114.24 41.1567 3
+      vertex 140 12 3
+      vertex 120.5 65 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 114.24 40.8433 3
+      vertex 140 12 3
+      vertex 114.25 41 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 114.211 40.6891 3
+      vertex 140 12 3
+      vertex 114.24 40.8433 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 114.162 40.5398 3
+      vertex 140 12 3
+      vertex 114.211 40.6891 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 114.095 40.3978 3
+      vertex 140 12 3
+      vertex 114.162 40.5398 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 114.011 40.2653 3
+      vertex 140 12 3
+      vertex 114.095 40.3978 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 113.911 40.1443 3
+      vertex 140 12 3
+      vertex 114.011 40.2653 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 113.797 40.0369 3
+      vertex 140 12 3
+      vertex 113.911 40.1443 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 113.67 39.9446 3
+      vertex 140 12 3
+      vertex 113.797 40.0369 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 113.532 39.869 3
+      vertex 140 12 3
+      vertex 113.67 39.9446 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 113.386 39.8112 3
+      vertex 140 12 3
+      vertex 113.532 39.869 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 113.234 39.7721 3
+      vertex 140 12 3
+      vertex 113.386 39.8112 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 113.078 39.7525 3
+      vertex 140 12 3
+      vertex 113.234 39.7721 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 112.922 39.7525 3
+      vertex 140 12 3
+      vertex 113.078 39.7525 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 112.766 39.7721 3
+      vertex 140 12 3
+      vertex 112.922 39.7525 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 112.614 39.8112 3
+      vertex 140 12 3
+      vertex 112.766 39.7721 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 90.3863 39.8112 3
+      vertex 112.614 39.8112 3
+      vertex 112.468 39.869 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 90.5322 39.869 3
+      vertex 112.468 39.869 3
+      vertex 112.33 39.9446 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 90.6698 39.9446 3
+      vertex 112.33 39.9446 3
+      vertex 112.203 40.0369 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 90.7968 40.0369 3
+      vertex 112.203 40.0369 3
+      vertex 112.089 40.1443 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.2401 41.1567 3
+      vertex 111.76 41.1567 3
+      vertex 111.789 41.3109 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 111.76 41.1567 3
+      vertex 91.25 41 3
+      vertex 111.75 41 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 91.25 41 3
+      vertex 111.76 40.8433 3
+      vertex 111.75 41 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.2401 40.8433 3
+      vertex 111.76 40.8433 3
+      vertex 91.25 41 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 111.76 40.8433 3
+      vertex 91.2401 40.8433 3
+      vertex 111.789 40.6891 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.2107 40.6891 3
+      vertex 111.789 40.6891 3
+      vertex 91.2401 40.8433 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 111.789 40.6891 3
+      vertex 91.2107 40.6891 3
+      vertex 111.838 40.5398 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.1622 40.5398 3
+      vertex 111.838 40.5398 3
+      vertex 91.2107 40.6891 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 111.838 40.5398 3
+      vertex 91.1622 40.5398 3
+      vertex 111.905 40.3978 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.0954 40.3978 3
+      vertex 111.905 40.3978 3
+      vertex 91.1622 40.5398 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 111.905 40.3978 3
+      vertex 91.0954 40.3978 3
+      vertex 111.989 40.2653 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.0113 40.2653 3
+      vertex 111.989 40.2653 3
+      vertex 91.0954 40.3978 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 111.989 40.2653 3
+      vertex 91.0113 40.2653 3
+      vertex 112.089 40.1443 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 90.9112 40.1443 3
+      vertex 112.089 40.1443 3
+      vertex 91.0113 40.2653 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 90.7968 40.0369 3
+      vertex 112.089 40.1443 3
+      vertex 90.9112 40.1443 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 112.203 40.0369 3
+      vertex 90.7968 40.0369 3
+      vertex 90.6698 39.9446 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 112.33 39.9446 3
+      vertex 90.6698 39.9446 3
+      vertex 90.5322 39.869 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 112.468 39.869 3
+      vertex 90.5322 39.869 3
+      vertex 90.3863 39.8112 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 112.614 39.8112 3
+      vertex 90.3863 39.8112 3
+      vertex 140 12 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.0555 32.6801 3
+      vertex 90.3863 39.8112 3
+      vertex 90.2342 39.7721 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 76.5032 33.0748 3
+      vertex 90.2342 39.7721 3
+      vertex 90.0785 39.7525 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.3199 33.9445 3
+      vertex 90.0785 39.7525 3
+      vertex 89.9215 39.7525 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 77.6857 34.416 3
+      vertex 89.9215 39.7525 3
+      vertex 89.7658 39.7721 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.0211 34.9096 3
+      vertex 89.7658 39.7721 3
+      vertex 89.6137 39.8112 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.3249 35.4233 3
+      vertex 89.6137 39.8112 3
+      vertex 89.4678 39.869 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.5959 35.9551 3
+      vertex 89.4678 39.869 3
+      vertex 89.3302 39.9446 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 89.3302 42.0554 3
+      vertex 79.9407 49.6162 3
+      vertex 89.2032 41.9631 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 79.848 49.4343 3
+      vertex 89.2032 41.9631 3
+      vertex 79.9407 49.6162 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 89.2032 41.9631 3
+      vertex 79.848 49.4343 3
+      vertex 89.0888 41.8557 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 79.7441 49.2586 3
+      vertex 89.0888 41.8557 3
+      vertex 79.848 49.4343 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 79.6293 49.0897 3
+      vertex 89.0888 41.8557 3
+      vertex 79.7441 49.2586 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 89.0888 41.8557 3
+      vertex 79.6293 49.0897 3
+      vertex 88.9887 41.7347 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.8329 43.4972 3
+      vertex 79.6293 49.0897 3
+      vertex 79.5042 48.9284 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.6293 49.0897 3
+      vertex 78.8329 43.4972 3
+      vertex 88.9887 41.7347 3
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 79.035 42.9357 3
+      vertex 88.9887 41.7347 3
+      vertex 78.8329 43.4972 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.4813 40.5965 3
+      vertex 88.8378 41.4602 3
+      vertex 88.9046 41.6022 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.4813 40.5965 3
+      vertex 88.7893 41.3109 3
+      vertex 88.8378 41.4602 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.4813 40.5965 3
+      vertex 88.7599 41.1567 3
+      vertex 88.7893 41.3109 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.4813 40.5965 3
+      vertex 88.75 41 3
+      vertex 88.7599 41.1567 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.4813 40.5965 3
+      vertex 88.7599 40.8433 3
+      vertex 88.75 41 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 88.7599 40.8433 3
+      vertex 79.5 40 3
+      vertex 88.7893 40.6891 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.4813 39.4035 3
+      vertex 88.7893 40.6891 3
+      vertex 79.5 40 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 88.7893 40.6891 3
+      vertex 79.4813 39.4035 3
+      vertex 88.8378 40.5398 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.4251 38.8093 3
+      vertex 88.8378 40.5398 3
+      vertex 79.4813 39.4035 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 88.8378 40.5398 3
+      vertex 79.4251 38.8093 3
+      vertex 88.9046 40.3978 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.3317 38.2199 3
+      vertex 88.9046 40.3978 3
+      vertex 79.4251 38.8093 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 88.9046 40.3978 3
+      vertex 79.3317 38.2199 3
+      vertex 88.9887 40.2653 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.2015 37.6374 3
+      vertex 88.9887 40.2653 3
+      vertex 79.3317 38.2199 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 88.9887 40.2653 3
+      vertex 79.2015 37.6374 3
+      vertex 89.0888 40.1443 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 89.0888 40.1443 3
+      vertex 79.2015 37.6374 3
+      vertex 89.2032 40.0369 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 79.035 37.0643 3
+      vertex 89.2032 40.0369 3
+      vertex 79.2015 37.6374 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 89.2032 40.0369 3
+      vertex 79.035 37.0643 3
+      vertex 89.3302 39.9446 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.8329 36.5028 3
+      vertex 89.3302 39.9446 3
+      vertex 79.035 37.0643 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 78.5959 35.9551 3
+      vertex 89.3302 39.9446 3
+      vertex 78.8329 36.5028 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 89.4678 39.869 3
+      vertex 78.5959 35.9551 3
+      vertex 78.3249 35.4233 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 89.6137 39.8112 3
+      vertex 78.3249 35.4233 3
+      vertex 78.0211 34.9096 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 89.7658 39.7721 3
+      vertex 78.0211 34.9096 3
+      vertex 77.6857 34.416 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 89.9215 39.7525 3
+      vertex 77.6857 34.416 3
+      vertex 77.3199 33.9445 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 90.0785 39.7525 3
+      vertex 77.3199 33.9445 3
+      vertex 76.9252 33.4968 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 90.0785 39.7525 3
+      vertex 76.9252 33.4968 3
+      vertex 76.5032 33.0748 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 90.2342 39.7721 3
+      vertex 76.5032 33.0748 3
+      vertex 76.0555 32.6801 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 90.3863 39.8112 3
+      vertex 76.0555 32.6801 3
+      vertex 140 12 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 75.584 32.3143 3
+      vertex 140 12 3
+      vertex 76.0555 32.6801 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 75.0904 31.9789 3
+      vertex 140 12 3
+      vertex 75.584 32.3143 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 74.5767 31.6751 3
+      vertex 140 12 3
+      vertex 75.0904 31.9789 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 74.0449 31.4041 3
+      vertex 140 12 3
+      vertex 74.5767 31.6751 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 73.4972 31.1671 3
+      vertex 140 12 3
+      vertex 74.0449 31.4041 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 72.9357 30.965 3
+      vertex 140 12 3
+      vertex 73.4972 31.1671 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 72.3626 30.7985 3
+      vertex 140 12 3
+      vertex 72.9357 30.965 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 71.7801 30.6683 3
+      vertex 140 12 3
+      vertex 72.3626 30.7985 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 71.1907 30.5749 3
+      vertex 140 12 3
+      vertex 71.7801 30.6683 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 70.5965 30.5187 3
+      vertex 140 12 3
+      vertex 71.1907 30.5749 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 70 30.5 3
+      vertex 140 12 3
+      vertex 70.5965 30.5187 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 12 3
+      vertex 70 30.5 3
+      vertex 69.4035 30.5187 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 12 3
+      vertex 69.4035 30.5187 3
+      vertex 68.8093 30.5749 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 12 3
+      vertex 68.8093 30.5749 3
+      vertex 68.2199 30.6683 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 12 3
+      vertex 68.2199 30.6683 3
+      vertex 67.6374 30.7985 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 59.8691 53.7752 3
+      vertex 60.7985 42.3626 3
+      vertex 60.0042 53.9284 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 59.7248 53.6309 3
+      vertex 60.7985 42.3626 3
+      vertex 59.8691 53.7752 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 59.5716 53.4958 3
+      vertex 60.7985 42.3626 3
+      vertex 59.7248 53.6309 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 59.4103 53.3707 3
+      vertex 60.7985 42.3626 3
+      vertex 59.5716 53.4958 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 59.2414 53.2559 3
+      vertex 60.7985 42.3626 3
+      vertex 59.4103 53.3707 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 59.0657 53.152 3
+      vertex 60.7985 42.3626 3
+      vertex 59.2414 53.2559 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 58.8838 53.0593 3
+      vertex 60.7985 42.3626 3
+      vertex 59.0657 53.152 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 58.6964 52.9782 3
+      vertex 60.7985 42.3626 3
+      vertex 58.8838 53.0593 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 58.5043 52.9091 3
+      vertex 60.7985 42.3626 3
+      vertex 58.6964 52.9782 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 58.3082 52.8521 3
+      vertex 60.7985 42.3626 3
+      vertex 58.5043 52.9091 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 58.109 52.8076 3
+      vertex 60.7985 42.3626 3
+      vertex 58.3082 52.8521 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 57.9073 52.7756 3
+      vertex 60.7985 42.3626 3
+      vertex 58.109 52.8076 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 57.7041 52.7564 3
+      vertex 60.7985 42.3626 3
+      vertex 57.9073 52.7756 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 57.5 52.75 3
+      vertex 60.7985 42.3626 3
+      vertex 57.7041 52.7564 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 57.2959 52.7564 3
+      vertex 60.7985 42.3626 3
+      vertex 57.5 52.75 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 57.0927 52.7756 3
+      vertex 60.7985 42.3626 3
+      vertex 57.2959 52.7564 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 56.891 52.8076 3
+      vertex 60.7985 42.3626 3
+      vertex 57.0927 52.7756 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 56.6918 52.8521 3
+      vertex 60.7985 42.3626 3
+      vertex 56.891 52.8076 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 56.4957 52.9091 3
+      vertex 60.7985 42.3626 3
+      vertex 56.6918 52.8521 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 56.3036 52.9782 3
+      vertex 60.7985 42.3626 3
+      vertex 56.4957 52.9091 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 56.1162 53.0593 3
+      vertex 60.7985 42.3626 3
+      vertex 56.3036 52.9782 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 55.9343 53.152 3
+      vertex 60.7985 42.3626 3
+      vertex 56.1162 53.0593 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.7985 42.3626 3
+      vertex 55.9343 53.152 3
+      vertex 60.6683 41.7801 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 55.7586 53.2559 3
+      vertex 60.6683 41.7801 3
+      vertex 55.9343 53.152 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 55.5897 53.3707 3
+      vertex 60.6683 41.7801 3
+      vertex 55.7586 53.2559 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.6683 41.7801 3
+      vertex 55.5897 53.3707 3
+      vertex 60.5749 41.1907 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 55.4284 53.4958 3
+      vertex 60.5749 41.1907 3
+      vertex 55.5897 53.3707 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.5749 41.1907 3
+      vertex 55.4284 53.4958 3
+      vertex 60.5187 40.5965 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 55.2752 53.6309 3
+      vertex 60.5187 40.5965 3
+      vertex 55.4284 53.4958 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.5187 40.5965 3
+      vertex 55.2752 53.6309 3
+      vertex 60.5 40 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 55.1309 53.7752 3
+      vertex 60.5 40 3
+      vertex 55.2752 53.6309 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.9958 53.9284 3
+      vertex 60.5 40 3
+      vertex 55.1309 53.7752 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.5 40 3
+      vertex 54.9958 53.9284 3
+      vertex 60.5187 39.4035 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8707 54.0897 3
+      vertex 60.5187 39.4035 3
+      vertex 54.9958 53.9284 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.5187 39.4035 3
+      vertex 54.8707 54.0897 3
+      vertex 60.5749 38.8093 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 12 3
+      vertex 60.5749 38.8093 3
+      vertex 54.8707 54.0897 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.5749 38.8093 3
+      vertex 0 12 3
+      vertex 60.6683 38.2199 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.6683 38.2199 3
+      vertex 0 12 3
+      vertex 60.7985 37.6374 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 12 3
+      vertex 54.8707 54.0897 3
+      vertex 54.7559 54.2586 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.7985 37.6374 3
+      vertex 0 12 3
+      vertex 60.965 37.0643 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 12 3
+      vertex 54.7559 54.2586 3
+      vertex 54.652 54.4343 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 12 3
+      vertex 54.652 54.4343 3
+      vertex 54.5593 54.6162 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 12 3
+      vertex 54.5593 54.6162 3
+      vertex 54.4782 54.8036 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.2564 56.2041 3
+      vertex 0 12 3
+      vertex 54.25 56 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.25 56 3
+      vertex 0 12 3
+      vertex 54.2564 55.7959 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.2564 55.7959 3
+      vertex 0 12 3
+      vertex 54.2756 55.5927 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.2756 55.5927 3
+      vertex 0 12 3
+      vertex 54.3076 55.391 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.3076 55.391 3
+      vertex 0 12 3
+      vertex 54.3521 55.1918 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.3521 55.1918 3
+      vertex 0 12 3
+      vertex 54.4091 54.9957 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.4091 54.9957 3
+      vertex 0 12 3
+      vertex 54.4782 54.8036 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.965 37.0643 3
+      vertex 0 12 3
+      vertex 61.1671 36.5028 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.1671 36.5028 3
+      vertex 0 12 3
+      vertex 61.4041 35.9551 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.4041 35.9551 3
+      vertex 0 12 3
+      vertex 61.6751 35.4233 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 70 30.5 3
+      vertex 0 12 3
+      vertex 140 12 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 67.0643 30.965 3
+      vertex 0 12 3
+      vertex 67.6374 30.7985 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 66.5028 31.1671 3
+      vertex 0 12 3
+      vertex 67.0643 30.965 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.9551 31.4041 3
+      vertex 0 12 3
+      vertex 66.5028 31.1671 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.4233 31.6751 3
+      vertex 0 12 3
+      vertex 65.9551 31.4041 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.9096 31.9789 3
+      vertex 0 12 3
+      vertex 65.4233 31.6751 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.416 32.3143 3
+      vertex 0 12 3
+      vertex 64.9096 31.9789 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.9445 32.6801 3
+      vertex 0 12 3
+      vertex 64.416 32.3143 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.4968 33.0748 3
+      vertex 0 12 3
+      vertex 63.9445 32.6801 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.0748 33.4968 3
+      vertex 0 12 3
+      vertex 63.4968 33.0748 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.6801 33.9445 3
+      vertex 0 12 3
+      vertex 63.0748 33.4968 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.3143 34.416 3
+      vertex 0 12 3
+      vertex 62.6801 33.9445 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.9789 34.9096 3
+      vertex 0 12 3
+      vertex 62.3143 34.416 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.6751 35.4233 3
+      vertex 0 12 3
+      vertex 61.9789 34.9096 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 140 128 3
+      vertex 114.24 98.8433 3
+      vertex 120.5 75 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 114.211 98.6891 3
+      vertex 120.5 75 3
+      vertex 114.24 98.8433 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 114.162 98.5398 3
+      vertex 120.5 75 3
+      vertex 114.211 98.6891 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 114.095 98.3978 3
+      vertex 120.5 75 3
+      vertex 114.162 98.5398 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 114.011 98.2653 3
+      vertex 120.5 75 3
+      vertex 114.095 98.3978 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 113.911 98.1443 3
+      vertex 120.5 75 3
+      vertex 114.011 98.2653 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 113.797 98.0369 3
+      vertex 120.5 75 3
+      vertex 113.911 98.1443 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 113.67 97.9446 3
+      vertex 120.5 75 3
+      vertex 113.797 98.0369 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 113.532 97.869 3
+      vertex 120.5 75 3
+      vertex 113.67 97.9446 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 110.75 77.75 3
+      vertex 113.532 97.869 3
+      vertex 113.386 97.8112 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 110.75 77.75 3
+      vertex 113.386 97.8112 3
+      vertex 113.234 97.7721 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 110.75 77.75 3
+      vertex 113.234 97.7721 3
+      vertex 113.078 97.7525 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 110.75 77.75 3
+      vertex 113.078 97.7525 3
+      vertex 112.922 97.7525 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 110.75 77.75 3
+      vertex 112.922 97.7525 3
+      vertex 112.766 97.7721 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 110.75 77.75 3
+      vertex 112.766 97.7721 3
+      vertex 112.614 97.8112 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 110.75 77.75 3
+      vertex 112.614 97.8112 3
+      vertex 112.468 97.869 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 110.75 77.75 3
+      vertex 112.468 97.869 3
+      vertex 112.33 97.9446 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 110.75 77.75 3
+      vertex 112.33 97.9446 3
+      vertex 112.203 98.0369 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 110.75 77.75 3
+      vertex 112.203 98.0369 3
+      vertex 112.089 98.1443 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.1622 98.5398 3
+      vertex 111.838 98.5398 3
+      vertex 91.2107 98.6891 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 111.789 98.6891 3
+      vertex 91.2107 98.6891 3
+      vertex 111.838 98.5398 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.2107 98.6891 3
+      vertex 111.789 98.6891 3
+      vertex 91.2401 98.8433 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 91.25 99 3
+      vertex 111.76 98.8433 3
+      vertex 111.75 99 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.2401 98.8433 3
+      vertex 111.76 98.8433 3
+      vertex 91.25 99 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 111.76 98.8433 3
+      vertex 91.2401 98.8433 3
+      vertex 111.789 98.6891 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 113.532 97.869 3
+      vertex 110.75 77.75 3
+      vertex 120.5 75 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 120.5 75 3
+      vertex 110.75 77.75 3
+      vertex 110.75 75 3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 70 78 0
+      vertex 64.4901 83.8433 0
+      vertex 64.5 84 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.9006 76.1641 0
+      vertex 64.4607 83.6891 0
+      vertex 64.4901 83.8433 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.9006 76.1641 0
+      vertex 64.4122 83.5398 0
+      vertex 64.4607 83.6891 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.9006 76.1641 0
+      vertex 64.3454 83.3978 0
+      vertex 64.4122 83.5398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.9006 76.1641 0
+      vertex 64.2613 83.2653 0
+      vertex 64.3454 83.3978 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.8637 82.8112 0
+      vertex 64.5236 75.8317 0
+      vertex 64.1683 75.4764 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.9006 76.1641 0
+      vertex 64.1612 83.1443 0
+      vertex 64.2613 83.2653 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.9006 76.1641 0
+      vertex 64.0468 83.0369 0
+      vertex 64.1612 83.1443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.9006 76.1641 0
+      vertex 63.9198 82.9446 0
+      vertex 64.0468 83.0369 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.7178 82.869 0
+      vertex 64.1683 75.4764 0
+      vertex 63.8359 75.0994 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.9006 76.1641 0
+      vertex 63.7822 82.869 0
+      vertex 63.9198 82.9446 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.9006 76.1641 0
+      vertex 63.6363 82.8112 0
+      vertex 63.7822 82.869 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.5802 82.9446 0
+      vertex 63.8359 75.0994 0
+      vertex 63.5279 74.7023 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.9006 76.1641 0
+      vertex 63.4842 82.7721 0
+      vertex 63.6363 82.8112 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.9006 76.1641 0
+      vertex 63.3285 82.7525 0
+      vertex 63.4842 82.7721 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.4532 83.0369 0
+      vertex 63.5279 74.7023 0
+      vertex 63.2454 74.2866 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.9006 76.1641 0
+      vertex 63.1715 82.7525 0
+      vertex 63.3285 82.7525 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.9006 76.1641 0
+      vertex 63.0158 82.7721 0
+      vertex 63.1715 82.7525 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.3388 83.1443 0
+      vertex 63.2454 74.2866 0
+      vertex 62.9895 73.854 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.5236 75.8317 0
+      vertex 62.8637 82.8112 0
+      vertex 63.0158 82.7721 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.2387 83.2653 0
+      vertex 62.9895 73.854 0
+      vertex 62.7614 73.4062 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.1683 75.4764 0
+      vertex 62.7178 82.869 0
+      vertex 62.8637 82.8112 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.8359 75.0994 0
+      vertex 62.5802 82.9446 0
+      vertex 62.7178 82.869 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.1546 83.3978 0
+      vertex 62.7614 73.4062 0
+      vertex 62.5618 72.945 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.5279 74.7023 0
+      vertex 62.4532 83.0369 0
+      vertex 62.5802 82.9446 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.0878 83.5398 0
+      vertex 62.5618 72.945 0
+      vertex 62.3915 72.4721 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.2454 74.2866 0
+      vertex 62.3388 83.1443 0
+      vertex 62.4532 83.0369 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.2559 87.2586 0
+      vertex 62.3915 72.4721 0
+      vertex 62.2513 71.9895 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.9895 73.854 0
+      vertex 62.2387 83.2653 0
+      vertex 62.3388 83.1443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.7614 73.4062 0
+      vertex 62.1546 83.3978 0
+      vertex 62.2387 83.2653 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.152 87.4343 0
+      vertex 62.2513 71.9895 0
+      vertex 62.1417 71.4991 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.5618 72.945 0
+      vertex 62.0878 83.5398 0
+      vertex 62.1546 83.3978 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55.2752 58.3691 0
+      vertex 62.1417 71.4991 0
+      vertex 62.0631 71.0027 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.3915 72.4721 0
+      vertex 60.2559 87.2586 0
+      vertex 62.0878 83.5398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55.4284 58.5042 0
+      vertex 62.0631 71.0027 0
+      vertex 62.0158 70.5023 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.0878 83.5398 0
+      vertex 60.2559 87.2586 0
+      vertex 62.0393 83.6891 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55.5897 58.6293 0
+      vertex 62.0158 70.5023 0
+      vertex 62 70 0
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 60.3707 87.0897 0
+      vertex 62.0393 83.6891 0
+      vertex 60.2559 87.2586 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 66.1924 89.609 0
+      vertex 67.6374 90.7985 0
+      vertex 66.2244 89.4073 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 66.1479 89.8082 0
+      vertex 67.6374 90.7985 0
+      vertex 66.1924 89.609 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 67.6374 90.7985 0
+      vertex 66.1479 89.8082 0
+      vertex 67.0643 90.965 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 66.0909 90.0043 0
+      vertex 67.0643 90.965 0
+      vertex 66.1479 89.8082 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 66.0218 90.1964 0
+      vertex 67.0643 90.965 0
+      vertex 66.0909 90.0043 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 67.0643 90.965 0
+      vertex 66.0218 90.1964 0
+      vertex 66.5028 91.1671 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 65.9407 90.3838 0
+      vertex 66.5028 91.1671 0
+      vertex 66.0218 90.1964 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 65.848 90.5657 0
+      vertex 66.5028 91.1671 0
+      vertex 65.9407 90.3838 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 65.7441 90.7414 0
+      vertex 66.5028 91.1671 0
+      vertex 65.848 90.5657 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 66.5028 91.1671 0
+      vertex 65.7441 90.7414 0
+      vertex 65.9551 91.4041 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 65.6293 90.9103 0
+      vertex 65.9551 91.4041 0
+      vertex 65.7441 90.7414 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 65.5042 91.0716 0
+      vertex 65.9551 91.4041 0
+      vertex 65.6293 90.9103 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 65.3691 91.2248 0
+      vertex 65.9551 91.4041 0
+      vertex 65.5042 91.0716 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 65.9551 91.4041 0
+      vertex 65.3691 91.2248 0
+      vertex 65.4233 91.6751 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 65.2248 91.3691 0
+      vertex 65.4233 91.6751 0
+      vertex 65.3691 91.2248 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 65.0716 91.5042 0
+      vertex 65.4233 91.6751 0
+      vertex 65.2248 91.3691 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.9103 91.6293 0
+      vertex 65.4233 91.6751 0
+      vertex 65.0716 91.5042 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.9103 91.6293 0
+      vertex 64.9096 91.9789 0
+      vertex 65.4233 91.6751 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.7414 91.7441 0
+      vertex 64.9096 91.9789 0
+      vertex 64.9103 91.6293 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.5657 91.848 0
+      vertex 64.9096 91.9789 0
+      vertex 64.7414 91.7441 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.5657 91.848 0
+      vertex 64.416 92.3143 0
+      vertex 64.9096 91.9789 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.3838 91.9407 0
+      vertex 64.416 92.3143 0
+      vertex 64.5657 91.848 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.1964 92.0218 0
+      vertex 64.416 92.3143 0
+      vertex 64.3838 91.9407 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.0043 92.0909 0
+      vertex 64.416 92.3143 0
+      vertex 64.1964 92.0218 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.0043 92.0909 0
+      vertex 63.9445 92.6801 0
+      vertex 64.416 92.3143 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.8082 92.1479 0
+      vertex 63.9445 92.6801 0
+      vertex 64.0043 92.0909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.609 92.1924 0
+      vertex 63.9445 92.6801 0
+      vertex 63.8082 92.1479 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.4073 92.2244 0
+      vertex 63.9445 92.6801 0
+      vertex 63.609 92.1924 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 63.9445 92.6801 0
+      vertex 63.4073 92.2244 0
+      vertex 63.4968 93.0748 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.2041 92.2436 0
+      vertex 63.4968 93.0748 0
+      vertex 63.4073 92.2244 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63 92.25 0
+      vertex 63.4968 93.0748 0
+      vertex 63.2041 92.2436 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 63.4968 93.0748 0
+      vertex 63 92.25 0
+      vertex 63.0748 93.4968 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.7959 92.2436 0
+      vertex 63.0748 93.4968 0
+      vertex 63 92.25 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.5927 92.2244 0
+      vertex 63.0748 93.4968 0
+      vertex 62.7959 92.2436 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.391 92.1924 0
+      vertex 63.0748 93.4968 0
+      vertex 62.5927 92.2244 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 63.0748 93.4968 0
+      vertex 62.391 92.1924 0
+      vertex 62.6801 93.9445 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.1918 92.1479 0
+      vertex 62.6801 93.9445 0
+      vertex 62.391 92.1924 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.9957 92.0909 0
+      vertex 62.6801 93.9445 0
+      vertex 62.1918 92.1479 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.6801 93.9445 0
+      vertex 61.9957 92.0909 0
+      vertex 62.3143 94.416 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.8036 92.0218 0
+      vertex 62.3143 94.416 0
+      vertex 61.9957 92.0909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.6162 91.9407 0
+      vertex 62.3143 94.416 0
+      vertex 61.8036 92.0218 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.4343 91.848 0
+      vertex 62.3143 94.416 0
+      vertex 61.6162 91.9407 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.3143 94.416 0
+      vertex 61.4343 91.848 0
+      vertex 61.9789 94.9096 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.2586 91.7441 0
+      vertex 61.9789 94.9096 0
+      vertex 61.4343 91.848 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.0897 91.6293 0
+      vertex 61.9789 94.9096 0
+      vertex 61.2586 91.7441 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 61.9789 94.9096 0
+      vertex 61.0897 91.6293 0
+      vertex 61.6751 95.4233 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.9284 91.5042 0
+      vertex 61.6751 95.4233 0
+      vertex 61.0897 91.6293 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.7752 91.3691 0
+      vertex 61.6751 95.4233 0
+      vertex 60.9284 91.5042 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 61.6751 95.4233 0
+      vertex 60.7752 91.3691 0
+      vertex 61.4041 95.9551 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.6309 91.2248 0
+      vertex 61.4041 95.9551 0
+      vertex 60.7752 91.3691 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.4958 91.0716 0
+      vertex 61.4041 95.9551 0
+      vertex 60.6309 91.2248 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 61.4041 95.9551 0
+      vertex 60.4958 91.0716 0
+      vertex 61.1671 96.5028 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.3707 90.9103 0
+      vertex 61.1671 96.5028 0
+      vertex 60.4958 91.0716 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 61.1671 96.5028 0
+      vertex 60.3707 90.9103 0
+      vertex 60.965 97.0643 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.2559 90.7414 0
+      vertex 60.965 97.0643 0
+      vertex 60.3707 90.9103 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.152 90.5657 0
+      vertex 60.965 97.0643 0
+      vertex 60.2559 90.7414 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 60.965 97.0643 0
+      vertex 60.152 90.5657 0
+      vertex 60.7985 97.6374 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.0593 90.3838 0
+      vertex 60.7985 97.6374 0
+      vertex 60.152 90.5657 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 67.5279 62.3915 0
+      vertex 64.0468 56.9631 0
+      vertex 67.055 62.5618 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.9198 57.0554 0
+      vertex 67.055 62.5618 0
+      vertex 64.0468 56.9631 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 67.055 62.5618 0
+      vertex 63.9198 57.0554 0
+      vertex 66.5938 62.7614 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.7822 57.131 0
+      vertex 66.5938 62.7614 0
+      vertex 63.9198 57.0554 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 66.5938 62.7614 0
+      vertex 63.7822 57.131 0
+      vertex 66.146 62.9895 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.6363 57.1888 0
+      vertex 66.146 62.9895 0
+      vertex 63.7822 57.131 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.4842 57.2279 0
+      vertex 66.146 62.9895 0
+      vertex 63.6363 57.1888 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 66.146 62.9895 0
+      vertex 63.4842 57.2279 0
+      vertex 65.7134 63.2454 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.3285 57.2475 0
+      vertex 65.7134 63.2454 0
+      vertex 63.4842 57.2279 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 65.7134 63.2454 0
+      vertex 63.3285 57.2475 0
+      vertex 65.2977 63.5279 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.1715 57.2475 0
+      vertex 65.2977 63.5279 0
+      vertex 63.3285 57.2475 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 65.2977 63.5279 0
+      vertex 63.1715 57.2475 0
+      vertex 64.9006 63.8359 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.0158 57.2279 0
+      vertex 64.9006 63.8359 0
+      vertex 63.1715 57.2475 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 59.7248 58.3691 0
+      vertex 64.9006 63.8359 0
+      vertex 63.0158 57.2279 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 64.9006 63.8359 0
+      vertex 59.7248 58.3691 0
+      vertex 64.5236 64.1683 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 59.5716 58.5042 0
+      vertex 64.5236 64.1683 0
+      vertex 59.7248 58.3691 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 64.5236 64.1683 0
+      vertex 59.4103 58.6293 0
+      vertex 64.1683 64.5236 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 59.4103 58.6293 0
+      vertex 64.5236 64.1683 0
+      vertex 59.5716 58.5042 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 59.2414 58.7441 0
+      vertex 64.1683 64.5236 0
+      vertex 59.4103 58.6293 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 59.8691 58.2248 0
+      vertex 63.0158 57.2279 0
+      vertex 62.8637 57.1888 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 64.1683 64.5236 0
+      vertex 59.2414 58.7441 0
+      vertex 63.8359 64.9006 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.1293 57.9103 0
+      vertex 62.8637 57.1888 0
+      vertex 62.7178 57.131 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.2441 57.7414 0
+      vertex 62.7178 57.131 0
+      vertex 62.5802 57.0554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 59.0657 58.848 0
+      vertex 63.8359 64.9006 0
+      vertex 59.2414 58.7441 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.348 57.5657 0
+      vertex 62.5802 57.0554 0
+      vertex 62.4532 56.9631 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 58.8838 58.9407 0
+      vertex 63.8359 64.9006 0
+      vertex 59.0657 58.848 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.4407 57.3838 0
+      vertex 62.4532 56.9631 0
+      vertex 62.3388 56.8557 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 63.8359 64.9006 0
+      vertex 58.8838 58.9407 0
+      vertex 63.5279 65.2977 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.5218 57.1964 0
+      vertex 62.3388 56.8557 0
+      vertex 62.2387 56.7347 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.6479 56.8082 0
+      vertex 62.2387 56.7347 0
+      vertex 62.1546 56.6022 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.0158 57.2279 0
+      vertex 59.8691 58.2248 0
+      vertex 59.7248 58.3691 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.6924 56.609 0
+      vertex 62.1546 56.6022 0
+      vertex 62.0878 56.4602 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.8637 57.1888 0
+      vertex 60.0042 58.0716 0
+      vertex 59.8691 58.2248 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.7244 56.4073 0
+      vertex 62.0878 56.4602 0
+      vertex 62.0393 56.3109 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 58.6964 59.0218 0
+      vertex 63.5279 65.2977 0
+      vertex 58.8838 58.9407 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.7436 56.2041 0
+      vertex 62.0393 56.3109 0
+      vertex 62.0099 56.1567 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.7436 56.2041 0
+      vertex 62.0099 56.1567 0
+      vertex 62 56 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.8637 57.1888 0
+      vertex 60.1293 57.9103 0
+      vertex 60.0042 58.0716 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.0878 56.4602 0
+      vertex 60.7244 56.4073 0
+      vertex 60.6924 56.609 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.1546 56.6022 0
+      vertex 60.6924 56.609 0
+      vertex 60.6479 56.8082 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.2387 56.7347 0
+      vertex 60.6479 56.8082 0
+      vertex 60.5909 57.0043 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.2387 56.7347 0
+      vertex 60.5909 57.0043 0
+      vertex 60.5218 57.1964 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.3388 56.8557 0
+      vertex 60.5218 57.1964 0
+      vertex 60.4407 57.3838 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.4532 56.9631 0
+      vertex 60.4407 57.3838 0
+      vertex 60.348 57.5657 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.5802 57.0554 0
+      vertex 60.348 57.5657 0
+      vertex 60.2441 57.7414 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.7178 57.131 0
+      vertex 60.2441 57.7414 0
+      vertex 60.1293 57.9103 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 58.5043 59.0909 0
+      vertex 63.5279 65.2977 0
+      vertex 58.6964 59.0218 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 63.5279 65.2977 0
+      vertex 58.5043 59.0909 0
+      vertex 63.2454 65.7134 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 58.3082 59.1479 0
+      vertex 63.2454 65.7134 0
+      vertex 58.5043 59.0909 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 63.2454 65.7134 0
+      vertex 58.3082 59.1479 0
+      vertex 62.9895 66.146 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 58.109 59.1924 0
+      vertex 62.9895 66.146 0
+      vertex 58.3082 59.1479 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 57.9073 59.2244 0
+      vertex 62.9895 66.146 0
+      vertex 58.109 59.1924 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.9895 66.146 0
+      vertex 57.9073 59.2244 0
+      vertex 62.7614 66.5938 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 57.7041 59.2436 0
+      vertex 62.7614 66.5938 0
+      vertex 57.9073 59.2244 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 57.5 59.25 0
+      vertex 62.7614 66.5938 0
+      vertex 57.7041 59.2436 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.7614 66.5938 0
+      vertex 57.5 59.25 0
+      vertex 62.5618 67.055 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 57.2959 59.2436 0
+      vertex 62.5618 67.055 0
+      vertex 57.5 59.25 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.5618 67.055 0
+      vertex 57.2959 59.2436 0
+      vertex 62.3915 67.5279 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 57.0927 59.2244 0
+      vertex 62.3915 67.5279 0
+      vertex 57.2959 59.2436 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 56.891 59.1924 0
+      vertex 62.3915 67.5279 0
+      vertex 57.0927 59.2244 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.3915 67.5279 0
+      vertex 56.891 59.1924 0
+      vertex 62.2513 68.0105 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 56.6918 59.1479 0
+      vertex 62.2513 68.0105 0
+      vertex 56.891 59.1924 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.2513 68.0105 0
+      vertex 56.6918 59.1479 0
+      vertex 62.1417 68.5009 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 56.4957 59.0909 0
+      vertex 62.1417 68.5009 0
+      vertex 56.6918 59.1479 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 112.614 100.189 0
+      vertex 71.9842 133.749 0
+      vertex 72 134 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 72.9357 109.035 0
+      vertex 71.9372 133.503 0
+      vertex 71.9842 133.749 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 72.9357 109.035 0
+      vertex 71.8596 133.264 0
+      vertex 71.9372 133.503 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 70.618 132.098 0
+      vertex 72.3626 109.202 0
+      vertex 71.7801 109.332 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 72.9357 109.035 0
+      vertex 71.7526 133.036 0
+      vertex 71.8596 133.264 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 72.9357 109.035 0
+      vertex 71.618 132.824 0
+      vertex 71.7526 133.036 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 72.9357 109.035 0
+      vertex 71.4579 132.631 0
+      vertex 71.618 132.824 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 72.9357 109.035 0
+      vertex 71.2748 132.459 0
+      vertex 71.4579 132.631 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 70.618 132.098 0
+      vertex 71.7801 109.332 0
+      vertex 71.1907 109.425 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 72.9357 109.035 0
+      vertex 71.0717 132.311 0
+      vertex 71.2748 132.459 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 72.9357 109.035 0
+      vertex 70.8516 132.19 0
+      vertex 71.0717 132.311 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 72.3626 109.202 0
+      vertex 70.618 132.098 0
+      vertex 70.8516 132.19 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 70.3748 132.035 0
+      vertex 71.1907 109.425 0
+      vertex 70.5965 109.481 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.1907 109.425 0
+      vertex 70.3748 132.035 0
+      vertex 70.618 132.098 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 70.5965 109.481 0
+      vertex 70.1256 132.004 0
+      vertex 70.3748 132.035 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 70 109.5 0
+      vertex 70.1256 132.004 0
+      vertex 70.5965 109.481 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 70 109.5 0
+      vertex 69.8744 132.004 0
+      vertex 70.1256 132.004 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 69.4035 109.481 0
+      vertex 69.8744 132.004 0
+      vertex 70 109.5 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 69.8744 132.004 0
+      vertex 69.4035 109.481 0
+      vertex 69.6252 132.035 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 68.8093 109.425 0
+      vertex 69.6252 132.035 0
+      vertex 69.4035 109.481 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 69.6252 132.035 0
+      vertex 68.8093 109.425 0
+      vertex 69.382 132.098 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 68.2199 109.332 0
+      vertex 69.382 132.098 0
+      vertex 68.8093 109.425 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 67.6374 109.202 0
+      vertex 69.382 132.098 0
+      vertex 68.2199 109.332 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 69.382 132.098 0
+      vertex 67.6374 109.202 0
+      vertex 69.1484 132.19 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 67.0643 109.035 0
+      vertex 69.1484 132.19 0
+      vertex 67.6374 109.202 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 69.1484 132.19 0
+      vertex 67.0643 109.035 0
+      vertex 68.9283 132.311 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 66.5028 108.833 0
+      vertex 68.9283 132.311 0
+      vertex 67.0643 109.035 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 68.9283 132.311 0
+      vertex 66.5028 108.833 0
+      vertex 68.7252 132.459 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 65.9551 108.596 0
+      vertex 68.7252 132.459 0
+      vertex 66.5028 108.833 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 65.4233 108.325 0
+      vertex 68.7252 132.459 0
+      vertex 65.9551 108.596 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 68.7252 132.459 0
+      vertex 65.4233 108.325 0
+      vertex 68.5421 132.631 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.9096 108.021 0
+      vertex 68.5421 132.631 0
+      vertex 65.4233 108.325 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 68.5421 132.631 0
+      vertex 64.9096 108.021 0
+      vertex 68.382 132.824 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.4579 7.36909 0
+      vertex 75.0904 31.9789 0
+      vertex 71.618 7.17557 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.0904 31.9789 0
+      vertex 71.4579 7.36909 0
+      vertex 74.5767 31.6751 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.2748 7.54103 0
+      vertex 74.5767 31.6751 0
+      vertex 71.4579 7.36909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 74.5767 31.6751 0
+      vertex 71.2748 7.54103 0
+      vertex 74.0449 31.4041 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 74.0449 31.4041 0
+      vertex 71.2748 7.54103 0
+      vertex 73.4972 31.1671 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.0717 7.68866 0
+      vertex 73.4972 31.1671 0
+      vertex 71.2748 7.54103 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 73.4972 31.1671 0
+      vertex 71.0717 7.68866 0
+      vertex 72.9357 30.965 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 70.8516 7.80965 0
+      vertex 72.9357 30.965 0
+      vertex 71.0717 7.68866 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 72.9357 30.965 0
+      vertex 70.8516 7.80965 0
+      vertex 72.3626 30.7985 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 70.618 7.90211 0
+      vertex 72.3626 30.7985 0
+      vertex 70.8516 7.80965 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 72.3626 30.7985 0
+      vertex 70.618 7.90211 0
+      vertex 71.7801 30.6683 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.7801 30.6683 0
+      vertex 70.618 7.90211 0
+      vertex 71.1907 30.5749 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 70.3748 7.96457 0
+      vertex 71.1907 30.5749 0
+      vertex 70.618 7.90211 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.1907 30.5749 0
+      vertex 70.3748 7.96457 0
+      vertex 70.5965 30.5187 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 70.1256 7.99605 0
+      vertex 70.5965 30.5187 0
+      vertex 70.3748 7.96457 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 70.1256 7.99605 0
+      vertex 70 30.5 0
+      vertex 70.5965 30.5187 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 69.8744 7.99605 0
+      vertex 70 30.5 0
+      vertex 70.1256 7.99605 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 69.4035 30.5187 0
+      vertex 69.8744 7.99605 0
+      vertex 69.6252 7.96457 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 69.8744 7.99605 0
+      vertex 69.4035 30.5187 0
+      vertex 70 30.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 68.8093 30.5749 0
+      vertex 69.6252 7.96457 0
+      vertex 69.382 7.90211 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 67.6374 30.7985 0
+      vertex 69.382 7.90211 0
+      vertex 69.1484 7.80965 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 67.0643 30.965 0
+      vertex 69.1484 7.80965 0
+      vertex 68.9283 7.68866 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 69.6252 7.96457 0
+      vertex 68.8093 30.5749 0
+      vertex 69.4035 30.5187 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 66.5028 31.1671 0
+      vertex 68.9283 7.68866 0
+      vertex 68.7252 7.54103 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 65.4233 31.6751 0
+      vertex 68.7252 7.54103 0
+      vertex 68.5421 7.36909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.9096 31.9789 0
+      vertex 68.5421 7.36909 0
+      vertex 68.382 7.17557 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.9445 32.6801 0
+      vertex 68.382 7.17557 0
+      vertex 68.2474 6.96351 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 69.382 7.90211 0
+      vertex 68.2199 30.6683 0
+      vertex 68.8093 30.5749 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.4968 33.0748 0
+      vertex 68.2474 6.96351 0
+      vertex 68.1404 6.73625 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.6801 33.9445 0
+      vertex 68.1404 6.73625 0
+      vertex 68.0628 6.49738 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 68.0628 6.49738 0
+      vertex 68.0158 6.25067 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 68.0158 6.25067 0
+      vertex 68 6 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 69.382 7.90211 0
+      vertex 67.6374 30.7985 0
+      vertex 68.2199 30.6683 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 77.75 0
+      vertex 77.9901 83.8433 0
+      vertex 78 84 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.9369 71.0027 0
+      vertex 90.25 77.75 0
+      vertex 77.9842 70.5023 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.8583 71.4991 0
+      vertex 90.25 77.75 0
+      vertex 77.9369 71.0027 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.7487 71.9895 0
+      vertex 90.25 77.75 0
+      vertex 77.8583 71.4991 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 77.75 0
+      vertex 77.9607 83.6891 0
+      vertex 77.9901 83.8433 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.6085 72.4721 0
+      vertex 90.25 77.75 0
+      vertex 77.7487 71.9895 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 77.75 0
+      vertex 77.9122 83.5398 0
+      vertex 77.9607 83.6891 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.4382 72.945 0
+      vertex 90.25 77.75 0
+      vertex 77.6085 72.4721 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.2386 73.4062 0
+      vertex 90.25 77.75 0
+      vertex 77.4382 72.945 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 77.75 0
+      vertex 77.8454 83.3978 0
+      vertex 77.9122 83.5398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.0105 73.854 0
+      vertex 90.25 77.75 0
+      vertex 77.2386 73.4062 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 77.75 0
+      vertex 77.7613 83.2653 0
+      vertex 77.8454 83.3978 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.7546 74.2866 0
+      vertex 90.25 77.75 0
+      vertex 77.0105 73.854 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 77.75 0
+      vertex 77.6612 83.1443 0
+      vertex 77.7613 83.2653 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 90.25 77.75 0
+      vertex 76.7546 74.2866 0
+      vertex 77.6612 83.1443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.6612 83.1443 0
+      vertex 76.7546 74.2866 0
+      vertex 77.5468 83.0369 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.4721 74.7023 0
+      vertex 77.5468 83.0369 0
+      vertex 76.7546 74.2866 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.5468 83.0369 0
+      vertex 76.4721 74.7023 0
+      vertex 77.4198 82.9446 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.1641 75.0994 0
+      vertex 77.4198 82.9446 0
+      vertex 76.4721 74.7023 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.4198 82.9446 0
+      vertex 76.1641 75.0994 0
+      vertex 77.2822 82.869 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.8317 75.4764 0
+      vertex 77.2822 82.869 0
+      vertex 76.1641 75.0994 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.2822 82.869 0
+      vertex 75.8317 75.4764 0
+      vertex 77.1363 82.8112 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.4764 75.8317 0
+      vertex 77.1363 82.8112 0
+      vertex 75.8317 75.4764 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.1363 82.8112 0
+      vertex 75.4764 75.8317 0
+      vertex 76.9842 82.7721 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.0994 76.1641 0
+      vertex 76.9842 82.7721 0
+      vertex 75.4764 75.8317 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.9842 82.7721 0
+      vertex 75.0994 76.1641 0
+      vertex 76.8285 82.7525 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 74.7023 76.4721 0
+      vertex 76.8285 82.7525 0
+      vertex 75.0994 76.1641 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 76.8285 82.7525 0
+      vertex 74.7023 76.4721 0
+      vertex 76.6715 82.7525 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 74.2866 76.7546 0
+      vertex 76.6715 82.7525 0
+      vertex 74.7023 76.4721 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 76.6715 82.7525 0
+      vertex 74.2866 76.7546 0
+      vertex 76.5158 82.7721 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 73.854 77.0105 0
+      vertex 76.5158 82.7721 0
+      vertex 74.2866 76.7546 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 76.5158 82.7721 0
+      vertex 73.854 77.0105 0
+      vertex 76.3637 82.8112 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 76.3637 82.8112 0
+      vertex 73.854 77.0105 0
+      vertex 76.2178 82.869 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 73.4062 77.2386 0
+      vertex 76.2178 82.869 0
+      vertex 73.854 77.0105 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 76.2178 82.869 0
+      vertex 73.4062 77.2386 0
+      vertex 76.0802 82.9446 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 72.945 77.4382 0
+      vertex 76.0802 82.9446 0
+      vertex 73.4062 77.2386 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 76.0802 82.9446 0
+      vertex 72.945 77.4382 0
+      vertex 75.9532 83.0369 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 72.4721 77.6085 0
+      vertex 75.9532 83.0369 0
+      vertex 72.945 77.4382 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.5042 53.0716 0
+      vertex 77.9607 56.3109 0
+      vertex 90.25 62.25 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 62.25 0
+      vertex 77.9842 69.4977 0
+      vertex 78 70 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.9122 56.4602 0
+      vertex 90.25 62.25 0
+      vertex 77.9607 56.3109 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 62.25 0
+      vertex 77.9369 68.9973 0
+      vertex 77.9842 69.4977 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.8454 56.6022 0
+      vertex 90.25 62.25 0
+      vertex 77.9122 56.4602 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 62.25 0
+      vertex 77.8583 68.5009 0
+      vertex 77.9369 68.9973 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.7613 56.7347 0
+      vertex 90.25 62.25 0
+      vertex 77.8454 56.6022 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.6612 56.8557 0
+      vertex 90.25 62.25 0
+      vertex 77.7613 56.7347 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 62.25 0
+      vertex 77.7487 68.0105 0
+      vertex 77.8583 68.5009 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.7546 65.7134 0
+      vertex 90.25 62.25 0
+      vertex 77.6612 56.8557 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 62.25 0
+      vertex 77.6085 67.5279 0
+      vertex 77.7487 68.0105 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.7546 65.7134 0
+      vertex 77.6612 56.8557 0
+      vertex 77.5468 56.9631 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 62.25 0
+      vertex 77.4382 67.055 0
+      vertex 77.6085 67.5279 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.4721 65.2977 0
+      vertex 77.5468 56.9631 0
+      vertex 77.4198 57.0554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.1641 64.9006 0
+      vertex 77.4198 57.0554 0
+      vertex 77.2822 57.131 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 62.25 0
+      vertex 77.2386 66.5938 0
+      vertex 77.4382 67.055 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.8317 64.5236 0
+      vertex 77.2822 57.131 0
+      vertex 77.1363 57.1888 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 62.25 0
+      vertex 77.0105 66.146 0
+      vertex 77.2386 66.5938 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.4764 64.1683 0
+      vertex 77.1363 57.1888 0
+      vertex 76.9842 57.2279 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.0994 63.8359 0
+      vertex 76.9842 57.2279 0
+      vertex 76.8285 57.2475 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 62.25 0
+      vertex 76.7546 65.7134 0
+      vertex 77.0105 66.146 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 74.7023 63.5279 0
+      vertex 76.8285 57.2475 0
+      vertex 76.6715 57.2475 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 74.2866 63.2454 0
+      vertex 76.6715 57.2475 0
+      vertex 76.5158 57.2279 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.5468 56.9631 0
+      vertex 76.4721 65.2977 0
+      vertex 76.7546 65.7134 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 73.854 62.9895 0
+      vertex 76.5158 57.2279 0
+      vertex 76.3637 57.1888 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 73.854 62.9895 0
+      vertex 76.3637 57.1888 0
+      vertex 76.2178 57.131 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.4198 57.0554 0
+      vertex 76.1641 64.9006 0
+      vertex 76.4721 65.2977 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 73.4062 62.7614 0
+      vertex 76.2178 57.131 0
+      vertex 76.0802 57.0554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 72.945 62.5618 0
+      vertex 76.0802 57.0554 0
+      vertex 75.9532 56.9631 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 72.4721 62.3915 0
+      vertex 75.9532 56.9631 0
+      vertex 75.8388 56.8557 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.2822 57.131 0
+      vertex 75.8317 64.5236 0
+      vertex 76.1641 64.9006 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.9895 62.2513 0
+      vertex 75.8388 56.8557 0
+      vertex 75.7387 56.7347 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.9895 62.2513 0
+      vertex 75.7387 56.7347 0
+      vertex 75.6546 56.6022 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.4991 62.1417 0
+      vertex 75.6546 56.6022 0
+      vertex 75.5878 56.4602 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.0027 62.0631 0
+      vertex 75.5878 56.4602 0
+      vertex 75.5393 56.3109 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 70.5023 62.0158 0
+      vertex 75.5393 56.3109 0
+      vertex 75.5099 56.1567 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 70 62 0
+      vertex 75.5099 56.1567 0
+      vertex 75.5 56 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.1363 57.1888 0
+      vertex 75.4764 64.1683 0
+      vertex 75.8317 64.5236 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.0716 53.5042 0
+      vertex 77.9901 55.8433 0
+      vertex 78 56 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 78.1964 54.0218 0
+      vertex 77.9607 55.6891 0
+      vertex 77.9901 55.8433 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 78.1964 54.0218 0
+      vertex 77.9122 55.5398 0
+      vertex 77.9607 55.6891 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 78.1964 54.0218 0
+      vertex 77.8454 55.3978 0
+      vertex 77.9122 55.5398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.6612 55.1443 0
+      vertex 78.0043 54.0909 0
+      vertex 77.8082 54.1479 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 78.1964 54.0218 0
+      vertex 77.7613 55.2653 0
+      vertex 77.8454 55.3978 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 78.0043 54.0909 0
+      vertex 77.6612 55.1443 0
+      vertex 77.7613 55.2653 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.5468 55.0369 0
+      vertex 77.8082 54.1479 0
+      vertex 77.609 54.1924 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.8082 54.1479 0
+      vertex 77.5468 55.0369 0
+      vertex 77.6612 55.1443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.609 54.1924 0
+      vertex 77.4198 54.9446 0
+      vertex 77.5468 55.0369 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.4073 54.2244 0
+      vertex 77.4198 54.9446 0
+      vertex 77.609 54.1924 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.4073 54.2244 0
+      vertex 77.2822 54.869 0
+      vertex 77.4198 54.9446 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.2041 54.2436 0
+      vertex 77.2822 54.869 0
+      vertex 77.4073 54.2244 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.2041 54.2436 0
+      vertex 77.1363 54.8112 0
+      vertex 77.2822 54.869 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.9842 54.7721 0
+      vertex 77.2041 54.2436 0
+      vertex 77 54.25 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.2041 54.2436 0
+      vertex 76.9842 54.7721 0
+      vertex 77.1363 54.8112 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77 54.25 0
+      vertex 76.8285 54.7525 0
+      vertex 76.9842 54.7721 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.7959 54.2436 0
+      vertex 76.8285 54.7525 0
+      vertex 77 54.25 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.7959 54.2436 0
+      vertex 76.6715 54.7525 0
+      vertex 76.8285 54.7525 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.5927 54.2244 0
+      vertex 76.6715 54.7525 0
+      vertex 76.7959 54.2436 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.5927 54.2244 0
+      vertex 76.5158 54.7721 0
+      vertex 76.6715 54.7525 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.391 54.1924 0
+      vertex 76.5158 54.7721 0
+      vertex 76.5927 54.2244 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.391 54.1924 0
+      vertex 76.3637 54.8112 0
+      vertex 76.5158 54.7721 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.1918 54.1479 0
+      vertex 76.3637 54.8112 0
+      vertex 76.391 54.1924 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 76.3637 54.8112 0
+      vertex 76.1918 54.1479 0
+      vertex 76.2178 54.869 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.9957 54.0909 0
+      vertex 76.2178 54.869 0
+      vertex 76.1918 54.1479 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 76.2178 54.869 0
+      vertex 75.9957 54.0909 0
+      vertex 76.0802 54.9446 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.8036 54.0218 0
+      vertex 76.0802 54.9446 0
+      vertex 75.9957 54.0909 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 76.0802 54.9446 0
+      vertex 75.8036 54.0218 0
+      vertex 75.9532 55.0369 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.6162 53.9407 0
+      vertex 75.9532 55.0369 0
+      vertex 75.8036 54.0218 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 75.9532 55.0369 0
+      vertex 75.6162 53.9407 0
+      vertex 75.8388 55.1443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.4343 53.848 0
+      vertex 75.8388 55.1443 0
+      vertex 75.6162 53.9407 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 75.8388 55.1443 0
+      vertex 75.4343 53.848 0
+      vertex 75.7387 55.2653 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.2586 53.7441 0
+      vertex 75.7387 55.2653 0
+      vertex 75.4343 53.848 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 75.7387 55.2653 0
+      vertex 75.2586 53.7441 0
+      vertex 75.6546 55.3978 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.0897 53.6293 0
+      vertex 75.6546 55.3978 0
+      vertex 75.2586 53.7441 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 75.6546 55.3978 0
+      vertex 75.0897 53.6293 0
+      vertex 75.5878 55.5398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 74.9284 53.5042 0
+      vertex 75.5878 55.5398 0
+      vertex 75.0897 53.6293 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 75.5878 55.5398 0
+      vertex 74.9284 53.5042 0
+      vertex 75.5393 55.6891 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 74.7752 53.3691 0
+      vertex 75.5393 55.6891 0
+      vertex 74.9284 53.5042 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.9842 57.2279 0
+      vertex 75.0994 63.8359 0
+      vertex 75.4764 64.1683 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 75.5393 55.6891 0
+      vertex 74.7752 53.3691 0
+      vertex 75.5099 55.8433 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 74.6309 53.2248 0
+      vertex 75.5099 55.8433 0
+      vertex 74.7752 53.3691 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 75.5099 55.8433 0
+      vertex 74.6309 53.2248 0
+      vertex 75.5 56 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.8285 57.2475 0
+      vertex 74.7023 63.5279 0
+      vertex 75.0994 63.8359 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 74.4958 53.0716 0
+      vertex 75.5 56 0
+      vertex 74.6309 53.2248 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 74.3707 52.9103 0
+      vertex 75.5 56 0
+      vertex 74.4958 53.0716 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.5 56 0
+      vertex 75.5 56 0
+      vertex 74.3707 52.9103 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.6715 57.2475 0
+      vertex 74.2866 63.2454 0
+      vertex 74.7023 63.5279 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.5 56 0
+      vertex 74.3707 52.9103 0
+      vertex 74.2559 52.7414 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.4901 55.8433 0
+      vertex 74.2559 52.7414 0
+      vertex 74.152 52.5657 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.4901 55.8433 0
+      vertex 74.152 52.5657 0
+      vertex 74.0593 52.3838 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 70 49.5 0
+      vertex 74.0593 52.3838 0
+      vertex 73.9782 52.1964 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 70 49.5 0
+      vertex 73.9782 52.1964 0
+      vertex 73.9091 52.0043 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.5158 57.2279 0
+      vertex 73.854 62.9895 0
+      vertex 74.2866 63.2454 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 70.5965 49.4813 0
+      vertex 73.9091 52.0043 0
+      vertex 73.8521 51.8082 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 70.5965 49.4813 0
+      vertex 73.8521 51.8082 0
+      vertex 73.8076 51.609 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.1907 49.4251 0
+      vertex 73.8076 51.609 0
+      vertex 73.7756 51.4073 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.1907 49.4251 0
+      vertex 73.7756 51.4073 0
+      vertex 73.7564 51.2041 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.7801 49.3317 0
+      vertex 73.7564 51.2041 0
+      vertex 73.75 51 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 73.7756 50.5927 0
+      vertex 72.3626 49.2015 0
+      vertex 73.7564 50.7959 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.2178 57.131 0
+      vertex 73.4062 62.7614 0
+      vertex 73.854 62.9895 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.0802 57.0554 0
+      vertex 72.945 62.5618 0
+      vertex 73.4062 62.7614 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.7801 49.3317 0
+      vertex 73.7564 50.7959 0
+      vertex 72.3626 49.2015 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.9532 56.9631 0
+      vertex 72.4721 62.3915 0
+      vertex 72.945 62.5618 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 73.7564 50.7959 0
+      vertex 71.7801 49.3317 0
+      vertex 73.75 51 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.8388 56.8557 0
+      vertex 71.9895 62.2513 0
+      vertex 72.4721 62.3915 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 73.7564 51.2041 0
+      vertex 71.7801 49.3317 0
+      vertex 71.1907 49.4251 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.6546 56.6022 0
+      vertex 71.4991 62.1417 0
+      vertex 71.9895 62.2513 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 73.8076 51.609 0
+      vertex 71.1907 49.4251 0
+      vertex 70.5965 49.4813 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.5878 56.4602 0
+      vertex 71.0027 62.0631 0
+      vertex 71.4991 62.1417 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 73.9091 52.0043 0
+      vertex 70.5965 49.4813 0
+      vertex 70 49.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.5393 56.3109 0
+      vertex 70.5023 62.0158 0
+      vertex 71.0027 62.0631 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 74.0593 52.3838 0
+      vertex 70 49.5 0
+      vertex 69.4035 49.4813 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.5 56 0
+      vertex 64.5 56 0
+      vertex 70 62 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.5099 56.1567 0
+      vertex 70 62 0
+      vertex 70.5023 62.0158 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 74.0593 52.3838 0
+      vertex 69.4035 49.4813 0
+      vertex 64.4607 55.6891 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.4901 56.1567 0
+      vertex 70 62 0
+      vertex 64.5 56 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.4122 55.5398 0
+      vertex 69.4035 49.4813 0
+      vertex 68.8093 49.4251 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 70 62 0
+      vertex 64.4901 56.1567 0
+      vertex 69.4977 62.0158 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.3454 55.3978 0
+      vertex 68.8093 49.4251 0
+      vertex 68.2199 49.3317 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.4607 56.3109 0
+      vertex 69.4977 62.0158 0
+      vertex 64.4901 56.1567 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.2613 55.2653 0
+      vertex 68.2199 49.3317 0
+      vertex 67.6374 49.2015 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 69.4977 62.0158 0
+      vertex 64.4607 56.3109 0
+      vertex 68.9973 62.0631 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.0468 55.0369 0
+      vertex 67.6374 49.2015 0
+      vertex 67.0643 49.035 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.4122 56.4602 0
+      vertex 68.9973 62.0631 0
+      vertex 64.4607 56.3109 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 68.9973 62.0631 0
+      vertex 64.4122 56.4602 0
+      vertex 68.5009 62.1417 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.9198 54.9446 0
+      vertex 67.0643 49.035 0
+      vertex 66.5028 48.8329 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.3454 56.6022 0
+      vertex 68.5009 62.1417 0
+      vertex 64.4122 56.4602 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.7822 54.869 0
+      vertex 66.5028 48.8329 0
+      vertex 65.9551 48.5959 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 68.5009 62.1417 0
+      vertex 64.3454 56.6022 0
+      vertex 68.0105 62.2513 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.4842 54.7721 0
+      vertex 65.9551 48.5959 0
+      vertex 65.4233 48.3249 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.2613 56.7347 0
+      vertex 68.0105 62.2513 0
+      vertex 64.3454 56.6022 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.3285 54.7525 0
+      vertex 65.4233 48.3249 0
+      vertex 64.9096 48.0211 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.1612 56.8557 0
+      vertex 68.0105 62.2513 0
+      vertex 64.2613 56.7347 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 68.0105 62.2513 0
+      vertex 64.1612 56.8557 0
+      vertex 67.5279 62.3915 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.0468 56.9631 0
+      vertex 67.5279 62.3915 0
+      vertex 64.1612 56.8557 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 74.2559 52.7414 0
+      vertex 64.4901 55.8433 0
+      vertex 64.5 56 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 74.0593 52.3838 0
+      vertex 64.4607 55.6891 0
+      vertex 64.4901 55.8433 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.0158 54.7721 0
+      vertex 64.9096 48.0211 0
+      vertex 64.416 47.6857 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 69.4035 49.4813 0
+      vertex 64.4122 55.5398 0
+      vertex 64.4607 55.6891 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 68.8093 49.4251 0
+      vertex 64.3454 55.3978 0
+      vertex 64.4122 55.5398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 68.2199 49.3317 0
+      vertex 64.2613 55.2653 0
+      vertex 64.3454 55.3978 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 67.6374 49.2015 0
+      vertex 64.1612 55.1443 0
+      vertex 64.2613 55.2653 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 67.6374 49.2015 0
+      vertex 64.0468 55.0369 0
+      vertex 64.1612 55.1443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 59.5716 53.4958 0
+      vertex 64.416 47.6857 0
+      vertex 63.9445 47.3199 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 67.0643 49.035 0
+      vertex 63.9198 54.9446 0
+      vertex 64.0468 55.0369 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 66.5028 48.8329 0
+      vertex 63.7822 54.869 0
+      vertex 63.9198 54.9446 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 65.9551 48.5959 0
+      vertex 63.6363 54.8112 0
+      vertex 63.7822 54.869 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 59.2414 53.2559 0
+      vertex 63.9445 47.3199 0
+      vertex 63.4968 46.9252 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 65.9551 48.5959 0
+      vertex 63.4842 54.7721 0
+      vertex 63.6363 54.8112 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 65.4233 48.3249 0
+      vertex 63.3285 54.7525 0
+      vertex 63.4842 54.7721 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.9096 48.0211 0
+      vertex 63.1715 54.7525 0
+      vertex 63.3285 54.7525 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 58.8838 53.0593 0
+      vertex 63.4968 46.9252 0
+      vertex 63.0748 46.5032 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.9096 48.0211 0
+      vertex 63.0158 54.7721 0
+      vertex 63.1715 54.7525 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.416 47.6857 0
+      vertex 59.7248 53.6309 0
+      vertex 63.0158 54.7721 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 59.8691 53.7752 0
+      vertex 63.0158 54.7721 0
+      vertex 59.7248 53.6309 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 58.5043 52.9091 0
+      vertex 63.0748 46.5032 0
+      vertex 62.6801 46.0555 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 63.0158 54.7721 0
+      vertex 59.8691 53.7752 0
+      vertex 62.8637 54.8112 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 60.0042 53.9284 0
+      vertex 62.8637 54.8112 0
+      vertex 59.8691 53.7752 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.8637 54.8112 0
+      vertex 60.1293 54.0897 0
+      vertex 62.7178 54.869 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 58.109 52.8076 0
+      vertex 62.6801 46.0555 0
+      vertex 62.3143 45.584 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 60.2441 54.2586 0
+      vertex 62.7178 54.869 0
+      vertex 60.1293 54.0897 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.7178 54.869 0
+      vertex 60.2441 54.2586 0
+      vertex 62.5802 54.9446 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.5802 54.9446 0
+      vertex 60.348 54.4343 0
+      vertex 62.4532 55.0369 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 60.4407 54.6162 0
+      vertex 62.4532 55.0369 0
+      vertex 60.348 54.4343 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 60.5218 54.8036 0
+      vertex 62.3388 55.1443 0
+      vertex 60.4407 54.6162 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.3388 55.1443 0
+      vertex 60.5218 54.8036 0
+      vertex 62.2387 55.2653 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.7436 56.2041 0
+      vertex 62 56 0
+      vertex 60.75 56 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.0393 56.3109 0
+      vertex 60.7436 56.2041 0
+      vertex 60.7244 56.4073 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 57.9073 52.7756 0
+      vertex 62.3143 45.584 0
+      vertex 61.9789 45.0904 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 60.6479 55.1918 0
+      vertex 62.2387 55.2653 0
+      vertex 60.5909 54.9957 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.0099 83.8433 0
+      vertex 60.7752 86.6309 0
+      vertex 62 84 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 57.5 52.75 0
+      vertex 61.9789 45.0904 0
+      vertex 61.6751 44.5767 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62 84 0
+      vertex 61.8036 85.9782 0
+      vertex 61.9957 85.9091 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62 84 0
+      vertex 61.6162 86.0593 0
+      vertex 61.8036 85.9782 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 57.0927 52.7756 0
+      vertex 61.6751 44.5767 0
+      vertex 61.4041 44.0449 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62 84 0
+      vertex 61.4343 86.152 0
+      vertex 61.6162 86.0593 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 56.6918 52.8521 0
+      vertex 61.4041 44.0449 0
+      vertex 61.1671 43.4972 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62 84 0
+      vertex 61.2586 86.2559 0
+      vertex 61.4343 86.152 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 56.4957 52.9091 0
+      vertex 61.1671 43.4972 0
+      vertex 60.965 42.9357 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62 84 0
+      vertex 61.0897 86.3707 0
+      vertex 61.2586 86.2559 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 56.1162 53.0593 0
+      vertex 60.965 42.9357 0
+      vertex 60.7985 42.3626 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62 84 0
+      vertex 60.9284 86.4958 0
+      vertex 61.0897 86.3707 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62 84 0
+      vertex 60.7752 86.6309 0
+      vertex 60.9284 86.4958 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62 56 0
+      vertex 60.7436 55.7959 0
+      vertex 60.75 56 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.0099 55.8433 0
+      vertex 60.7436 55.7959 0
+      vertex 62 56 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.0393 55.6891 0
+      vertex 60.7436 55.7959 0
+      vertex 62.0099 55.8433 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55.9343 53.152 0
+      vertex 60.7985 42.3626 0
+      vertex 60.6683 41.7801 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 60.7436 55.7959 0
+      vertex 62.0393 55.6891 0
+      vertex 60.7244 55.5927 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.0878 55.5398 0
+      vertex 60.7244 55.5927 0
+      vertex 62.0393 55.6891 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55.5897 53.3707 0
+      vertex 60.6683 41.7801 0
+      vertex 60.5749 41.1907 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 60.7244 55.5927 0
+      vertex 62.0878 55.5398 0
+      vertex 60.6924 55.391 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55.4284 53.4958 0
+      vertex 60.5749 41.1907 0
+      vertex 60.5187 40.5965 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55.2752 53.6309 0
+      vertex 60.5187 40.5965 0
+      vertex 60.5 40 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.1546 55.3978 0
+      vertex 60.6924 55.391 0
+      vertex 62.0878 55.5398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 88.7599 99.1567 0
+      vertex 79.4813 99.4035 0
+      vertex 79.5 100 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 77.75 0
+      vertex 79.4251 98.8093 0
+      vertex 79.4813 99.4035 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.2248 53.3691 0
+      vertex 77.9901 56.1567 0
+      vertex 79.3691 53.2248 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.9842 70.5023 0
+      vertex 90.25 77.75 0
+      vertex 78 70 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.9901 56.1567 0
+      vertex 79.2248 53.3691 0
+      vertex 78 56 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.9901 84.1567 0
+      vertex 90.25 77.75 0
+      vertex 78 84 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 78 56 0
+      vertex 79.2248 53.3691 0
+      vertex 79.0716 53.5042 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 77.75 0
+      vertex 79.3317 98.2199 0
+      vertex 79.4251 98.8093 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.9901 55.8433 0
+      vertex 79.0716 53.5042 0
+      vertex 78.9103 53.6293 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 77.75 0
+      vertex 79.2015 97.6374 0
+      vertex 79.3317 98.2199 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.9901 55.8433 0
+      vertex 78.9103 53.6293 0
+      vertex 78.7414 53.7441 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.9607 84.3109 0
+      vertex 90.25 77.75 0
+      vertex 77.9901 84.1567 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.9901 55.8433 0
+      vertex 78.7414 53.7441 0
+      vertex 78.5657 53.848 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.9901 55.8433 0
+      vertex 78.5657 53.848 0
+      vertex 78.3838 53.9407 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 77.75 0
+      vertex 79.035 97.0643 0
+      vertex 79.2015 97.6374 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.9901 55.8433 0
+      vertex 78.3838 53.9407 0
+      vertex 78.1964 54.0218 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 77.75 0
+      vertex 78.8329 96.5028 0
+      vertex 79.035 97.0643 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.7613 55.2653 0
+      vertex 78.1964 54.0218 0
+      vertex 78.0043 54.0909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 62.25 0
+      vertex 78 70 0
+      vertex 90.25 77.75 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.9122 84.4602 0
+      vertex 90.25 77.75 0
+      vertex 77.9607 84.3109 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 77.75 0
+      vertex 78.5959 95.9551 0
+      vertex 78.8329 96.5028 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 78.3249 95.4233 0
+      vertex 90.25 77.75 0
+      vertex 77.9122 84.4602 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 77.75 0
+      vertex 78.3249 95.4233 0
+      vertex 78.5959 95.9551 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.8454 84.6022 0
+      vertex 78.3249 95.4233 0
+      vertex 77.9122 84.4602 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 78.3249 95.4233 0
+      vertex 77.8454 84.6022 0
+      vertex 78.0211 94.9096 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.7613 84.7347 0
+      vertex 78.0211 94.9096 0
+      vertex 77.8454 84.6022 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.7613 84.7347 0
+      vertex 77.6857 94.416 0
+      vertex 78.0211 94.9096 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.6612 84.8557 0
+      vertex 77.6857 94.416 0
+      vertex 77.7613 84.7347 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.3199 93.9445 0
+      vertex 77.6612 84.8557 0
+      vertex 77.5468 84.9631 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.9252 93.4968 0
+      vertex 77.5468 84.9631 0
+      vertex 77.4198 85.0554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.6612 84.8557 0
+      vertex 77.3199 93.9445 0
+      vertex 77.6857 94.416 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.5032 93.0748 0
+      vertex 77.4198 85.0554 0
+      vertex 77.2822 85.131 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.0555 92.6801 0
+      vertex 77.2822 85.131 0
+      vertex 77.1363 85.1888 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.584 92.3143 0
+      vertex 77.1363 85.1888 0
+      vertex 76.9842 85.2279 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.5468 84.9631 0
+      vertex 76.9252 93.4968 0
+      vertex 77.3199 93.9445 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.0904 91.9789 0
+      vertex 76.9842 85.2279 0
+      vertex 76.8285 85.2475 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.0904 91.9789 0
+      vertex 76.8285 85.2475 0
+      vertex 76.6715 85.2475 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 74.5767 91.6751 0
+      vertex 76.6715 85.2475 0
+      vertex 76.5158 85.2279 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.4198 85.0554 0
+      vertex 76.5032 93.0748 0
+      vertex 76.9252 93.4968 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 74.0449 91.4041 0
+      vertex 76.5158 85.2279 0
+      vertex 76.3637 85.1888 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 74.0449 91.4041 0
+      vertex 76.3637 85.1888 0
+      vertex 76.2178 85.131 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 73.4972 91.1671 0
+      vertex 76.2178 85.131 0
+      vertex 76.0802 85.0554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.2822 85.131 0
+      vertex 76.0555 92.6801 0
+      vertex 76.5032 93.0748 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 72.9357 90.965 0
+      vertex 76.0802 85.0554 0
+      vertex 75.9532 84.9631 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 72.3626 90.7985 0
+      vertex 75.9532 84.9631 0
+      vertex 75.8388 84.8557 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 72.3626 90.7985 0
+      vertex 75.8388 84.8557 0
+      vertex 75.7387 84.7347 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.7801 90.6683 0
+      vertex 75.7387 84.7347 0
+      vertex 75.6546 84.6022 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.1907 90.5749 0
+      vertex 75.6546 84.6022 0
+      vertex 75.5878 84.4602 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.1363 85.1888 0
+      vertex 75.584 92.3143 0
+      vertex 76.0555 92.6801 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 70.5965 90.5187 0
+      vertex 75.5878 84.4602 0
+      vertex 75.5393 84.3109 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 65.9407 87.6162 0
+      vertex 75.5393 84.3109 0
+      vertex 75.5099 84.1567 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 65.7441 87.2586 0
+      vertex 75.5099 84.1567 0
+      vertex 75.5 84 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 75.9532 83.0369 0
+      vertex 72.4721 77.6085 0
+      vertex 75.8388 83.1443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.9895 77.7487 0
+      vertex 75.8388 83.1443 0
+      vertex 72.4721 77.6085 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.9842 85.2279 0
+      vertex 75.0904 91.9789 0
+      vertex 75.584 92.3143 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 75.8388 83.1443 0
+      vertex 71.9895 77.7487 0
+      vertex 75.7387 83.2653 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 75.7387 83.2653 0
+      vertex 71.9895 77.7487 0
+      vertex 75.6546 83.3978 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.6715 85.2475 0
+      vertex 74.5767 91.6751 0
+      vertex 75.0904 91.9789 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.4991 77.8583 0
+      vertex 75.6546 83.3978 0
+      vertex 71.9895 77.7487 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.5158 85.2279 0
+      vertex 74.0449 91.4041 0
+      vertex 74.5767 91.6751 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 75.6546 83.3978 0
+      vertex 71.4991 77.8583 0
+      vertex 75.5878 83.5398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.2178 85.131 0
+      vertex 73.4972 91.1671 0
+      vertex 74.0449 91.4041 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.0027 77.9369 0
+      vertex 75.5878 83.5398 0
+      vertex 71.4991 77.8583 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.0802 85.0554 0
+      vertex 72.9357 90.965 0
+      vertex 73.4972 91.1671 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 75.5878 83.5398 0
+      vertex 71.0027 77.9369 0
+      vertex 75.5393 83.6891 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.9532 84.9631 0
+      vertex 72.3626 90.7985 0
+      vertex 72.9357 90.965 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 70.5023 77.9842 0
+      vertex 75.5393 83.6891 0
+      vertex 71.0027 77.9369 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.7387 84.7347 0
+      vertex 71.7801 90.6683 0
+      vertex 72.3626 90.7985 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 75.5393 83.6891 0
+      vertex 70.5023 77.9842 0
+      vertex 75.5099 83.8433 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.6546 84.6022 0
+      vertex 71.1907 90.5749 0
+      vertex 71.7801 90.6683 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 70 78 0
+      vertex 75.5099 83.8433 0
+      vertex 70.5023 77.9842 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.5878 84.4602 0
+      vertex 70.5965 90.5187 0
+      vertex 71.1907 90.5749 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 75.5099 83.8433 0
+      vertex 70 78 0
+      vertex 75.5 84 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.5 84 0
+      vertex 75.5 84 0
+      vertex 70 78 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.5099 84.1567 0
+      vertex 65.848 87.4343 0
+      vertex 65.9407 87.6162 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.4901 83.8433 0
+      vertex 70 78 0
+      vertex 69.4977 77.9842 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.5393 84.3109 0
+      vertex 65.9407 87.6162 0
+      vertex 70.5965 90.5187 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.4901 83.8433 0
+      vertex 69.4977 77.9842 0
+      vertex 68.9973 77.9369 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 70.5965 90.5187 0
+      vertex 65.9407 87.6162 0
+      vertex 70 90.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.4901 83.8433 0
+      vertex 68.9973 77.9369 0
+      vertex 68.5009 77.8583 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 66.0909 87.9957 0
+      vertex 70 90.5 0
+      vertex 66.0218 87.8036 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.4901 83.8433 0
+      vertex 68.5009 77.8583 0
+      vertex 68.0105 77.7487 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 70 90.5 0
+      vertex 66.0909 87.9957 0
+      vertex 69.4035 90.5187 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.4901 83.8433 0
+      vertex 68.0105 77.7487 0
+      vertex 67.5279 77.6085 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 69.4035 90.5187 0
+      vertex 66.1924 88.391 0
+      vertex 68.8093 90.5749 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.4901 83.8433 0
+      vertex 67.5279 77.6085 0
+      vertex 67.055 77.4382 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.4901 83.8433 0
+      vertex 67.055 77.4382 0
+      vertex 66.5938 77.2386 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 66.2436 88.7959 0
+      vertex 68.8093 90.5749 0
+      vertex 66.2244 88.5927 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 68.2199 90.6683 0
+      vertex 66.2436 89.2041 0
+      vertex 67.6374 90.7985 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 66.2244 89.4073 0
+      vertex 67.6374 90.7985 0
+      vertex 66.2436 89.2041 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 66.2436 89.2041 0
+      vertex 68.2199 90.6683 0
+      vertex 66.25 89 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 66.25 89 0
+      vertex 68.2199 90.6683 0
+      vertex 66.2436 88.7959 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 68.8093 90.5749 0
+      vertex 66.2436 88.7959 0
+      vertex 68.2199 90.6683 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.4901 83.8433 0
+      vertex 66.5938 77.2386 0
+      vertex 66.146 77.0105 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 66.2244 88.5927 0
+      vertex 68.8093 90.5749 0
+      vertex 66.1924 88.391 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 66.1924 88.391 0
+      vertex 69.4035 90.5187 0
+      vertex 66.1479 88.1918 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 66.1479 88.1918 0
+      vertex 69.4035 90.5187 0
+      vertex 66.0909 87.9957 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 66.0218 87.8036 0
+      vertex 70 90.5 0
+      vertex 65.9407 87.6162 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.5099 84.1567 0
+      vertex 65.7441 87.2586 0
+      vertex 65.848 87.4343 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.4901 83.8433 0
+      vertex 66.146 77.0105 0
+      vertex 65.7134 76.7546 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.5 84 0
+      vertex 64.5 84 0
+      vertex 65.6293 87.0897 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.5 84 0
+      vertex 65.6293 87.0897 0
+      vertex 65.7441 87.2586 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 65.6293 87.0897 0
+      vertex 64.5 84 0
+      vertex 65.5042 86.9284 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.4901 83.8433 0
+      vertex 65.7134 76.7546 0
+      vertex 65.2977 76.4721 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 65.5042 86.9284 0
+      vertex 64.5 84 0
+      vertex 65.3691 86.7752 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.4901 84.1567 0
+      vertex 65.3691 86.7752 0
+      vertex 64.5 84 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 65.3691 86.7752 0
+      vertex 64.4901 84.1567 0
+      vertex 65.2248 86.6309 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.4901 83.8433 0
+      vertex 65.2977 76.4721 0
+      vertex 64.9006 76.1641 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.4607 84.3109 0
+      vertex 65.2248 86.6309 0
+      vertex 64.4901 84.1567 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 65.2248 86.6309 0
+      vertex 64.4607 84.3109 0
+      vertex 65.0716 86.4958 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.0158 82.7721 0
+      vertex 64.9006 76.1641 0
+      vertex 64.5236 75.8317 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.4122 84.4602 0
+      vertex 65.0716 86.4958 0
+      vertex 64.4607 84.3109 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 65.0716 86.4958 0
+      vertex 64.4122 84.4602 0
+      vertex 64.9103 86.3707 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.3454 84.6022 0
+      vertex 64.9103 86.3707 0
+      vertex 64.4122 84.4602 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.9103 86.3707 0
+      vertex 64.3454 84.6022 0
+      vertex 64.7414 86.2559 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.2613 84.7347 0
+      vertex 64.7414 86.2559 0
+      vertex 64.3454 84.6022 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.7414 86.2559 0
+      vertex 64.2613 84.7347 0
+      vertex 64.5657 86.152 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.1612 84.8557 0
+      vertex 64.5657 86.152 0
+      vertex 64.2613 84.7347 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.5657 86.152 0
+      vertex 64.1612 84.8557 0
+      vertex 64.3838 86.0593 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.0468 84.9631 0
+      vertex 64.3838 86.0593 0
+      vertex 64.1612 84.8557 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.3838 86.0593 0
+      vertex 64.0468 84.9631 0
+      vertex 64.1964 85.9782 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.9198 85.0554 0
+      vertex 64.1964 85.9782 0
+      vertex 64.0468 84.9631 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.1964 85.9782 0
+      vertex 63.9198 85.0554 0
+      vertex 64.0043 85.9091 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.7822 85.131 0
+      vertex 64.0043 85.9091 0
+      vertex 63.9198 85.0554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.0043 85.9091 0
+      vertex 63.7822 85.131 0
+      vertex 63.8082 85.8521 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.6363 85.1888 0
+      vertex 63.8082 85.8521 0
+      vertex 63.7822 85.131 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.6363 85.1888 0
+      vertex 63.609 85.8076 0
+      vertex 63.8082 85.8521 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.4842 85.2279 0
+      vertex 63.609 85.8076 0
+      vertex 63.6363 85.1888 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.4842 85.2279 0
+      vertex 63.4073 85.7756 0
+      vertex 63.609 85.8076 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.3285 85.2475 0
+      vertex 63.4073 85.7756 0
+      vertex 63.4842 85.2279 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.3285 85.2475 0
+      vertex 63.2041 85.7564 0
+      vertex 63.4073 85.7756 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.1715 85.2475 0
+      vertex 63.2041 85.7564 0
+      vertex 63.3285 85.2475 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63 85.75 0
+      vertex 63.1715 85.2475 0
+      vertex 63.0158 85.2279 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.1715 85.2475 0
+      vertex 63 85.75 0
+      vertex 63.2041 85.7564 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.7959 85.7564 0
+      vertex 63.0158 85.2279 0
+      vertex 62.8637 85.1888 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.0158 85.2279 0
+      vertex 62.7959 85.7564 0
+      vertex 63 85.75 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.7178 85.131 0
+      vertex 62.7959 85.7564 0
+      vertex 62.8637 85.1888 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.7178 85.131 0
+      vertex 62.5927 85.7756 0
+      vertex 62.7959 85.7564 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.5802 85.0554 0
+      vertex 62.5927 85.7756 0
+      vertex 62.7178 85.131 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.391 85.8076 0
+      vertex 62.5802 85.0554 0
+      vertex 62.4532 84.9631 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.5802 85.0554 0
+      vertex 62.391 85.8076 0
+      vertex 62.5927 85.7756 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.1918 85.8521 0
+      vertex 62.4532 84.9631 0
+      vertex 62.3388 84.8557 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.9957 85.9091 0
+      vertex 62.3388 84.8557 0
+      vertex 62.2387 84.7347 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.4532 84.9631 0
+      vertex 62.1918 85.8521 0
+      vertex 62.391 85.8076 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.9957 85.9091 0
+      vertex 62.2387 84.7347 0
+      vertex 62.1546 84.6022 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.9957 85.9091 0
+      vertex 62.1546 84.6022 0
+      vertex 62.0878 84.4602 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.9957 85.9091 0
+      vertex 62.0878 84.4602 0
+      vertex 62.0393 84.3109 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.9957 85.9091 0
+      vertex 62.0393 84.3109 0
+      vertex 62.0099 84.1567 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.3388 84.8557 0
+      vertex 61.9957 85.9091 0
+      vertex 62.1918 85.8521 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.9957 85.9091 0
+      vertex 62.0099 84.1567 0
+      vertex 62 84 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 88.7893 41.3109 0
+      vertex 79.3317 41.7801 0
+      vertex 88.8378 41.4602 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.2015 42.3626 0
+      vertex 88.8378 41.4602 0
+      vertex 79.3317 41.7801 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 88.8378 41.4602 0
+      vertex 79.2015 42.3626 0
+      vertex 88.9046 41.6022 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.035 42.9357 0
+      vertex 88.9046 41.6022 0
+      vertex 79.2015 42.3626 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 78.8329 43.4972 0
+      vertex 88.9046 41.6022 0
+      vertex 79.035 42.9357 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 88.9046 41.6022 0
+      vertex 78.8329 43.4972 0
+      vertex 79.5042 48.9284 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 78.5959 44.0449 0
+      vertex 79.5042 48.9284 0
+      vertex 78.8329 43.4972 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.5042 48.9284 0
+      vertex 78.5959 44.0449 0
+      vertex 79.3691 48.7752 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.3691 48.7752 0
+      vertex 78.5959 44.0449 0
+      vertex 79.2248 48.6309 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 78.3249 44.5767 0
+      vertex 79.2248 48.6309 0
+      vertex 78.5959 44.0449 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.2248 48.6309 0
+      vertex 78.3249 44.5767 0
+      vertex 79.0716 48.4958 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.0716 48.4958 0
+      vertex 78.3249 44.5767 0
+      vertex 78.9103 48.3707 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 78.0211 45.0904 0
+      vertex 78.9103 48.3707 0
+      vertex 78.3249 44.5767 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 78.9103 48.3707 0
+      vertex 78.0211 45.0904 0
+      vertex 78.7414 48.2559 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 78.7414 48.2559 0
+      vertex 78.0211 45.0904 0
+      vertex 78.5657 48.152 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.6857 45.584 0
+      vertex 78.5657 48.152 0
+      vertex 78.0211 45.0904 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 78.5657 48.152 0
+      vertex 77.6857 45.584 0
+      vertex 78.3838 48.0593 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 78.3838 48.0593 0
+      vertex 77.6857 45.584 0
+      vertex 78.1964 47.9782 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 78.1964 47.9782 0
+      vertex 77.6857 45.584 0
+      vertex 78.0043 47.9091 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.3199 46.0555 0
+      vertex 78.0043 47.9091 0
+      vertex 77.6857 45.584 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 78.0043 47.9091 0
+      vertex 77.3199 46.0555 0
+      vertex 77.8082 47.8521 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.8082 47.8521 0
+      vertex 77.3199 46.0555 0
+      vertex 77.609 47.8076 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.9252 46.5032 0
+      vertex 77.609 47.8076 0
+      vertex 77.3199 46.0555 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.609 47.8076 0
+      vertex 76.9252 46.5032 0
+      vertex 77.4073 47.7756 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.4073 47.7756 0
+      vertex 76.9252 46.5032 0
+      vertex 77.2041 47.7564 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.2041 47.7564 0
+      vertex 76.9252 46.5032 0
+      vertex 77 47.75 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.5032 46.9252 0
+      vertex 77 47.75 0
+      vertex 76.9252 46.5032 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 77 47.75 0
+      vertex 76.5032 46.9252 0
+      vertex 76.7959 47.7564 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 76.7959 47.7564 0
+      vertex 76.5032 46.9252 0
+      vertex 76.5927 47.7756 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.0555 47.3199 0
+      vertex 76.5927 47.7756 0
+      vertex 76.5032 46.9252 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 76.5927 47.7756 0
+      vertex 76.0555 47.3199 0
+      vertex 76.391 47.8076 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 76.391 47.8076 0
+      vertex 76.0555 47.3199 0
+      vertex 76.1918 47.8521 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.0555 47.3199 0
+      vertex 75.9957 47.9091 0
+      vertex 76.1918 47.8521 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.584 47.6857 0
+      vertex 75.9957 47.9091 0
+      vertex 76.0555 47.3199 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 75.9957 47.9091 0
+      vertex 75.584 47.6857 0
+      vertex 75.8036 47.9782 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 75.8036 47.9782 0
+      vertex 75.584 47.6857 0
+      vertex 75.6162 48.0593 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.584 47.6857 0
+      vertex 75.4343 48.152 0
+      vertex 75.6162 48.0593 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.0904 48.0211 0
+      vertex 75.4343 48.152 0
+      vertex 75.584 47.6857 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 75.4343 48.152 0
+      vertex 75.0904 48.0211 0
+      vertex 75.2586 48.2559 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.0904 48.0211 0
+      vertex 75.0897 48.3707 0
+      vertex 75.2586 48.2559 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 74.5767 48.3249 0
+      vertex 75.0897 48.3707 0
+      vertex 75.0904 48.0211 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 75.0897 48.3707 0
+      vertex 74.5767 48.3249 0
+      vertex 74.9284 48.4958 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 74.9284 48.4958 0
+      vertex 74.5767 48.3249 0
+      vertex 74.7752 48.6309 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 74.7752 48.6309 0
+      vertex 74.5767 48.3249 0
+      vertex 74.6309 48.7752 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 74.0449 48.5959 0
+      vertex 74.6309 48.7752 0
+      vertex 74.5767 48.3249 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 74.6309 48.7752 0
+      vertex 74.0449 48.5959 0
+      vertex 74.4958 48.9284 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 74.4958 48.9284 0
+      vertex 74.0449 48.5959 0
+      vertex 74.3707 49.0897 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 74.3707 49.0897 0
+      vertex 74.0449 48.5959 0
+      vertex 74.2559 49.2586 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 73.4972 48.8329 0
+      vertex 74.2559 49.2586 0
+      vertex 74.0449 48.5959 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 74.2559 49.2586 0
+      vertex 73.4972 48.8329 0
+      vertex 74.152 49.4343 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 74.152 49.4343 0
+      vertex 73.4972 48.8329 0
+      vertex 74.0593 49.6162 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 74.0593 49.6162 0
+      vertex 73.4972 48.8329 0
+      vertex 73.9782 49.8036 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 72.9357 49.035 0
+      vertex 73.9782 49.8036 0
+      vertex 73.4972 48.8329 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 73.9782 49.8036 0
+      vertex 72.9357 49.035 0
+      vertex 73.9091 49.9957 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 73.9091 49.9957 0
+      vertex 72.9357 49.035 0
+      vertex 73.8521 50.1918 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 73.8076 50.391 0
+      vertex 72.3626 49.2015 0
+      vertex 73.7756 50.5927 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 73.8521 50.1918 0
+      vertex 72.3626 49.2015 0
+      vertex 73.8076 50.391 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 72.3626 49.2015 0
+      vertex 73.8521 50.1918 0
+      vertex 72.9357 49.035 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 111.76 98.8433 0
+      vertex 91.2401 98.8433 0
+      vertex 91.25 99 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 112.089 98.1443 0
+      vertex 91.2107 98.6891 0
+      vertex 91.2401 98.8433 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 112.089 98.1443 0
+      vertex 91.1622 98.5398 0
+      vertex 91.2107 98.6891 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 112.089 98.1443 0
+      vertex 91.0954 98.3978 0
+      vertex 91.1622 98.5398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 112.089 98.1443 0
+      vertex 91.0113 98.2653 0
+      vertex 91.0954 98.3978 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 112.089 98.1443 0
+      vertex 90.9112 98.1443 0
+      vertex 91.0113 98.2653 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 110.75 77.75 0
+      vertex 90.7968 98.0369 0
+      vertex 90.9112 98.1443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 77.75 0
+      vertex 90.7968 98.0369 0
+      vertex 110.75 77.75 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.7968 98.0369 0
+      vertex 90.25 77.75 0
+      vertex 90.6698 97.9446 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.6698 97.9446 0
+      vertex 90.25 77.75 0
+      vertex 90.5322 97.869 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.5322 97.869 0
+      vertex 90.25 77.75 0
+      vertex 90.3863 97.8112 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 77.75 0
+      vertex 90.2342 97.7721 0
+      vertex 90.3863 97.8112 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.848 52.5657 0
+      vertex 90.25 62.25 0
+      vertex 79.9407 52.3838 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 80.1924 51.609 0
+      vertex 90.2342 42.2279 0
+      vertex 90.0785 42.2475 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.5042 53.0716 0
+      vertex 90.25 62.25 0
+      vertex 79.6293 52.9103 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 80.2436 51.2041 0
+      vertex 90.0785 42.2475 0
+      vertex 89.9215 42.2475 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.3691 53.2248 0
+      vertex 77.9901 56.1567 0
+      vertex 79.5042 53.0716 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 80.25 51 0
+      vertex 89.9215 42.2475 0
+      vertex 89.7658 42.2279 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.9607 56.3109 0
+      vertex 79.5042 53.0716 0
+      vertex 77.9901 56.1567 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 80.2244 50.5927 0
+      vertex 89.7658 42.2279 0
+      vertex 89.6137 42.1888 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.6293 52.9103 0
+      vertex 90.25 62.25 0
+      vertex 79.7441 52.7414 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 80.1479 50.1918 0
+      vertex 89.6137 42.1888 0
+      vertex 89.4678 42.131 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 77.75 0
+      vertex 90.0785 97.7525 0
+      vertex 90.2342 97.7721 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 80.0909 49.9957 0
+      vertex 89.4678 42.131 0
+      vertex 89.3302 42.0554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 77.75 0
+      vertex 89.9215 97.7525 0
+      vertex 90.0785 97.7525 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.9407 49.6162 0
+      vertex 89.3302 42.0554 0
+      vertex 89.2032 41.9631 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 77.75 0
+      vertex 89.7658 97.7721 0
+      vertex 89.9215 97.7525 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.848 49.4343 0
+      vertex 89.2032 41.9631 0
+      vertex 89.0888 41.8557 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 77.75 0
+      vertex 89.6137 97.8112 0
+      vertex 89.7658 97.7721 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.6293 49.0897 0
+      vertex 89.0888 41.8557 0
+      vertex 88.9887 41.7347 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 77.75 0
+      vertex 89.4678 97.869 0
+      vertex 89.6137 97.8112 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.5042 48.9284 0
+      vertex 88.9887 41.7347 0
+      vertex 88.9046 41.6022 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.4813 99.4035 0
+      vertex 89.3302 97.9446 0
+      vertex 90.25 77.75 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 88.7599 41.1567 0
+      vertex 79.4251 41.1907 0
+      vertex 88.7893 41.3109 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 77.75 0
+      vertex 89.3302 97.9446 0
+      vertex 89.4678 97.869 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.4251 41.1907 0
+      vertex 88.7599 41.1567 0
+      vertex 79.4813 40.5965 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.4813 99.4035 0
+      vertex 89.2032 98.0369 0
+      vertex 89.3302 97.9446 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 88.75 41 0
+      vertex 79.4813 40.5965 0
+      vertex 88.7599 41.1567 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.7441 52.7414 0
+      vertex 90.25 62.25 0
+      vertex 79.848 52.5657 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 88.7599 40.8433 0
+      vertex 79.4813 40.5965 0
+      vertex 88.75 41 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.4813 99.4035 0
+      vertex 89.0888 98.1443 0
+      vertex 89.2032 98.0369 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 110.75 62.25 0
+      vertex 140 0 0
+      vertex 114.211 41.3109 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 140 0
+      vertex 114.24 98.8433 0
+      vertex 114.25 99 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 0 0
+      vertex 110.75 62.25 0
+      vertex 140 140 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 140 0
+      vertex 114.211 98.6891 0
+      vertex 114.24 98.8433 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 110.75 62.25 0
+      vertex 114.211 41.3109 0
+      vertex 114.162 41.4602 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 110.75 77.75 0
+      vertex 140 140 0
+      vertex 110.75 62.25 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 110.75 62.25 0
+      vertex 114.162 41.4602 0
+      vertex 114.095 41.6022 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 140 0
+      vertex 110.75 77.75 0
+      vertex 114.211 98.6891 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 110.75 62.25 0
+      vertex 114.095 41.6022 0
+      vertex 114.011 41.7347 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 114.211 98.6891 0
+      vertex 110.75 77.75 0
+      vertex 114.162 98.5398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 110.75 62.25 0
+      vertex 114.011 41.7347 0
+      vertex 113.911 41.8557 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 114.162 98.5398 0
+      vertex 110.75 77.75 0
+      vertex 114.095 98.3978 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 110.75 62.25 0
+      vertex 113.911 41.8557 0
+      vertex 113.797 41.9631 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 114.095 98.3978 0
+      vertex 110.75 77.75 0
+      vertex 114.011 98.2653 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 110.75 62.25 0
+      vertex 113.797 41.9631 0
+      vertex 113.67 42.0554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 114.011 98.2653 0
+      vertex 110.75 77.75 0
+      vertex 113.911 98.1443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 110.75 62.25 0
+      vertex 113.67 42.0554 0
+      vertex 113.532 42.131 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 113.911 98.1443 0
+      vertex 110.75 77.75 0
+      vertex 113.797 98.0369 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 110.75 62.25 0
+      vertex 113.532 42.131 0
+      vertex 113.386 42.1888 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 113.797 98.0369 0
+      vertex 110.75 77.75 0
+      vertex 113.67 97.9446 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 110.75 62.25 0
+      vertex 113.386 42.1888 0
+      vertex 113.234 42.2279 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 113.67 97.9446 0
+      vertex 110.75 77.75 0
+      vertex 113.532 97.869 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 110.75 62.25 0
+      vertex 113.234 42.2279 0
+      vertex 113.078 42.2475 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 113.532 97.869 0
+      vertex 110.75 77.75 0
+      vertex 113.386 97.8112 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 110.75 62.25 0
+      vertex 113.078 42.2475 0
+      vertex 112.922 42.2475 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 113.386 97.8112 0
+      vertex 110.75 77.75 0
+      vertex 113.234 97.7721 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 110.75 62.25 0
+      vertex 112.922 42.2475 0
+      vertex 112.766 42.2279 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 113.234 97.7721 0
+      vertex 110.75 77.75 0
+      vertex 113.078 97.7525 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 110.75 62.25 0
+      vertex 112.766 42.2279 0
+      vertex 112.614 42.1888 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 113.078 97.7525 0
+      vertex 110.75 77.75 0
+      vertex 112.922 97.7525 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 110.75 62.25 0
+      vertex 112.614 42.1888 0
+      vertex 112.468 42.131 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 112.922 97.7525 0
+      vertex 110.75 77.75 0
+      vertex 112.766 97.7721 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 110.75 62.25 0
+      vertex 112.468 42.131 0
+      vertex 112.33 42.0554 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 112.766 97.7721 0
+      vertex 110.75 77.75 0
+      vertex 112.614 97.8112 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 110.75 62.25 0
+      vertex 112.33 42.0554 0
+      vertex 112.203 41.9631 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 112.614 97.8112 0
+      vertex 110.75 77.75 0
+      vertex 112.468 97.869 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 110.75 62.25 0
+      vertex 112.203 41.9631 0
+      vertex 112.089 41.8557 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 112.468 97.869 0
+      vertex 110.75 77.75 0
+      vertex 112.33 97.9446 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.9112 41.8557 0
+      vertex 112.089 41.8557 0
+      vertex 111.989 41.7347 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 112.33 97.9446 0
+      vertex 110.75 77.75 0
+      vertex 112.203 98.0369 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 91.0113 41.7347 0
+      vertex 111.989 41.7347 0
+      vertex 111.905 41.6022 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 112.203 98.0369 0
+      vertex 110.75 77.75 0
+      vertex 112.089 98.1443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 91.0954 41.6022 0
+      vertex 111.905 41.6022 0
+      vertex 111.838 41.4602 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.9112 98.1443 0
+      vertex 112.089 98.1443 0
+      vertex 110.75 77.75 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 91.1622 41.4602 0
+      vertex 111.838 41.4602 0
+      vertex 111.789 41.3109 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 91.2401 98.8433 0
+      vertex 111.989 98.2653 0
+      vertex 112.089 98.1443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 91.2107 41.3109 0
+      vertex 111.789 41.3109 0
+      vertex 111.76 41.1567 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 91.2401 98.8433 0
+      vertex 111.905 98.3978 0
+      vertex 111.989 98.2653 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 91.2401 41.1567 0
+      vertex 111.76 41.1567 0
+      vertex 111.75 41 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 91.2401 98.8433 0
+      vertex 111.838 98.5398 0
+      vertex 111.905 98.3978 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 114.24 41.1567 0
+      vertex 140 0 0
+      vertex 114.25 41 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 0 0
+      vertex 114.24 40.8433 0
+      vertex 114.25 41 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 0 0
+      vertex 114.211 40.6891 0
+      vertex 114.24 40.8433 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 0 0
+      vertex 114.162 40.5398 0
+      vertex 114.211 40.6891 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 0 0
+      vertex 114.095 40.3978 0
+      vertex 114.162 40.5398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 0 0
+      vertex 114.011 40.2653 0
+      vertex 114.095 40.3978 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 0 0
+      vertex 113.911 40.1443 0
+      vertex 114.011 40.2653 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 0 0
+      vertex 113.797 40.0369 0
+      vertex 113.911 40.1443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 0 0
+      vertex 113.67 39.9446 0
+      vertex 113.797 40.0369 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 0 0
+      vertex 113.532 39.869 0
+      vertex 113.67 39.9446 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 0 0
+      vertex 113.386 39.8112 0
+      vertex 113.532 39.869 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 0 0
+      vertex 113.234 39.7721 0
+      vertex 113.386 39.8112 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 0 0
+      vertex 113.078 39.7525 0
+      vertex 113.234 39.7721 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 0 0
+      vertex 112.922 39.7525 0
+      vertex 113.078 39.7525 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 0 0
+      vertex 112.766 39.7721 0
+      vertex 112.922 39.7525 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 72 6 0
+      vertex 112.766 39.7721 0
+      vertex 140 0 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 112.766 39.7721 0
+      vertex 72 6 0
+      vertex 112.614 39.8112 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.9842 6.25067 0
+      vertex 112.614 39.8112 0
+      vertex 72 6 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 112.614 39.8112 0
+      vertex 71.9842 6.25067 0
+      vertex 112.468 39.869 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 112.468 39.869 0
+      vertex 90.5322 39.869 0
+      vertex 112.33 39.9446 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 90.6698 39.9446 0
+      vertex 112.33 39.9446 0
+      vertex 90.5322 39.869 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 91.2401 98.8433 0
+      vertex 111.789 98.6891 0
+      vertex 111.838 98.5398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 91.2401 41.1567 0
+      vertex 111.75 41 0
+      vertex 91.25 41 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 111.76 40.8433 0
+      vertex 91.25 41 0
+      vertex 111.75 41 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 91.2401 40.8433 0
+      vertex 111.76 40.8433 0
+      vertex 111.789 40.6891 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 91.2107 40.6891 0
+      vertex 111.789 40.6891 0
+      vertex 111.838 40.5398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 91.1622 40.5398 0
+      vertex 111.838 40.5398 0
+      vertex 111.905 40.3978 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 91.0954 40.3978 0
+      vertex 111.905 40.3978 0
+      vertex 111.989 40.2653 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 112.33 39.9446 0
+      vertex 90.6698 39.9446 0
+      vertex 112.203 40.0369 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 111.76 40.8433 0
+      vertex 91.2401 40.8433 0
+      vertex 91.25 41 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 111.789 40.6891 0
+      vertex 91.2107 40.6891 0
+      vertex 91.2401 40.8433 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 111.838 40.5398 0
+      vertex 91.1622 40.5398 0
+      vertex 91.2107 40.6891 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 111.905 40.3978 0
+      vertex 91.0954 40.3978 0
+      vertex 91.1622 40.5398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 111.989 40.2653 0
+      vertex 91.0113 40.2653 0
+      vertex 91.0954 40.3978 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 111.989 40.2653 0
+      vertex 90.9112 40.1443 0
+      vertex 91.0113 40.2653 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 112.089 40.1443 0
+      vertex 90.9112 40.1443 0
+      vertex 111.989 40.2653 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 90.9112 40.1443 0
+      vertex 112.089 40.1443 0
+      vertex 90.7968 40.0369 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 112.203 40.0369 0
+      vertex 90.7968 40.0369 0
+      vertex 112.089 40.1443 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 90.7968 40.0369 0
+      vertex 112.203 40.0369 0
+      vertex 90.6698 39.9446 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 112.468 39.869 0
+      vertex 71.9842 6.25067 0
+      vertex 90.5322 39.869 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.5322 39.869 0
+      vertex 71.9842 6.25067 0
+      vertex 90.3863 39.8112 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.9372 6.49738 0
+      vertex 90.3863 39.8112 0
+      vertex 71.9842 6.25067 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.3863 39.8112 0
+      vertex 71.9372 6.49738 0
+      vertex 90.2342 39.7721 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 76.9252 33.4968 0
+      vertex 90.0785 39.7525 0
+      vertex 76.5032 33.0748 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 77.3199 33.9445 0
+      vertex 90.0785 39.7525 0
+      vertex 76.9252 33.4968 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 77.6857 34.416 0
+      vertex 89.9215 39.7525 0
+      vertex 77.3199 33.9445 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 89.9215 39.7525 0
+      vertex 77.6857 34.416 0
+      vertex 89.7658 39.7721 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 89.9215 42.2475 0
+      vertex 80.25 51 0
+      vertex 80.2436 51.2041 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.4813 40.5965 0
+      vertex 88.7599 40.8433 0
+      vertex 79.5 40 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.5 40 0
+      vertex 88.7599 40.8433 0
+      vertex 88.7893 40.6891 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.4813 39.4035 0
+      vertex 88.7893 40.6891 0
+      vertex 88.8378 40.5398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.4251 38.8093 0
+      vertex 88.8378 40.5398 0
+      vertex 88.9046 40.3978 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.3317 38.2199 0
+      vertex 88.9046 40.3978 0
+      vertex 88.9887 40.2653 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 89.7658 42.2279 0
+      vertex 80.2436 50.7959 0
+      vertex 80.25 51 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.2015 37.6374 0
+      vertex 88.9887 40.2653 0
+      vertex 89.0888 40.1443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 89.7658 42.2279 0
+      vertex 80.2244 50.5927 0
+      vertex 80.2436 50.7959 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 89.6137 42.1888 0
+      vertex 80.1924 50.391 0
+      vertex 80.2244 50.5927 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 89.6137 42.1888 0
+      vertex 80.1479 50.1918 0
+      vertex 80.1924 50.391 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 89.4678 42.131 0
+      vertex 80.0909 49.9957 0
+      vertex 80.1479 50.1918 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 89.3302 42.0554 0
+      vertex 80.0218 49.8036 0
+      vertex 80.0909 49.9957 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 89.3302 42.0554 0
+      vertex 79.9407 49.6162 0
+      vertex 80.0218 49.8036 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 89.2032 41.9631 0
+      vertex 79.848 49.4343 0
+      vertex 79.9407 49.6162 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 89.0888 41.8557 0
+      vertex 79.7441 49.2586 0
+      vertex 79.848 49.4343 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 89.0888 41.8557 0
+      vertex 79.6293 49.0897 0
+      vertex 79.7441 49.2586 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 88.9887 41.7347 0
+      vertex 79.5042 48.9284 0
+      vertex 79.6293 49.0897 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.2015 37.6374 0
+      vertex 89.0888 40.1443 0
+      vertex 89.2032 40.0369 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.3317 41.7801 0
+      vertex 88.7893 41.3109 0
+      vertex 79.4251 41.1907 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 78.0211 34.9096 0
+      vertex 89.7658 39.7721 0
+      vertex 77.6857 34.416 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 88.7893 40.6891 0
+      vertex 79.4813 39.4035 0
+      vertex 79.5 40 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 88.8378 40.5398 0
+      vertex 79.4251 38.8093 0
+      vertex 79.4813 39.4035 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 88.9046 40.3978 0
+      vertex 79.3317 38.2199 0
+      vertex 79.4251 38.8093 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 88.9887 40.2653 0
+      vertex 79.2015 37.6374 0
+      vertex 79.3317 38.2199 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 89.2032 40.0369 0
+      vertex 79.035 37.0643 0
+      vertex 79.2015 37.6374 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 89.2032 40.0369 0
+      vertex 78.8329 36.5028 0
+      vertex 79.035 37.0643 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 89.3302 39.9446 0
+      vertex 78.8329 36.5028 0
+      vertex 89.2032 40.0369 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 78.8329 36.5028 0
+      vertex 89.3302 39.9446 0
+      vertex 78.5959 35.9551 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 89.4678 39.869 0
+      vertex 78.5959 35.9551 0
+      vertex 89.3302 39.9446 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 78.5959 35.9551 0
+      vertex 89.4678 39.869 0
+      vertex 78.3249 35.4233 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 89.7658 39.7721 0
+      vertex 78.0211 34.9096 0
+      vertex 89.6137 39.8112 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 89.6137 39.8112 0
+      vertex 78.3249 35.4233 0
+      vertex 89.4678 39.869 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 78.3249 35.4233 0
+      vertex 89.6137 39.8112 0
+      vertex 78.0211 34.9096 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 90.0785 39.7525 0
+      vertex 77.3199 33.9445 0
+      vertex 89.9215 39.7525 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.8596 6.73625 0
+      vertex 90.2342 39.7721 0
+      vertex 71.9372 6.49738 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.2342 39.7721 0
+      vertex 71.8596 6.73625 0
+      vertex 90.0785 39.7525 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.0785 39.7525 0
+      vertex 71.8596 6.73625 0
+      vertex 76.5032 33.0748 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.7526 6.96351 0
+      vertex 76.5032 33.0748 0
+      vertex 71.8596 6.73625 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.5032 33.0748 0
+      vertex 71.7526 6.96351 0
+      vertex 76.0555 32.6801 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.618 7.17557 0
+      vertex 76.0555 32.6801 0
+      vertex 71.7526 6.96351 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 76.0555 32.6801 0
+      vertex 71.618 7.17557 0
+      vertex 75.584 32.3143 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 75.584 32.3143 0
+      vertex 71.618 7.17557 0
+      vertex 75.0904 31.9789 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 0 0
+      vertex 71.9842 5.74933 0
+      vertex 72 6 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 0 0
+      vertex 71.9372 5.50262 0
+      vertex 71.9842 5.74933 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 0 0
+      vertex 71.8596 5.26375 0
+      vertex 71.9372 5.50262 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 0 0
+      vertex 71.7526 5.03649 0
+      vertex 71.8596 5.26375 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 0 0
+      vertex 71.618 4.82443 0
+      vertex 71.7526 5.03649 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 0 0
+      vertex 71.4579 4.63091 0
+      vertex 71.618 4.82443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 0 0
+      vertex 71.2748 4.45897 0
+      vertex 71.4579 4.63091 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 0 0
+      vertex 71.0717 4.31135 0
+      vertex 71.2748 4.45897 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 0 0
+      vertex 70.8516 4.19035 0
+      vertex 71.0717 4.31135 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 0 0
+      vertex 70.618 4.09789 0
+      vertex 70.8516 4.19035 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 0 0
+      vertex 70.3748 4.03543 0
+      vertex 70.618 4.09789 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 0 0
+      vertex 70.1256 4.00395 0
+      vertex 70.3748 4.03543 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 140 0 0
+      vertex 69.8744 4.00395 0
+      vertex 70.1256 4.00395 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 69.1484 7.80965 0
+      vertex 67.0643 30.965 0
+      vertex 67.6374 30.7985 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 68.9283 7.68866 0
+      vertex 66.5028 31.1671 0
+      vertex 67.0643 30.965 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 68.7252 7.54103 0
+      vertex 65.9551 31.4041 0
+      vertex 66.5028 31.1671 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 68 6 0
+      vertex 68.0158 5.74933 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 68.7252 7.54103 0
+      vertex 65.4233 31.6751 0
+      vertex 65.9551 31.4041 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 68.5421 7.36909 0
+      vertex 64.9096 31.9789 0
+      vertex 65.4233 31.6751 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 68.382 7.17557 0
+      vertex 64.416 32.3143 0
+      vertex 64.9096 31.9789 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 68.382 7.17557 0
+      vertex 63.9445 32.6801 0
+      vertex 64.416 32.3143 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 68.2474 6.96351 0
+      vertex 63.4968 33.0748 0
+      vertex 63.9445 32.6801 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 68.1404 6.73625 0
+      vertex 63.0748 33.4968 0
+      vertex 63.4968 33.0748 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 68.1404 6.73625 0
+      vertex 62.6801 33.9445 0
+      vertex 63.0748 33.4968 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 68.0628 6.49738 0
+      vertex 62.3143 34.416 0
+      vertex 62.6801 33.9445 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 68.0158 5.74933 0
+      vertex 68.0628 5.50262 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 68.0628 6.49738 0
+      vertex 0 0 0
+      vertex 62.3143 34.416 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.3143 34.416 0
+      vertex 0 0 0
+      vertex 61.9789 34.9096 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 61.9789 34.9096 0
+      vertex 0 0 0
+      vertex 61.6751 35.4233 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 61.6751 35.4233 0
+      vertex 0 0 0
+      vertex 61.4041 35.9551 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 61.4041 35.9551 0
+      vertex 0 0 0
+      vertex 61.1671 36.5028 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 61.1671 36.5028 0
+      vertex 0 0 0
+      vertex 60.965 37.0643 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 60.6924 55.391 0
+      vertex 62.1546 55.3978 0
+      vertex 60.6479 55.1918 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.2387 55.2653 0
+      vertex 60.6479 55.1918 0
+      vertex 62.1546 55.3978 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 60.5909 54.9957 0
+      vertex 62.2387 55.2653 0
+      vertex 60.5218 54.8036 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.4532 55.0369 0
+      vertex 60.4407 54.6162 0
+      vertex 62.3388 55.1443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.9958 53.9284 0
+      vertex 60.5 40 0
+      vertex 60.5187 39.4035 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 60.348 54.4343 0
+      vertex 62.5802 54.9446 0
+      vertex 60.2441 54.2586 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 60.1293 54.0897 0
+      vertex 62.8637 54.8112 0
+      vertex 60.0042 53.9284 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.416 47.6857 0
+      vertex 59.5716 53.4958 0
+      vertex 59.7248 53.6309 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.9445 47.3199 0
+      vertex 59.4103 53.3707 0
+      vertex 59.5716 53.4958 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.9445 47.3199 0
+      vertex 59.2414 53.2559 0
+      vertex 59.4103 53.3707 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.4968 46.9252 0
+      vertex 59.0657 53.152 0
+      vertex 59.2414 53.2559 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8707 54.0897 0
+      vertex 60.5187 39.4035 0
+      vertex 60.5749 38.8093 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.4968 46.9252 0
+      vertex 58.8838 53.0593 0
+      vertex 59.0657 53.152 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.0748 46.5032 0
+      vertex 58.6964 52.9782 0
+      vertex 58.8838 53.0593 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.0748 46.5032 0
+      vertex 58.5043 52.9091 0
+      vertex 58.6964 52.9782 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.6801 46.0555 0
+      vertex 58.3082 52.8521 0
+      vertex 58.5043 52.9091 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 60.5749 38.8093 0
+      vertex 60.6683 38.2199 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.6801 46.0555 0
+      vertex 58.109 52.8076 0
+      vertex 58.3082 52.8521 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.3143 45.584 0
+      vertex 57.9073 52.7756 0
+      vertex 58.109 52.8076 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.9789 45.0904 0
+      vertex 57.7041 52.7564 0
+      vertex 57.9073 52.7756 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.9789 45.0904 0
+      vertex 57.5 52.75 0
+      vertex 57.7041 52.7564 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.6751 44.5767 0
+      vertex 57.2959 52.7564 0
+      vertex 57.5 52.75 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 60.6683 38.2199 0
+      vertex 60.7985 37.6374 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 60.965 37.0643 0
+      vertex 0 0 0
+      vertex 60.7985 37.6374 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.6751 44.5767 0
+      vertex 57.0927 52.7756 0
+      vertex 57.2959 52.7564 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.4041 44.0449 0
+      vertex 56.891 52.8076 0
+      vertex 57.0927 52.7756 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.4041 44.0449 0
+      vertex 56.6918 52.8521 0
+      vertex 56.891 52.8076 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.1671 43.4972 0
+      vertex 56.4957 52.9091 0
+      vertex 56.6918 52.8521 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.965 42.9357 0
+      vertex 56.3036 52.9782 0
+      vertex 56.4957 52.9091 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.965 42.9357 0
+      vertex 56.1162 53.0593 0
+      vertex 56.3036 52.9782 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.7985 42.3626 0
+      vertex 55.9343 53.152 0
+      vertex 56.1162 53.0593 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.6683 41.7801 0
+      vertex 55.7586 53.2559 0
+      vertex 55.9343 53.152 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.6683 41.7801 0
+      vertex 55.5897 53.3707 0
+      vertex 55.7586 53.2559 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 60.5749 38.8093 0
+      vertex 0 0 0
+      vertex 54.7559 54.2586 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.5749 41.1907 0
+      vertex 55.4284 53.4958 0
+      vertex 55.5897 53.3707 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.5187 40.5965 0
+      vertex 55.2752 53.6309 0
+      vertex 55.4284 53.4958 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.5 40 0
+      vertex 55.1309 53.7752 0
+      vertex 55.2752 53.6309 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.5 40 0
+      vertex 54.9958 53.9284 0
+      vertex 55.1309 53.7752 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.5187 39.4035 0
+      vertex 54.8707 54.0897 0
+      vertex 54.9958 53.9284 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.5749 38.8093 0
+      vertex 54.7559 54.2586 0
+      vertex 54.8707 54.0897 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 54.7559 54.2586 0
+      vertex 0 0 0
+      vertex 54.652 54.4343 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 54.652 54.4343 0
+      vertex 0 0 0
+      vertex 54.5593 54.6162 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 54.5593 54.6162 0
+      vertex 0 0 0
+      vertex 54.4782 54.8036 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 54.4782 54.8036 0
+      vertex 0 0 0
+      vertex 54.4091 54.9957 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 54.2564 55.7959 0
+      vertex 0 0 0
+      vertex 54.25 56 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 54.2756 55.5927 0
+      vertex 0 0 0
+      vertex 54.2564 55.7959 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 54.3076 55.391 0
+      vertex 0 0 0
+      vertex 54.2756 55.5927 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 54.3521 55.1918 0
+      vertex 0 0 0
+      vertex 54.3076 55.391 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 54.4091 54.9957 0
+      vertex 0 0 0
+      vertex 54.3521 55.1918 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 68.1404 5.26375 0
+      vertex 0 0 0
+      vertex 68.0628 5.50262 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 68.2474 5.03649 0
+      vertex 0 0 0
+      vertex 68.1404 5.26375 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 68.382 4.82443 0
+      vertex 0 0 0
+      vertex 68.2474 5.03649 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 68.5421 4.63091 0
+      vertex 0 0 0
+      vertex 68.382 4.82443 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 68.7252 4.45897 0
+      vertex 0 0 0
+      vertex 68.5421 4.63091 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 68.9283 4.31135 0
+      vertex 0 0 0
+      vertex 68.7252 4.45897 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 69.1484 4.19035 0
+      vertex 0 0 0
+      vertex 68.9283 4.31135 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 69.382 4.09789 0
+      vertex 0 0 0
+      vertex 69.1484 4.19035 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 69.6252 4.03543 0
+      vertex 0 0 0
+      vertex 69.382 4.09789 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 69.8744 4.00395 0
+      vertex 0 0 0
+      vertex 69.6252 4.03543 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 69.8744 4.00395 0
+      vertex 140 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 114.211 41.3109 0
+      vertex 140 0 0
+      vertex 114.24 41.1567 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 114.24 99.1567 0
+      vertex 140 140 0
+      vertex 114.25 99 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 114.211 99.3109 0
+      vertex 140 140 0
+      vertex 114.24 99.1567 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 114.162 99.4602 0
+      vertex 140 140 0
+      vertex 114.211 99.3109 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 114.095 99.6022 0
+      vertex 140 140 0
+      vertex 114.162 99.4602 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 114.011 99.7347 0
+      vertex 140 140 0
+      vertex 114.095 99.6022 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 113.911 99.8557 0
+      vertex 140 140 0
+      vertex 114.011 99.7347 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 113.797 99.9631 0
+      vertex 140 140 0
+      vertex 113.911 99.8557 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 113.67 100.055 0
+      vertex 140 140 0
+      vertex 113.797 99.9631 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 113.532 100.131 0
+      vertex 140 140 0
+      vertex 113.67 100.055 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 113.386 100.189 0
+      vertex 140 140 0
+      vertex 113.532 100.131 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 113.234 100.228 0
+      vertex 140 140 0
+      vertex 113.386 100.189 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 113.078 100.248 0
+      vertex 140 140 0
+      vertex 113.234 100.228 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 112.922 100.248 0
+      vertex 140 140 0
+      vertex 113.078 100.248 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 112.766 100.228 0
+      vertex 140 140 0
+      vertex 112.922 100.248 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 72 134 0
+      vertex 112.766 100.228 0
+      vertex 112.614 100.189 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.9842 133.749 0
+      vertex 112.614 100.189 0
+      vertex 112.468 100.131 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.5322 100.131 0
+      vertex 112.468 100.131 0
+      vertex 112.33 100.055 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.6698 100.055 0
+      vertex 112.33 100.055 0
+      vertex 112.203 99.9631 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.7968 99.9631 0
+      vertex 112.203 99.9631 0
+      vertex 112.089 99.8557 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.9112 99.8557 0
+      vertex 112.089 99.8557 0
+      vertex 111.989 99.7347 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 91.2401 98.8433 0
+      vertex 111.76 98.8433 0
+      vertex 111.789 98.6891 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 111.76 98.8433 0
+      vertex 91.25 99 0
+      vertex 111.75 99 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 91.25 99 0
+      vertex 111.76 99.1567 0
+      vertex 111.75 99 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 91.2401 99.1567 0
+      vertex 111.76 99.1567 0
+      vertex 91.25 99 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 111.76 99.1567 0
+      vertex 91.2401 99.1567 0
+      vertex 111.789 99.3109 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 91.2107 99.3109 0
+      vertex 111.789 99.3109 0
+      vertex 91.2401 99.1567 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 111.789 99.3109 0
+      vertex 91.2107 99.3109 0
+      vertex 111.838 99.4602 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 91.1622 99.4602 0
+      vertex 111.838 99.4602 0
+      vertex 91.2107 99.3109 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 111.838 99.4602 0
+      vertex 91.1622 99.4602 0
+      vertex 111.905 99.6022 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 91.0954 99.6022 0
+      vertex 111.905 99.6022 0
+      vertex 91.1622 99.4602 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 111.905 99.6022 0
+      vertex 91.0954 99.6022 0
+      vertex 111.989 99.7347 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 91.0113 99.7347 0
+      vertex 111.989 99.7347 0
+      vertex 91.0954 99.6022 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.9112 99.8557 0
+      vertex 111.989 99.7347 0
+      vertex 91.0113 99.7347 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 112.089 99.8557 0
+      vertex 90.9112 99.8557 0
+      vertex 90.7968 99.9631 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 112.203 99.9631 0
+      vertex 90.7968 99.9631 0
+      vertex 90.6698 100.055 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 112.33 100.055 0
+      vertex 90.6698 100.055 0
+      vertex 90.5322 100.131 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.9842 133.749 0
+      vertex 112.468 100.131 0
+      vertex 90.5322 100.131 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.9842 133.749 0
+      vertex 90.5322 100.131 0
+      vertex 90.3863 100.189 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.9842 133.749 0
+      vertex 90.3863 100.189 0
+      vertex 90.2342 100.228 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.9842 133.749 0
+      vertex 90.2342 100.228 0
+      vertex 90.0785 100.248 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.3199 106.056 0
+      vertex 90.0785 100.248 0
+      vertex 89.9215 100.248 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.6857 105.584 0
+      vertex 89.9215 100.248 0
+      vertex 89.7658 100.228 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 78.0211 105.09 0
+      vertex 89.7658 100.228 0
+      vertex 89.6137 100.189 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 78.3249 104.577 0
+      vertex 89.6137 100.189 0
+      vertex 89.4678 100.131 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 78.5959 104.045 0
+      vertex 89.4678 100.131 0
+      vertex 89.3302 100.055 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 78.8329 103.497 0
+      vertex 89.3302 100.055 0
+      vertex 89.2032 99.9631 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.0785 42.2475 0
+      vertex 80.2436 51.2041 0
+      vertex 80.2244 51.4073 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.0785 42.2475 0
+      vertex 80.2244 51.4073 0
+      vertex 80.1924 51.609 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.2342 42.2279 0
+      vertex 80.1924 51.609 0
+      vertex 80.1479 51.8082 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.2342 42.2279 0
+      vertex 80.1479 51.8082 0
+      vertex 80.0909 52.0043 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.2342 42.2279 0
+      vertex 80.0909 52.0043 0
+      vertex 80.0218 52.1964 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.2342 42.2279 0
+      vertex 80.0218 52.1964 0
+      vertex 79.9407 52.3838 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.4813 99.4035 0
+      vertex 88.9887 98.2653 0
+      vertex 89.0888 98.1443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.4813 99.4035 0
+      vertex 88.9046 98.3978 0
+      vertex 88.9887 98.2653 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.4813 99.4035 0
+      vertex 88.8378 98.5398 0
+      vertex 88.9046 98.3978 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.4813 99.4035 0
+      vertex 88.7893 98.6891 0
+      vertex 88.8378 98.5398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.4813 99.4035 0
+      vertex 88.7599 98.8433 0
+      vertex 88.7893 98.6891 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.4813 99.4035 0
+      vertex 88.75 99 0
+      vertex 88.7599 98.8433 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.4813 99.4035 0
+      vertex 88.7599 99.1567 0
+      vertex 88.75 99 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 88.7599 99.1567 0
+      vertex 79.5 100 0
+      vertex 88.7893 99.3109 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.4813 100.597 0
+      vertex 88.7893 99.3109 0
+      vertex 79.5 100 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 88.7893 99.3109 0
+      vertex 79.4813 100.597 0
+      vertex 88.8378 99.4602 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.4251 101.191 0
+      vertex 88.8378 99.4602 0
+      vertex 79.4813 100.597 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 88.8378 99.4602 0
+      vertex 79.4251 101.191 0
+      vertex 88.9046 99.6022 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.3317 101.78 0
+      vertex 88.9046 99.6022 0
+      vertex 79.4251 101.191 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 88.9046 99.6022 0
+      vertex 79.3317 101.78 0
+      vertex 88.9887 99.7347 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.2015 102.363 0
+      vertex 88.9887 99.7347 0
+      vertex 79.3317 101.78 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 88.9887 99.7347 0
+      vertex 79.2015 102.363 0
+      vertex 89.0888 99.8557 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 89.0888 99.8557 0
+      vertex 79.2015 102.363 0
+      vertex 89.2032 99.9631 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.035 102.936 0
+      vertex 89.2032 99.9631 0
+      vertex 79.2015 102.363 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 78.8329 103.497 0
+      vertex 89.2032 99.9631 0
+      vertex 79.035 102.936 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 89.3302 100.055 0
+      vertex 78.8329 103.497 0
+      vertex 78.5959 104.045 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 89.4678 100.131 0
+      vertex 78.5959 104.045 0
+      vertex 78.3249 104.577 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 89.6137 100.189 0
+      vertex 78.3249 104.577 0
+      vertex 78.0211 105.09 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 89.7658 100.228 0
+      vertex 78.0211 105.09 0
+      vertex 77.6857 105.584 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 89.9215 100.248 0
+      vertex 77.6857 105.584 0
+      vertex 77.3199 106.056 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.0785 100.248 0
+      vertex 77.3199 106.056 0
+      vertex 76.9252 106.503 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.0785 100.248 0
+      vertex 76.9252 106.503 0
+      vertex 76.5032 106.925 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.9842 133.749 0
+      vertex 90.0785 100.248 0
+      vertex 76.5032 106.925 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.9842 133.749 0
+      vertex 76.5032 106.925 0
+      vertex 76.0555 107.32 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.9842 133.749 0
+      vertex 76.0555 107.32 0
+      vertex 75.584 107.686 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.9842 133.749 0
+      vertex 75.584 107.686 0
+      vertex 75.0904 108.021 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.9842 133.749 0
+      vertex 75.0904 108.021 0
+      vertex 74.5767 108.325 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.9842 133.749 0
+      vertex 74.5767 108.325 0
+      vertex 74.0449 108.596 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.9842 133.749 0
+      vertex 74.0449 108.596 0
+      vertex 73.4972 108.833 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.9842 133.749 0
+      vertex 73.4972 108.833 0
+      vertex 72.9357 109.035 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 70.8516 132.19 0
+      vertex 72.9357 109.035 0
+      vertex 72.3626 109.202 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 112.766 100.228 0
+      vertex 72 134 0
+      vertex 140 140 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.9842 134.251 0
+      vertex 140 140 0
+      vertex 72 134 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.9372 134.497 0
+      vertex 140 140 0
+      vertex 71.9842 134.251 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.8596 134.736 0
+      vertex 140 140 0
+      vertex 71.9372 134.497 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.7526 134.964 0
+      vertex 140 140 0
+      vertex 71.8596 134.736 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.618 135.176 0
+      vertex 140 140 0
+      vertex 71.7526 134.964 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.4579 135.369 0
+      vertex 140 140 0
+      vertex 71.618 135.176 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.2748 135.541 0
+      vertex 140 140 0
+      vertex 71.4579 135.369 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.0717 135.689 0
+      vertex 140 140 0
+      vertex 71.2748 135.541 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 70.8516 135.81 0
+      vertex 140 140 0
+      vertex 71.0717 135.689 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 70.618 135.902 0
+      vertex 140 140 0
+      vertex 70.8516 135.81 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 70.3748 135.965 0
+      vertex 140 140 0
+      vertex 70.618 135.902 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 70.1256 135.996 0
+      vertex 140 140 0
+      vertex 70.3748 135.965 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 69.8744 135.996 0
+      vertex 140 140 0
+      vertex 70.1256 135.996 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.416 107.686 0
+      vertex 68.382 132.824 0
+      vertex 64.9096 108.021 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.9445 107.32 0
+      vertex 68.382 132.824 0
+      vertex 64.416 107.686 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 68.382 132.824 0
+      vertex 63.9445 107.32 0
+      vertex 68.2474 133.036 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.4968 106.925 0
+      vertex 68.2474 133.036 0
+      vertex 63.9445 107.32 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 68.2474 133.036 0
+      vertex 63.4968 106.925 0
+      vertex 68.1404 133.264 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.0748 106.503 0
+      vertex 68.1404 133.264 0
+      vertex 63.4968 106.925 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.6801 106.056 0
+      vertex 68.1404 133.264 0
+      vertex 63.0748 106.503 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 68.1404 133.264 0
+      vertex 62.6801 106.056 0
+      vertex 68.0628 133.503 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.3143 105.584 0
+      vertex 68.0628 133.503 0
+      vertex 62.6801 106.056 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 140 0
+      vertex 68.0628 133.503 0
+      vertex 62.3143 105.584 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 68.0628 133.503 0
+      vertex 0 140 0
+      vertex 68.0158 133.749 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 68.0158 133.749 0
+      vertex 0 140 0
+      vertex 68 134 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 68 134 0
+      vertex 0 140 0
+      vertex 68.0158 134.251 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 140 0
+      vertex 62.3143 105.584 0
+      vertex 61.9789 105.09 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 140 0
+      vertex 61.9789 105.09 0
+      vertex 61.6751 104.577 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 140 0
+      vertex 61.6751 104.577 0
+      vertex 61.4041 104.045 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 140 0
+      vertex 61.4041 104.045 0
+      vertex 61.1671 103.497 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 140 0
+      vertex 61.1671 103.497 0
+      vertex 60.965 102.936 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 140 0
+      vertex 60.965 102.936 0
+      vertex 60.7985 102.363 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 60.7985 97.6374 0
+      vertex 60.0593 90.3838 0
+      vertex 60.6683 98.2199 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 59.9782 90.1964 0
+      vertex 60.6683 98.2199 0
+      vertex 60.0593 90.3838 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 59.9091 90.0043 0
+      vertex 60.6683 98.2199 0
+      vertex 59.9782 90.1964 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 60.6683 98.2199 0
+      vertex 59.9091 90.0043 0
+      vertex 60.5749 98.8093 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 59.8521 89.8082 0
+      vertex 60.5749 98.8093 0
+      vertex 59.9091 90.0043 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 60.5749 98.8093 0
+      vertex 59.8521 89.8082 0
+      vertex 60.5187 99.4035 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 59.8076 89.609 0
+      vertex 60.5187 99.4035 0
+      vertex 59.8521 89.8082 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 140 0
+      vertex 60.5187 99.4035 0
+      vertex 59.8076 89.609 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.5187 99.4035 0
+      vertex 0 140 0
+      vertex 60.5 100 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 140 0
+      vertex 59.8076 89.609 0
+      vertex 59.7756 89.4073 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 140 0
+      vertex 59.7756 89.4073 0
+      vertex 59.7564 89.2041 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.1417 68.5009 0
+      vertex 56.4957 59.0909 0
+      vertex 62.0631 68.9973 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 56.3036 59.0218 0
+      vertex 62.0631 68.9973 0
+      vertex 56.4957 59.0909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 56.1162 58.9407 0
+      vertex 62.0631 68.9973 0
+      vertex 56.3036 59.0218 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.0631 68.9973 0
+      vertex 56.1162 58.9407 0
+      vertex 62.0158 69.4977 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55.9343 58.848 0
+      vertex 62.0158 69.4977 0
+      vertex 56.1162 58.9407 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.0158 69.4977 0
+      vertex 55.9343 58.848 0
+      vertex 62 70 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.0099 83.8433 0
+      vertex 60.6309 86.7752 0
+      vertex 60.7752 86.6309 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55.7586 58.7441 0
+      vertex 62 70 0
+      vertex 55.9343 58.848 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.0099 83.8433 0
+      vertex 60.4958 86.9284 0
+      vertex 60.6309 86.7752 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55.5897 58.6293 0
+      vertex 62 70 0
+      vertex 55.7586 58.7441 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.0393 83.6891 0
+      vertex 60.4958 86.9284 0
+      vertex 62.0099 83.8433 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.0158 70.5023 0
+      vertex 55.5897 58.6293 0
+      vertex 55.4284 58.5042 0
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 60.4958 86.9284 0
+      vertex 62.0393 83.6891 0
+      vertex 60.3707 87.0897 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.0631 71.0027 0
+      vertex 55.4284 58.5042 0
+      vertex 55.2752 58.3691 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.2513 71.9895 0
+      vertex 60.152 87.4343 0
+      vertex 60.2559 87.2586 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.1417 71.4991 0
+      vertex 55.2752 58.3691 0
+      vertex 60.0593 87.6162 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.1417 71.4991 0
+      vertex 60.0593 87.6162 0
+      vertex 60.152 87.4343 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55.1309 58.2248 0
+      vertex 60.0593 87.6162 0
+      vertex 55.2752 58.3691 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 60.0593 87.6162 0
+      vertex 55.1309 58.2248 0
+      vertex 59.9782 87.8036 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.9958 58.0716 0
+      vertex 59.9782 87.8036 0
+      vertex 55.1309 58.2248 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 59.9782 87.8036 0
+      vertex 54.9958 58.0716 0
+      vertex 59.9091 87.9957 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8707 57.9103 0
+      vertex 59.9091 87.9957 0
+      vertex 54.9958 58.0716 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 59.9091 87.9957 0
+      vertex 54.8707 57.9103 0
+      vertex 59.8521 88.1918 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.7559 57.7414 0
+      vertex 59.8521 88.1918 0
+      vertex 54.8707 57.9103 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 59.8521 88.1918 0
+      vertex 54.7559 57.7414 0
+      vertex 59.8076 88.391 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.652 57.5657 0
+      vertex 59.8076 88.391 0
+      vertex 54.7559 57.7414 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 59.8076 88.391 0
+      vertex 54.652 57.5657 0
+      vertex 59.7756 88.5927 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.5593 57.3838 0
+      vertex 59.7756 88.5927 0
+      vertex 54.652 57.5657 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 140 0
+      vertex 59.7756 88.5927 0
+      vertex 54.5593 57.3838 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 59.7756 88.5927 0
+      vertex 0 140 0
+      vertex 59.7564 88.7959 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.5 100 0
+      vertex 0 140 0
+      vertex 60.5187 100.597 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 59.7564 88.7959 0
+      vertex 0 140 0
+      vertex 59.75 89 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 59.75 89 0
+      vertex 0 140 0
+      vertex 59.7564 89.2041 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 140 0
+      vertex 54.5593 57.3838 0
+      vertex 54.4782 57.1964 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 140 0
+      vertex 54.4782 57.1964 0
+      vertex 54.4091 57.0043 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 140 0
+      vertex 54.4091 57.0043 0
+      vertex 54.3521 56.8082 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 140 0
+      vertex 54.3521 56.8082 0
+      vertex 54.3076 56.609 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 54.3076 56.609 0
+      vertex 54.2756 56.4073 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 54.2564 56.2041 0
+      vertex 54.25 56 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 54.2756 56.4073 0
+      vertex 54.2564 56.2041 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 54.3076 56.609 0
+      vertex 0 0 0
+      vertex 0 140 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.5187 100.597 0
+      vertex 0 140 0
+      vertex 60.5749 101.191 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.5749 101.191 0
+      vertex 0 140 0
+      vertex 60.6683 101.78 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.6683 101.78 0
+      vertex 0 140 0
+      vertex 60.7985 102.363 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 68.0158 134.251 0
+      vertex 0 140 0
+      vertex 68.0628 134.497 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 68.0628 134.497 0
+      vertex 0 140 0
+      vertex 68.1404 134.736 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 69.8744 135.996 0
+      vertex 0 140 0
+      vertex 140 140 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 69.6252 135.965 0
+      vertex 0 140 0
+      vertex 69.8744 135.996 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 69.382 135.902 0
+      vertex 0 140 0
+      vertex 69.6252 135.965 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 69.1484 135.81 0
+      vertex 0 140 0
+      vertex 69.382 135.902 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 68.9283 135.689 0
+      vertex 0 140 0
+      vertex 69.1484 135.81 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 68.7252 135.541 0
+      vertex 0 140 0
+      vertex 68.9283 135.689 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 68.5421 135.369 0
+      vertex 0 140 0
+      vertex 68.7252 135.541 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 68.382 135.176 0
+      vertex 0 140 0
+      vertex 68.5421 135.369 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 68.2474 134.964 0
+      vertex 0 140 0
+      vertex 68.382 135.176 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 68.1404 134.736 0
+      vertex 0 140 0
+      vertex 68.2474 134.964 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 111.76 41.1567 0
+      vertex 91.2401 41.1567 0
+      vertex 91.2107 41.3109 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 111.789 41.3109 0
+      vertex 91.2107 41.3109 0
+      vertex 91.1622 41.4602 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 111.838 41.4602 0
+      vertex 91.1622 41.4602 0
+      vertex 91.0954 41.6022 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 111.905 41.6022 0
+      vertex 91.0954 41.6022 0
+      vertex 91.0113 41.7347 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 111.989 41.7347 0
+      vertex 91.0113 41.7347 0
+      vertex 90.9112 41.8557 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 112.089 41.8557 0
+      vertex 90.9112 41.8557 0
+      vertex 110.75 62.25 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.7968 41.9631 0
+      vertex 110.75 62.25 0
+      vertex 90.9112 41.8557 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 62.25 0
+      vertex 90.7968 41.9631 0
+      vertex 90.6698 42.0554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 62.25 0
+      vertex 90.6698 42.0554 0
+      vertex 90.5322 42.131 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.25 62.25 0
+      vertex 90.5322 42.131 0
+      vertex 90.3863 42.1888 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.7968 41.9631 0
+      vertex 90.25 62.25 0
+      vertex 110.75 62.25 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 79.9407 52.3838 0
+      vertex 90.25 62.25 0
+      vertex 90.2342 42.2279 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 90.2342 42.2279 0
+      vertex 90.25 62.25 0
+      vertex 90.3863 42.1888 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 140 0
+      vertex 0 128 3
+      vertex 0 140 11
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 140 0
+      vertex 0 12 3
+      vertex 0 128 3
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 12 3
+      vertex 0 140 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 11
+      vertex 0 12 3
+      vertex 0 0 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 12 3
+      vertex 0 0 11
+      vertex 0 12 11
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 0 140 11
+      vertex 0 128 3
+      vertex 0 128 11
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 140 140 0
+      vertex 0 140 11
+      vertex 140 140 40
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 140 11
+      vertex 140 140 0
+      vertex 0 140 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 140 0 0
+      vertex 0 0 11
+      vertex 0 0 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 11
+      vertex 140 0 0
+      vertex 140 0 40
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 140 12 3
+      vertex 0 12 11
+      vertex 140 12 40
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 12 11
+      vertex 140 12 3
+      vertex 0 12 3
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 140 128 3
+      vertex 0 128 11
+      vertex 0 128 3
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 128 11
+      vertex 140 128 3
+      vertex 140 128 40
+    endloop
+  endfacet
+  facet normal -0.202837 0 0.979213
+    outer loop
+      vertex 140 140 40
+      vertex 72 134 25.9143
+      vertex 140 128 40
+    endloop
+  endfacet
+  facet normal -0.202846 0.000105319 0.979211
+    outer loop
+      vertex 140 140 40
+      vertex 71.9842 134.251 25.911
+      vertex 72 134 25.9143
+    endloop
+  endfacet
+  facet normal -0.202826 -0.000139938 0.979215
+    outer loop
+      vertex 140 140 40
+      vertex 71.9372 134.497 25.9013
+      vertex 71.9842 134.251 25.911
+    endloop
+  endfacet
+  facet normal -0.202845 0.000102764 0.979211
+    outer loop
+      vertex 140 140 40
+      vertex 71.8596 134.736 25.8852
+      vertex 71.9372 134.497 25.9013
+    endloop
+  endfacet
+  facet normal -0.202848 0.000148 0.97921
+    outer loop
+      vertex 140 140 40
+      vertex 71.7526 134.964 25.863
+      vertex 71.8596 134.736 25.8852
+    endloop
+  endfacet
+  facet normal -0.202812 -0.000359618 0.979218
+    outer loop
+      vertex 140 140 40
+      vertex 71.618 135.176 25.8352
+      vertex 71.7526 134.964 25.863
+    endloop
+  endfacet
+  facet normal -0.202848 0.000175088 0.97921
+    outer loop
+      vertex 140 140 40
+      vertex 71.4579 135.369 25.802
+      vertex 71.618 135.176 25.8352
+    endloop
+  endfacet
+  facet normal -0.202827 -0.000147861 0.979215
+    outer loop
+      vertex 140 140 40
+      vertex 71.2748 135.541 25.7641
+      vertex 71.4579 135.369 25.802
+    endloop
+  endfacet
+  facet normal -0.202848 0.000178537 0.97921
+    outer loop
+      vertex 140 140 40
+      vertex 71.0717 135.689 25.722
+      vertex 71.2748 135.541 25.7641
+    endloop
+  endfacet
+  facet normal -0.20284 5.72062e-05 0.979212
+    outer loop
+      vertex 140 140 40
+      vertex 70.8516 135.81 25.6764
+      vertex 71.0717 135.689 25.722
+    endloop
+  endfacet
+  facet normal -0.202843 0.000105332 0.979211
+    outer loop
+      vertex 140 140 40
+      vertex 70.618 135.902 25.628
+      vertex 70.8516 135.81 25.6764
+    endloop
+  endfacet
+  facet normal -0.202853 0.000288671 0.979209
+    outer loop
+      vertex 140 140 40
+      vertex 70.3748 135.965 25.5776
+      vertex 70.618 135.902 25.628
+    endloop
+  endfacet
+  facet normal -0.202813 -0.00043384 0.979217
+    outer loop
+      vertex 140 140 40
+      vertex 70.1256 135.996 25.526
+      vertex 70.3748 135.965 25.5776
+    endloop
+  endfacet
+  facet normal -0.202708 -0.0023366 0.979236
+    outer loop
+      vertex 140 140 40
+      vertex 69.8744 135.996 25.474
+      vertex 70.1256 135.996 25.526
+    endloop
+  endfacet
+  facet normal -0.202846 -0.000105319 0.979211
+    outer loop
+      vertex 68.0158 134.251 25.089
+      vertex 0 140 11
+      vertex 68 134 25.0857
+    endloop
+  endfacet
+  facet normal -0.202826 0.000139938 0.979215
+    outer loop
+      vertex 68.0628 134.497 25.0987
+      vertex 0 140 11
+      vertex 68.0158 134.251 25.089
+    endloop
+  endfacet
+  facet normal -0.202845 -0.000102764 0.979211
+    outer loop
+      vertex 68.1404 134.736 25.1148
+      vertex 0 140 11
+      vertex 68.0628 134.497 25.0987
+    endloop
+  endfacet
+  facet normal -0.202848 -0.000148 0.97921
+    outer loop
+      vertex 68.2474 134.964 25.137
+      vertex 0 140 11
+      vertex 68.1404 134.736 25.1148
+    endloop
+  endfacet
+  facet normal -0.202812 0.000359618 0.979218
+    outer loop
+      vertex 68.382 135.176 25.1648
+      vertex 0 140 11
+      vertex 68.2474 134.964 25.137
+    endloop
+  endfacet
+  facet normal -0.202848 -0.000175088 0.97921
+    outer loop
+      vertex 68.5421 135.369 25.198
+      vertex 0 140 11
+      vertex 68.382 135.176 25.1648
+    endloop
+  endfacet
+  facet normal -0.202827 0.000147861 0.979215
+    outer loop
+      vertex 68.7252 135.541 25.2359
+      vertex 0 140 11
+      vertex 68.5421 135.369 25.198
+    endloop
+  endfacet
+  facet normal -0.202848 -0.000178537 0.97921
+    outer loop
+      vertex 68.9283 135.689 25.278
+      vertex 0 140 11
+      vertex 68.7252 135.541 25.2359
+    endloop
+  endfacet
+  facet normal -0.20284 -5.72062e-05 0.979212
+    outer loop
+      vertex 69.1484 135.81 25.3236
+      vertex 0 140 11
+      vertex 68.9283 135.689 25.278
+    endloop
+  endfacet
+  facet normal -0.202843 -0.000105332 0.979211
+    outer loop
+      vertex 69.382 135.902 25.372
+      vertex 0 140 11
+      vertex 69.1484 135.81 25.3236
+    endloop
+  endfacet
+  facet normal -0.202853 -0.000288671 0.979209
+    outer loop
+      vertex 69.6252 135.965 25.4224
+      vertex 0 140 11
+      vertex 69.382 135.902 25.372
+    endloop
+  endfacet
+  facet normal -0.202813 0.00043384 0.979217
+    outer loop
+      vertex 69.8744 135.996 25.474
+      vertex 0 140 11
+      vertex 69.6252 135.965 25.4224
+    endloop
+  endfacet
+  facet normal -0.202837 4.19243e-06 0.979213
+    outer loop
+      vertex 0 140 11
+      vertex 69.8744 135.996 25.474
+      vertex 140 140 40
+    endloop
+  endfacet
+  facet normal -0.202846 -0.000105319 0.979211
+    outer loop
+      vertex 71.9842 133.749 25.911
+      vertex 140 128 40
+      vertex 72 134 25.9143
+    endloop
+  endfacet
+  facet normal -0.202826 0.000139938 0.979215
+    outer loop
+      vertex 71.9372 133.503 25.9013
+      vertex 140 128 40
+      vertex 71.9842 133.749 25.911
+    endloop
+  endfacet
+  facet normal -0.202845 -0.000102764 0.979211
+    outer loop
+      vertex 71.8596 133.264 25.8852
+      vertex 140 128 40
+      vertex 71.9372 133.503 25.9013
+    endloop
+  endfacet
+  facet normal -0.202848 -0.000148 0.97921
+    outer loop
+      vertex 71.7526 133.036 25.863
+      vertex 140 128 40
+      vertex 71.8596 133.264 25.8852
+    endloop
+  endfacet
+  facet normal -0.202812 0.000359618 0.979218
+    outer loop
+      vertex 71.618 132.824 25.8352
+      vertex 140 128 40
+      vertex 71.7526 133.036 25.863
+    endloop
+  endfacet
+  facet normal -0.202848 -0.000175088 0.97921
+    outer loop
+      vertex 71.4579 132.631 25.802
+      vertex 140 128 40
+      vertex 71.618 132.824 25.8352
+    endloop
+  endfacet
+  facet normal -0.202827 0.000147861 0.979215
+    outer loop
+      vertex 71.2748 132.459 25.7641
+      vertex 140 128 40
+      vertex 71.4579 132.631 25.802
+    endloop
+  endfacet
+  facet normal -0.202848 -0.000178537 0.97921
+    outer loop
+      vertex 71.0717 132.311 25.722
+      vertex 140 128 40
+      vertex 71.2748 132.459 25.7641
+    endloop
+  endfacet
+  facet normal -0.20284 -5.72062e-05 0.979212
+    outer loop
+      vertex 70.8516 132.19 25.6764
+      vertex 140 128 40
+      vertex 71.0717 132.311 25.722
+    endloop
+  endfacet
+  facet normal -0.202843 -0.000105332 0.979211
+    outer loop
+      vertex 70.618 132.098 25.628
+      vertex 140 128 40
+      vertex 70.8516 132.19 25.6764
+    endloop
+  endfacet
+  facet normal -0.202853 -0.000288671 0.979209
+    outer loop
+      vertex 70.3748 132.035 25.5776
+      vertex 140 128 40
+      vertex 70.618 132.098 25.628
+    endloop
+  endfacet
+  facet normal -0.202813 0.00043384 0.979217
+    outer loop
+      vertex 70.1256 132.004 25.526
+      vertex 140 128 40
+      vertex 70.3748 132.035 25.5776
+    endloop
+  endfacet
+  facet normal -0.202708 0.0023366 0.979236
+    outer loop
+      vertex 69.8744 132.004 25.474
+      vertex 140 128 40
+      vertex 70.1256 132.004 25.526
+    endloop
+  endfacet
+  facet normal -0.202837 0 0.979213
+    outer loop
+      vertex 0 128 11
+      vertex 68 134 25.0857
+      vertex 0 140 11
+    endloop
+  endfacet
+  facet normal -0.202846 0.000105319 0.979211
+    outer loop
+      vertex 68 134 25.0857
+      vertex 0 128 11
+      vertex 68.0158 133.749 25.089
+    endloop
+  endfacet
+  facet normal -0.202826 -0.000139938 0.979215
+    outer loop
+      vertex 68.0158 133.749 25.089
+      vertex 0 128 11
+      vertex 68.0628 133.503 25.0987
+    endloop
+  endfacet
+  facet normal -0.202845 0.000102764 0.979211
+    outer loop
+      vertex 68.0628 133.503 25.0987
+      vertex 0 128 11
+      vertex 68.1404 133.264 25.1148
+    endloop
+  endfacet
+  facet normal -0.202848 0.000148 0.97921
+    outer loop
+      vertex 68.1404 133.264 25.1148
+      vertex 0 128 11
+      vertex 68.2474 133.036 25.137
+    endloop
+  endfacet
+  facet normal -0.202812 -0.000359618 0.979218
+    outer loop
+      vertex 68.2474 133.036 25.137
+      vertex 0 128 11
+      vertex 68.382 132.824 25.1648
+    endloop
+  endfacet
+  facet normal -0.202848 0.000175088 0.97921
+    outer loop
+      vertex 68.382 132.824 25.1648
+      vertex 0 128 11
+      vertex 68.5421 132.631 25.198
+    endloop
+  endfacet
+  facet normal -0.202827 -0.000147861 0.979215
+    outer loop
+      vertex 68.5421 132.631 25.198
+      vertex 0 128 11
+      vertex 68.7252 132.459 25.2359
+    endloop
+  endfacet
+  facet normal -0.202848 0.000178537 0.97921
+    outer loop
+      vertex 68.7252 132.459 25.2359
+      vertex 0 128 11
+      vertex 68.9283 132.311 25.278
+    endloop
+  endfacet
+  facet normal -0.20284 5.72062e-05 0.979212
+    outer loop
+      vertex 68.9283 132.311 25.278
+      vertex 0 128 11
+      vertex 69.1484 132.19 25.3236
+    endloop
+  endfacet
+  facet normal -0.202843 0.000105332 0.979211
+    outer loop
+      vertex 69.1484 132.19 25.3236
+      vertex 0 128 11
+      vertex 69.382 132.098 25.372
+    endloop
+  endfacet
+  facet normal -0.202853 0.000288671 0.979209
+    outer loop
+      vertex 69.382 132.098 25.372
+      vertex 0 128 11
+      vertex 69.6252 132.035 25.4224
+    endloop
+  endfacet
+  facet normal -0.202837 -4.19243e-06 0.979213
+    outer loop
+      vertex 69.8744 132.004 25.474
+      vertex 0 128 11
+      vertex 140 128 40
+    endloop
+  endfacet
+  facet normal -0.202813 -0.00043384 0.979217
+    outer loop
+      vertex 69.6252 132.035 25.4224
+      vertex 0 128 11
+      vertex 69.8744 132.004 25.474
+    endloop
+  endfacet
+  facet normal -0.202837 0 0.979213
+    outer loop
+      vertex 140 12 40
+      vertex 72 6 25.9143
+      vertex 140 0 40
+    endloop
+  endfacet
+  facet normal -0.202846 0.000105457 0.979211
+    outer loop
+      vertex 140 12 40
+      vertex 71.9842 6.25067 25.911
+      vertex 72 6 25.9143
+    endloop
+  endfacet
+  facet normal -0.202826 -0.000139541 0.979215
+    outer loop
+      vertex 140 12 40
+      vertex 71.9372 6.49738 25.9013
+      vertex 71.9842 6.25067 25.911
+    endloop
+  endfacet
+  facet normal -0.202845 0.000102818 0.979211
+    outer loop
+      vertex 140 12 40
+      vertex 71.8596 6.73625 25.8852
+      vertex 71.9372 6.49738 25.9013
+    endloop
+  endfacet
+  facet normal -0.202848 0.000148465 0.97921
+    outer loop
+      vertex 140 12 40
+      vertex 71.7526 6.96351 25.863
+      vertex 71.8596 6.73625 25.8852
+    endloop
+  endfacet
+  facet normal -0.202812 -0.000359519 0.979218
+    outer loop
+      vertex 140 12 40
+      vertex 71.618 7.17557 25.8352
+      vertex 71.7526 6.96351 25.863
+    endloop
+  endfacet
+  facet normal -0.202848 0.000174643 0.97921
+    outer loop
+      vertex 140 12 40
+      vertex 71.4579 7.36909 25.802
+      vertex 71.618 7.17557 25.8352
+    endloop
+  endfacet
+  facet normal -0.202827 -0.000147909 0.979215
+    outer loop
+      vertex 140 12 40
+      vertex 71.2748 7.54103 25.7641
+      vertex 71.4579 7.36909 25.802
+    endloop
+  endfacet
+  facet normal -0.202848 0.000178948 0.97921
+    outer loop
+      vertex 140 12 40
+      vertex 71.0717 7.68866 25.722
+      vertex 71.2748 7.54103 25.7641
+    endloop
+  endfacet
+  facet normal -0.20284 5.721e-05 0.979212
+    outer loop
+      vertex 140 12 40
+      vertex 70.8516 7.80965 25.6764
+      vertex 71.0717 7.68866 25.722
+    endloop
+  endfacet
+  facet normal -0.202843 0.000104877 0.979211
+    outer loop
+      vertex 140 12 40
+      vertex 70.618 7.90211 25.628
+      vertex 70.8516 7.80965 25.6764
+    endloop
+  endfacet
+  facet normal -0.202854 0.000290702 0.979209
+    outer loop
+      vertex 140 12 40
+      vertex 70.3748 7.96457 25.5776
+      vertex 70.618 7.90211 25.628
+    endloop
+  endfacet
+  facet normal -0.202814 -0.000429291 0.979217
+    outer loop
+      vertex 140 12 40
+      vertex 70.1256 7.99605 25.526
+      vertex 70.3748 7.96457 25.5776
+    endloop
+  endfacet
+  facet normal -0.202708 -0.00233663 0.979236
+    outer loop
+      vertex 140 12 40
+      vertex 69.8744 7.99605 25.474
+      vertex 70.1256 7.99605 25.526
+    endloop
+  endfacet
+  facet normal -0.202846 -0.000105457 0.979211
+    outer loop
+      vertex 68.0158 6.25067 25.089
+      vertex 0 12 11
+      vertex 68 6 25.0857
+    endloop
+  endfacet
+  facet normal -0.202826 0.000139541 0.979215
+    outer loop
+      vertex 68.0628 6.49738 25.0987
+      vertex 0 12 11
+      vertex 68.0158 6.25067 25.089
+    endloop
+  endfacet
+  facet normal -0.202845 -0.000102818 0.979211
+    outer loop
+      vertex 68.1404 6.73625 25.1148
+      vertex 0 12 11
+      vertex 68.0628 6.49738 25.0987
+    endloop
+  endfacet
+  facet normal -0.202848 -0.000148465 0.97921
+    outer loop
+      vertex 68.2474 6.96351 25.137
+      vertex 0 12 11
+      vertex 68.1404 6.73625 25.1148
+    endloop
+  endfacet
+  facet normal -0.202812 0.000359519 0.979218
+    outer loop
+      vertex 68.382 7.17557 25.1648
+      vertex 0 12 11
+      vertex 68.2474 6.96351 25.137
+    endloop
+  endfacet
+  facet normal -0.202848 -0.000174643 0.97921
+    outer loop
+      vertex 68.5421 7.36909 25.198
+      vertex 0 12 11
+      vertex 68.382 7.17557 25.1648
+    endloop
+  endfacet
+  facet normal -0.202827 0.000147909 0.979215
+    outer loop
+      vertex 68.7252 7.54103 25.2359
+      vertex 0 12 11
+      vertex 68.5421 7.36909 25.198
+    endloop
+  endfacet
+  facet normal -0.202848 -0.000178948 0.97921
+    outer loop
+      vertex 68.9283 7.68866 25.278
+      vertex 0 12 11
+      vertex 68.7252 7.54103 25.2359
+    endloop
+  endfacet
+  facet normal -0.20284 -5.721e-05 0.979212
+    outer loop
+      vertex 69.1484 7.80965 25.3236
+      vertex 0 12 11
+      vertex 68.9283 7.68866 25.278
+    endloop
+  endfacet
+  facet normal -0.202843 -0.000104877 0.979211
+    outer loop
+      vertex 69.382 7.90211 25.372
+      vertex 0 12 11
+      vertex 69.1484 7.80965 25.3236
+    endloop
+  endfacet
+  facet normal -0.202854 -0.000290702 0.979209
+    outer loop
+      vertex 69.6252 7.96457 25.4224
+      vertex 0 12 11
+      vertex 69.382 7.90211 25.372
+    endloop
+  endfacet
+  facet normal -0.202814 0.000429291 0.979217
+    outer loop
+      vertex 69.8744 7.99605 25.474
+      vertex 0 12 11
+      vertex 69.6252 7.96457 25.4224
+    endloop
+  endfacet
+  facet normal -0.202837 4.19249e-06 0.979213
+    outer loop
+      vertex 0 12 11
+      vertex 69.8744 7.99605 25.474
+      vertex 140 12 40
+    endloop
+  endfacet
+  facet normal -0.202846 -0.000105457 0.979211
+    outer loop
+      vertex 71.9842 5.74933 25.911
+      vertex 140 0 40
+      vertex 72 6 25.9143
+    endloop
+  endfacet
+  facet normal -0.202826 0.000139541 0.979215
+    outer loop
+      vertex 71.9372 5.50262 25.9013
+      vertex 140 0 40
+      vertex 71.9842 5.74933 25.911
+    endloop
+  endfacet
+  facet normal -0.202845 -0.000102818 0.979211
+    outer loop
+      vertex 71.8596 5.26375 25.8852
+      vertex 140 0 40
+      vertex 71.9372 5.50262 25.9013
+    endloop
+  endfacet
+  facet normal -0.202848 -0.000148465 0.97921
+    outer loop
+      vertex 71.7526 5.03649 25.863
+      vertex 140 0 40
+      vertex 71.8596 5.26375 25.8852
+    endloop
+  endfacet
+  facet normal -0.202812 0.000359519 0.979218
+    outer loop
+      vertex 71.618 4.82443 25.8352
+      vertex 140 0 40
+      vertex 71.7526 5.03649 25.863
+    endloop
+  endfacet
+  facet normal -0.202848 -0.000174643 0.97921
+    outer loop
+      vertex 71.4579 4.63091 25.802
+      vertex 140 0 40
+      vertex 71.618 4.82443 25.8352
+    endloop
+  endfacet
+  facet normal -0.202827 0.000147909 0.979215
+    outer loop
+      vertex 71.2748 4.45897 25.7641
+      vertex 140 0 40
+      vertex 71.4579 4.63091 25.802
+    endloop
+  endfacet
+  facet normal -0.202848 -0.000178959 0.97921
+    outer loop
+      vertex 71.0717 4.31135 25.722
+      vertex 140 0 40
+      vertex 71.2748 4.45897 25.7641
+    endloop
+  endfacet
+  facet normal -0.20284 -5.72058e-05 0.979212
+    outer loop
+      vertex 70.8516 4.19035 25.6764
+      vertex 140 0 40
+      vertex 71.0717 4.31135 25.722
+    endloop
+  endfacet
+  facet normal -0.202843 -0.000104877 0.979211
+    outer loop
+      vertex 70.618 4.09789 25.628
+      vertex 140 0 40
+      vertex 70.8516 4.19035 25.6764
+    endloop
+  endfacet
+  facet normal -0.202854 -0.000290702 0.979209
+    outer loop
+      vertex 70.3748 4.03543 25.5776
+      vertex 140 0 40
+      vertex 70.618 4.09789 25.628
+    endloop
+  endfacet
+  facet normal -0.202814 0.000429291 0.979217
+    outer loop
+      vertex 70.1256 4.00395 25.526
+      vertex 140 0 40
+      vertex 70.3748 4.03543 25.5776
+    endloop
+  endfacet
+  facet normal -0.202708 0.00233663 0.979236
+    outer loop
+      vertex 69.8744 4.00395 25.474
+      vertex 140 0 40
+      vertex 70.1256 4.00395 25.526
+    endloop
+  endfacet
+  facet normal -0.202837 0 0.979213
+    outer loop
+      vertex 0 0 11
+      vertex 68 6 25.0857
+      vertex 0 12 11
+    endloop
+  endfacet
+  facet normal -0.202846 0.000105457 0.979211
+    outer loop
+      vertex 68 6 25.0857
+      vertex 0 0 11
+      vertex 68.0158 5.74933 25.089
+    endloop
+  endfacet
+  facet normal -0.202826 -0.000139541 0.979215
+    outer loop
+      vertex 68.0158 5.74933 25.089
+      vertex 0 0 11
+      vertex 68.0628 5.50262 25.0987
+    endloop
+  endfacet
+  facet normal -0.202845 0.000102818 0.979211
+    outer loop
+      vertex 68.0628 5.50262 25.0987
+      vertex 0 0 11
+      vertex 68.1404 5.26375 25.1148
+    endloop
+  endfacet
+  facet normal -0.202848 0.000148465 0.97921
+    outer loop
+      vertex 68.1404 5.26375 25.1148
+      vertex 0 0 11
+      vertex 68.2474 5.03649 25.137
+    endloop
+  endfacet
+  facet normal -0.202812 -0.000359519 0.979218
+    outer loop
+      vertex 68.2474 5.03649 25.137
+      vertex 0 0 11
+      vertex 68.382 4.82443 25.1648
+    endloop
+  endfacet
+  facet normal -0.202848 0.000174643 0.97921
+    outer loop
+      vertex 68.382 4.82443 25.1648
+      vertex 0 0 11
+      vertex 68.5421 4.63091 25.198
+    endloop
+  endfacet
+  facet normal -0.202827 -0.000147909 0.979215
+    outer loop
+      vertex 68.5421 4.63091 25.198
+      vertex 0 0 11
+      vertex 68.7252 4.45897 25.2359
+    endloop
+  endfacet
+  facet normal -0.202848 0.000178959 0.97921
+    outer loop
+      vertex 68.7252 4.45897 25.2359
+      vertex 0 0 11
+      vertex 68.9283 4.31135 25.278
+    endloop
+  endfacet
+  facet normal -0.20284 5.72058e-05 0.979212
+    outer loop
+      vertex 68.9283 4.31135 25.278
+      vertex 0 0 11
+      vertex 69.1484 4.19035 25.3236
+    endloop
+  endfacet
+  facet normal -0.202843 0.000104877 0.979211
+    outer loop
+      vertex 69.1484 4.19035 25.3236
+      vertex 0 0 11
+      vertex 69.382 4.09789 25.372
+    endloop
+  endfacet
+  facet normal -0.202854 0.000290702 0.979209
+    outer loop
+      vertex 69.382 4.09789 25.372
+      vertex 0 0 11
+      vertex 69.6252 4.03543 25.4224
+    endloop
+  endfacet
+  facet normal -0.202837 -4.19249e-06 0.979213
+    outer loop
+      vertex 69.8744 4.00395 25.474
+      vertex 0 0 11
+      vertex 140 0 40
+    endloop
+  endfacet
+  facet normal -0.202814 -0.000429291 0.979217
+    outer loop
+      vertex 69.6252 4.03543 25.4224
+      vertex 0 0 11
+      vertex 69.8744 4.00395 25.474
+    endloop
+  endfacet
+endsolid OpenSCAD_Model


### PR DESCRIPTION
Bei meiner Kamera waren die IR-Sensoren der Lampen genau spiegelverkehrt angebracht, und alles klapperte ein wenig lose, also habe ich den Geräteträger in OpenSCAD neu konstruiert. Dann kann das auch jeder einfacher an seine Bedürfnisse anpassen.
Der Clip dient dazu, die Kamera von der Gegenseite zu fixieren, die Dicke sollte nach dem Scharfstellen der Kamera gemessen werden.